### PR TITLE
PDX-75 [A8.2] McpForwarder: fix silent drop when no receivers attached

### DIFF
--- a/crates/orchestrator/src/mcp_forwarder.rs
+++ b/crates/orchestrator/src/mcp_forwarder.rs
@@ -135,9 +135,12 @@ impl McpForwarder {
         if already_active {
             return false;
         }
-        // Infallible: all receivers are lazily created; even if the last
-        // subscriber dropped, the `Sender` itself retains the value.
-        let _ = self.tx.send(ForwardingTarget::Agent(id));
+        // Use `send_replace` rather than `send`: the latter returns
+        // `Err(SendError)` when there are no live receivers and *does not*
+        // update the stored value, which would silently lose the target if
+        // no subscriber had attached yet. `send_replace` always overwrites
+        // the stored value and notifies any receivers that do exist.
+        self.tx.send_replace(ForwardingTarget::Agent(id));
         true
     }
 
@@ -152,7 +155,8 @@ impl McpForwarder {
         if matches!(&*self.tx.borrow(), ForwardingTarget::None) {
             return false;
         }
-        let _ = self.tx.send(ForwardingTarget::None);
+        // See `set_active` for why we prefer `send_replace` over `send`.
+        self.tx.send_replace(ForwardingTarget::None);
         true
     }
 


### PR DESCRIPTION
## Summary

Audit found 9/17 mcp_forwarder tests failing on master. Root cause: set_active / clear_active used tokio::sync::watch::Sender::send, which returns Err(SendError) and **refuses to update the stored value** when there are no live receivers. Since McpForwarder::new() drops its sentinel receiver immediately, every call before the first subscribe() was silently lost — the method returned true and claimed infallibility while doing nothing.

Fix (8 insertions, 4 deletions, one file): switched both methods to send_replace, which always overwrites the stored value and notifies any receivers that do exist. Added a comment noting the previous bug.

## Why this matters for B3

PDX-105 (B3) plans against this exact API surface — Arc<McpForwarder> in AppContext, set_active from the Router::select dispatch site, subscribe() from app/src/ai/mcp/manager.rs. After this fix, set_active actually persists between agent switches even when no subscriber has attached yet — without it, B3 would silently fail on the first agent switch in production.

## Test plan

- cargo check -p orchestrator clean
- cargo test -p orchestrator --test mcp_forwarder — 17/17 pass (was 8/17 on master)
- cargo test -p orchestrator — 50/50 across all suites + doc tests

Generated with Claude Code.