### PR TITLE
PDX-103 [B1 task 6] CliAgentSignInWidget above BYOK on AI settings

### DIFF
--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -1506,6 +1506,12 @@ impl AISettingsPageView {
                     widgets.push(Box::new(VoiceWidget::default()));
                 }
                 widgets.push(Box::new(CLIAgentWidget::default()));
+                // PDX-103 [B1] task 6: coding-agent sign-in row sits ABOVE
+                // the API keys (BYOK) section. PDX-104 (B2) appends Codex +
+                // Ollama rows inside this widget.
+                widgets.push(Box::new(
+                    super::cli_agent_sign_in_widget::CliAgentSignInWidget::default(),
+                ));
                 widgets.push(Box::new(ApiKeysWidget::new(ctx)));
                 widgets.push(Box::new(AwsBedrockWidget::new(ctx)));
                 widgets.push(Box::new(AgentAttributionWidget::default()));
@@ -1546,6 +1552,10 @@ impl AISettingsPageView {
                 if voice_supported {
                     widgets.push(Box::new(VoiceWidget::default()));
                 }
+                // PDX-103 [B1] task 6: same sign-in row above BYOK on this subpage.
+                widgets.push(Box::new(
+                    super::cli_agent_sign_in_widget::CliAgentSignInWidget::default(),
+                ));
                 widgets.push(Box::new(ApiKeysWidget::new(ctx)));
                 widgets.push(Box::new(AwsBedrockWidget::new(ctx)));
                 widgets.push(Box::new(AgentAttributionWidget::default()));
@@ -1567,6 +1577,11 @@ impl AISettingsPageView {
             }
             Some(AISubpage::ThirdPartyCLIAgents) => {
                 widgets.push(Box::new(CLIAgentWidget::default()));
+                // PDX-103 [B1] task 6: same sign-in row reused on the
+                // dedicated third-party agents subpage.
+                widgets.push(Box::new(
+                    super::cli_agent_sign_in_widget::CliAgentSignInWidget::default(),
+                ));
             }
         }
 
@@ -2271,6 +2286,11 @@ pub enum AISettingsPageAction {
         pattern: String,
         agent: Option<CLIAgent>,
     },
+    /// PDX-103 [B1] task 6: shells out `claude /login` fire-and-forget.
+    /// The CLI handles the browser/keychain flow exactly like `doppler login`.
+    /// Auth-state re-poll lands when PDX-103 task 2 hoists the Router into
+    /// AppContext.
+    SignInWithClaudeCode,
 }
 
 impl From<&AISettingsPageAction> for LoginGatedFeature {
@@ -2496,6 +2516,31 @@ impl TypedActionView for AISettingsPageView {
                     Ok(_new_value) => {}
                     Err(e) => {
                         log::warn!("Failed to set value for NLD in Terminal: {e:?}");
+                    }
+                }
+                ctx.notify();
+            }
+            AISettingsPageAction::SignInWithClaudeCode => {
+                // PDX-103 [B1] task 6. Fire-and-forget: do NOT wait, do NOT
+                // capture output. The Claude Code CLI opens the browser and
+                // runs the OAuth dance on its own. Nulling stdio prevents the
+                // child from blocking on the GUI's missing TTY.
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    match std::process::Command::new("claude")
+                        .arg("/login")
+                        .stdin(std::process::Stdio::null())
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .spawn()
+                    {
+                        Ok(_) => {
+                            // TODO(PDX-103 task 6): poll Router::health for
+                            // ClaudeCode and refresh the row when it flips
+                            // healthy, mirroring DopplerSignInWidget's
+                            // poll_until_authenticated.
+                        }
+                        Err(err) => log::warn!("failed to spawn `claude /login`: {err}"),
                     }
                 }
                 ctx.notify();

--- a/app/src/settings_view/cli_agent_sign_in_widget.rs
+++ b/app/src/settings_view/cli_agent_sign_in_widget.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Coding-agent sign-in widget for the AI settings page (PDX-103 [B1] task 6).
+//
+// Renders a "Sign in with Claude Code" row directly above the API keys (BYOK)
+// section in `ai_page.rs`. PDX-104 (B2) appends Codex + Ollama rows here.
+//
+// Mirrors the Doppler pattern from PDX-49/PDX-50: the button shells out to
+// `claude /login` fire-and-forget; the CLI handles the browser/keychain.
+//
+// Auth-state probe is stubbed pending PDX-103 task 2 (persistent Router in
+// AppContext). Once that lands, swap `CliAgentAuthState::detect_claude` to
+// read `Router::health(&AgentId::new("claude-sonnet-46"))` from AppContext
+// and gate `ClaudeCodeAgent` registration on the result.
+
+use warpui::elements::{
+    Align, Container, CrossAxisAlignment, Element, Flex, MouseStateHandle, ParentElement, Text,
+};
+use warpui::fonts::{Properties, Weight};
+use warpui::ui_components::{
+    button::ButtonVariant,
+    components::{Coords, UiComponent, UiComponentStyles},
+};
+use warpui::AppContext;
+
+use super::ai_page::{AISettingsPageAction, AISettingsPageView};
+use super::settings_page::{
+    render_settings_info_banner, SettingsWidget, CONTENT_FONT_SIZE, SUBHEADER_FONT_SIZE,
+};
+use crate::appearance::Appearance;
+
+/// Three-state auth model surfaced inline in the row.
+///
+/// Detection is intentionally cheap and synchronous; the auth-probe upgrade
+/// (PATH check + `Router::health` lookup) lands in PDX-103 task 6 once the
+/// Router is hoisted into AppContext per task 2.
+#[derive(Debug, PartialEq)]
+#[allow(dead_code)] // `NotInstalled` and `SignedIn` exercised once PDX-103 task 6 lands the real probe.
+pub(crate) enum CliAgentAuthState {
+    NotInstalled,
+    SignedOut,
+    SignedIn,
+}
+
+impl CliAgentAuthState {
+    /// Skeleton stub — always reports `SignedOut`. Replace once `which::which`
+    /// is wired in and the Router exposes a health view (PDX-103 task 2 + 6).
+    pub(crate) fn detect_claude() -> Self {
+        // TODO(PDX-103 task 6): replace stub with
+        //   match which::which("claude") {
+        //       Err(_) => CliAgentAuthState::NotInstalled,
+        //       Ok(_) => router_health(&AgentId::new("claude-sonnet-46"))
+        //                   .map(|h| if h.healthy { SignedIn } else { SignedOut })
+        //                   .unwrap_or(SignedOut),
+        //   }
+        Self::SignedOut
+    }
+
+    fn banner(&self) -> Option<(&'static str, &'static str)> {
+        match self {
+            Self::NotInstalled => Some((
+                "Claude Code CLI not installed",
+                "Install via `brew install anthropic/claude/claude` or follow https://docs.claude.com/claude-code/setup",
+            )),
+            Self::SignedOut => Some((
+                "Not signed in to Claude Code",
+                "Click \"Sign in with Claude Code\" — the CLI opens your browser for OAuth.",
+            )),
+            Self::SignedIn => Some((
+                "Signed in to Claude Code",
+                "Available in the in-prompt model selector.",
+            )),
+        }
+    }
+
+    fn button_enabled(&self) -> bool {
+        !matches!(self, Self::NotInstalled)
+    }
+
+    fn button_label(&self) -> &'static str {
+        match self {
+            Self::NotInstalled => "Install Claude Code",
+            Self::SignedOut => "Sign in with Claude Code",
+            Self::SignedIn => "Re-sign in with Claude Code",
+        }
+    }
+}
+
+#[derive(Default)]
+pub(super) struct CliAgentSignInWidget {
+    claude_button: MouseStateHandle,
+}
+
+impl SettingsWidget for CliAgentSignInWidget {
+    type View = AISettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "claude code codex ollama cli sign in login authenticate third-party coding agent"
+    }
+
+    fn render(
+        &self,
+        _view: &Self::View,
+        appearance: &Appearance,
+        _app: &AppContext,
+    ) -> Box<dyn Element> {
+        let ui_builder = appearance.ui_builder();
+        let theme = appearance.theme();
+        let state = CliAgentAuthState::detect_claude();
+
+        let header = Container::new(
+            Align::new(
+                Text::new_inline(
+                    "Coding agent sign-in",
+                    appearance.ui_font_family(),
+                    SUBHEADER_FONT_SIZE,
+                )
+                .with_style(Properties::default().weight(Weight::Bold))
+                .with_color(theme.active_ui_text_color().into())
+                .finish(),
+            )
+            .left()
+            .finish(),
+        )
+        .with_padding_bottom(8.)
+        .finish();
+
+        let description = Container::new(
+            Align::new(
+                Text::new_inline(
+                    "Sign in to coding agents Warp dispatches through. Each row shells out to that agent's own login flow.",
+                    appearance.ui_font_family(),
+                    CONTENT_FONT_SIZE,
+                )
+                .with_color(theme.nonactive_ui_text_color().into())
+                .finish(),
+            )
+            .left()
+            .finish(),
+        )
+        .with_padding_bottom(12.)
+        .finish();
+
+        let banner: Option<Box<dyn Element>> = state.banner().map(|(title, sub)| {
+            Container::new(render_settings_info_banner(title, Some(sub), appearance))
+                .with_padding_bottom(12.)
+                .finish()
+        });
+
+        let button_style = UiComponentStyles {
+            font_size: Some(14.),
+            font_weight: Some(Weight::Semibold),
+            padding: Some(Coords {
+                top: 8.,
+                bottom: 8.,
+                left: 24.,
+                right: 24.,
+            }),
+            ..Default::default()
+        };
+        let btn_builder = ui_builder
+            .button(ButtonVariant::Accent, self.claude_button.clone())
+            .with_text_label(state.button_label().to_owned())
+            .with_style(button_style);
+
+        let button: Box<dyn Element> = if state.button_enabled() {
+            btn_builder
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(AISettingsPageAction::SignInWithClaudeCode);
+                })
+                .finish()
+        } else {
+            btn_builder.disabled().build().finish()
+        };
+
+        // TODO(PDX-104 task 5): append Codex + Ollama rows below this button
+        // sharing the same header/description/auth-state pattern. Codex follows
+        // the same sign-in flow (`codex login`); Ollama is local-only with an
+        // "Install Ollama" link instead of a sign-in button.
+
+        let mut children: Vec<Box<dyn Element>> = vec![header, description];
+        if let Some(b) = banner {
+            children.push(b);
+        }
+        children.push(button);
+
+        Container::new(
+            Flex::column()
+                .with_cross_axis_alignment(CrossAxisAlignment::Start)
+                .with_children(children)
+                .finish(),
+        )
+        .with_padding_bottom(15.)
+        .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_installed_disables_button() {
+        let s = CliAgentAuthState::NotInstalled;
+        assert!(!s.button_enabled());
+        assert_eq!(s.button_label(), "Install Claude Code");
+        let (title, _) = s.banner().expect("banner");
+        assert!(title.to_lowercase().contains("not installed"));
+    }
+
+    #[test]
+    fn signed_out_enables_button_with_login_label() {
+        let s = CliAgentAuthState::SignedOut;
+        assert!(s.button_enabled());
+        assert_eq!(s.button_label(), "Sign in with Claude Code");
+    }
+
+    #[test]
+    fn signed_in_offers_resign_path() {
+        let s = CliAgentAuthState::SignedIn;
+        assert!(s.button_enabled());
+        assert!(s.button_label().contains("Re-sign in"));
+    }
+}

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -80,6 +80,7 @@ mod ai_page;
 mod appearance_page;
 mod billing_and_usage;
 mod billing_and_usage_page;
+mod cli_agent_sign_in_widget;
 mod code_page;
 mod delete_environment_confirmation_dialog;
 mod directory_color_add_picker;


### PR DESCRIPTION
Skeleton for the Claude Code sign-in row from PDX-103 task 6. Renders directly above the API keys (BYOK) section on three AI subpages — main, WarpAgent, ThirdPartyCLIAgents — preserving the order: existing rows → CLI agent sign-in → API keys.

- New app/src/settings_view/cli_agent_sign_in_widget.rs (~210 lines) modeled on DopplerSignInWidget (PDX-50)
- Three states (NotInstalled / SignedOut / SignedIn) with banner copy + button label per state
- AISettingsPageAction::SignInWithClaudeCode variant + handler that fire-and-forgets `claude /login` (nulled stdio, browser/keychain handled by the CLI, mirrors `doppler login`)
- Detection stubbed to always return SignedOut — TODO marker points at the which::which("claude") + Router::agent_health swap that lands in B1 task 2 + 6
- PDX-104 (B2) appends Codex + Ollama rows inside this same widget

Stack on the selector PR (#1) — merge that first, then this. Core B1 wiring (real Router registration, OutputChunk plumbing, swap the auth-state stubs) follows in a third PR.

Test plan: cargo check -p warp clean (only expected dead-code warnings on unused state variants — #[allow(dead_code)] until task 6 wires the real probe); 3/3 widget unit tests pass.

Generated with Claude Code.