### PR TITLE
feat(orchestrator): task→agent boundary tracker (PDX-40)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9224,6 +9224,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures-core",
+ "instant",
  "serde",
  "serde_json",
  "thiserror 2.0.17",

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 futures-core = "0.3.31"
+instant = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "sync"] }

--- a/crates/orchestrator/src/boundary.rs
+++ b/crates/orchestrator/src/boundary.rs
@@ -1,0 +1,160 @@
+//! Task→agent boundary tracking: enforce that an agent cannot be swapped
+//! mid-task.
+//!
+//! The orchestrator's invariant is "switches happen only at task boundaries":
+//! once a [`Task`] has been dispatched to an [`Agent`], no other agent may
+//! claim the same task until the current execution terminates. This module
+//! provides a small synchronous tracker — [`TaskBoundary`] — that enforces
+//! that rule independently of the [`Router`] selection logic.
+//!
+//! # Design
+//!
+//! The tracker is a thin wrapper around a `HashMap<TaskId, AgentId>` behind
+//! a [`std::sync::Mutex`]. A successful [`TaskBoundary::begin`] call inserts
+//! the binding and returns a [`BoundaryGuard`] whose [`Drop`] impl removes
+//! it. Subsequent attempts to bind the same [`TaskId`] — to the same agent
+//! or a different one — fail with [`BoundaryError::AlreadyBound`] until the
+//! original guard drops.
+//!
+//! Synchronous locking is deliberate: bind and release are O(1) and never
+//! need to `.await`, and synchronous locking is the only option inside
+//! [`Drop`]. Lock poisoning is recovered transparently so a panic in an
+//! unrelated code path cannot strand a binding.
+//!
+//! [`Router`]: crate::router::Router
+//! [`Task`]: crate::Task
+//! [`Agent`]: crate::Agent
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use thiserror::Error;
+
+use crate::{AgentId, TaskId};
+
+/// Tracker that enforces "no mid-task agent switching" by recording the
+/// agent currently bound to each in-flight [`TaskId`].
+///
+/// Cloning a [`TaskBoundary`] yields a new handle to the same underlying
+/// state — share clones across the dispatcher and any component that needs
+/// to inspect bindings.
+#[derive(Debug, Clone, Default)]
+pub struct TaskBoundary {
+    inner: Arc<Mutex<HashMap<TaskId, AgentId>>>,
+}
+
+/// Errors returned by [`TaskBoundary::begin`].
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum BoundaryError {
+    /// The task is already bound to an agent. The existing binding is
+    /// preserved unchanged.
+    ///
+    /// This single variant covers two cases the orchestrator forbids:
+    /// 1. A different agent attempting to claim a task already in flight
+    ///    (`current != requested`) — the canonical "mid-task switch".
+    /// 2. The same agent attempting to re-bind a task it already holds
+    ///    (`current == requested`) — almost always a caller bug
+    ///    (double-`begin`), worth surfacing rather than silently succeeding.
+    #[error(
+        "task {task_id} is already bound to agent {current}; cannot bind to {requested} mid-task"
+    )]
+    AlreadyBound {
+        /// The task that is already in flight.
+        task_id: TaskId,
+        /// The agent currently holding the task.
+        current: AgentId,
+        /// The agent the caller tried to (re)bind to.
+        requested: AgentId,
+    },
+}
+
+/// RAII guard returned by [`TaskBoundary::begin`].
+///
+/// While alive, the guard owns the (task, agent) binding inside the parent
+/// [`TaskBoundary`]. Dropping the guard removes the binding, freeing the
+/// task so a subsequent dispatch can target a different agent — the
+/// "switch at task boundary" semantic.
+#[must_use = "the binding is released as soon as the guard is dropped"]
+pub struct BoundaryGuard {
+    inner: Arc<Mutex<HashMap<TaskId, AgentId>>>,
+    task_id: TaskId,
+    agent_id: AgentId,
+}
+
+impl BoundaryGuard {
+    /// The task this guard is holding.
+    pub fn task_id(&self) -> TaskId {
+        self.task_id
+    }
+
+    /// The agent the guard's task is bound to.
+    pub fn agent_id(&self) -> &AgentId {
+        &self.agent_id
+    }
+}
+
+impl std::fmt::Debug for BoundaryGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BoundaryGuard")
+            .field("task_id", &self.task_id)
+            .field("agent_id", &self.agent_id)
+            .finish()
+    }
+}
+
+impl Drop for BoundaryGuard {
+    fn drop(&mut self) {
+        // Best-effort release. Recover from a poisoned mutex so a panic in
+        // some unrelated code path does not strand the binding forever.
+        let mut map = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        map.remove(&self.task_id);
+    }
+}
+
+impl TaskBoundary {
+    /// Construct a new, empty [`TaskBoundary`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Begin a new (task, agent) binding.
+    ///
+    /// Returns a [`BoundaryGuard`] that releases the binding on drop. If the
+    /// task is already bound to any agent — including the same one — this
+    /// returns [`BoundaryError::AlreadyBound`] without modifying state.
+    pub fn begin(
+        &self,
+        task_id: TaskId,
+        agent_id: AgentId,
+    ) -> Result<BoundaryGuard, BoundaryError> {
+        let mut map = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(current) = map.get(&task_id) {
+            return Err(BoundaryError::AlreadyBound {
+                task_id,
+                current: current.clone(),
+                requested: agent_id,
+            });
+        }
+        map.insert(task_id, agent_id.clone());
+        drop(map);
+        Ok(BoundaryGuard {
+            inner: self.inner.clone(),
+            task_id,
+            agent_id,
+        })
+    }
+
+    /// Look up the agent currently bound to `task_id`, if any.
+    pub fn bound_agent(&self, task_id: TaskId) -> Option<AgentId> {
+        let map = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        map.get(&task_id).cloned()
+    }
+
+    /// Number of currently in-flight task bindings.
+    pub fn in_flight(&self) -> usize {
+        self.inner.lock().unwrap_or_else(|p| p.into_inner()).len()
+    }
+}

--- a/crates/orchestrator/src/budget.rs
+++ b/crates/orchestrator/src/budget.rs
@@ -23,8 +23,8 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
 
+use instant::Instant;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::RwLock;

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -35,10 +35,12 @@
 
 #![deny(missing_docs)]
 
+pub mod boundary;
 pub mod budget;
 pub mod mcp_forwarder;
 pub mod router;
 
+pub use boundary::{BoundaryError, BoundaryGuard, TaskBoundary};
 pub use budget::{
     evaluate_charge, Budget, BudgetError, BudgetSnapshot, BudgetTier, Cap, CustomProviderId,
     Provider,

--- a/crates/orchestrator/tests/boundary.rs
+++ b/crates/orchestrator/tests/boundary.rs
@@ -1,0 +1,168 @@
+//! Integration tests for [`orchestrator::TaskBoundary`].
+//!
+//! The boundary tracker is a small synchronous primitive — these tests
+//! exercise the public API end-to-end without spinning up a runtime.
+
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use orchestrator::{AgentId, BoundaryError, TaskBoundary, TaskId};
+
+#[test]
+fn begin_returns_guard_when_no_existing_binding() {
+    let bd = TaskBoundary::new();
+    let task = TaskId::new();
+    let agent = AgentId("a".to_string());
+
+    let guard = bd.begin(task, agent.clone()).expect("first bind succeeds");
+    assert_eq!(guard.task_id(), task);
+    assert_eq!(guard.agent_id(), &agent);
+    assert_eq!(bd.bound_agent(task), Some(agent));
+    assert_eq!(bd.in_flight(), 1);
+}
+
+#[test]
+fn second_begin_with_different_agent_fails_with_already_bound() {
+    let bd = TaskBoundary::new();
+    let task = TaskId::new();
+    let a = AgentId("a".to_string());
+    let b = AgentId("b".to_string());
+
+    let _guard = bd.begin(task, a.clone()).unwrap();
+    let err = bd
+        .begin(task, b.clone())
+        .expect_err("mid-task switch must fail");
+    match err {
+        BoundaryError::AlreadyBound {
+            task_id,
+            current,
+            requested,
+        } => {
+            assert_eq!(task_id, task);
+            assert_eq!(current, a);
+            assert_eq!(requested, b);
+        }
+    }
+    // The original binding is untouched by the failed switch.
+    assert_eq!(bd.bound_agent(task), Some(a));
+    assert_eq!(bd.in_flight(), 1);
+}
+
+#[test]
+fn second_begin_with_same_agent_also_fails() {
+    // Double-begin is treated as a caller bug even when the agent matches.
+    let bd = TaskBoundary::new();
+    let task = TaskId::new();
+    let a = AgentId("a".to_string());
+
+    let _guard = bd.begin(task, a.clone()).unwrap();
+    let err = bd
+        .begin(task, a.clone())
+        .expect_err("double begin must fail");
+    assert!(matches!(
+        err,
+        BoundaryError::AlreadyBound { ref current, ref requested, .. }
+            if *current == a && *requested == a
+    ));
+}
+
+#[test]
+fn dropping_guard_releases_binding_and_allows_switch() {
+    // After a task completes, switching to a different agent at the
+    // boundary is the entire point.
+    let bd = TaskBoundary::new();
+    let task = TaskId::new();
+    let a = AgentId("a".to_string());
+    let b = AgentId("b".to_string());
+
+    {
+        let _guard = bd.begin(task, a.clone()).unwrap();
+        assert_eq!(bd.bound_agent(task), Some(a));
+    }
+    assert_eq!(bd.bound_agent(task), None);
+    assert_eq!(bd.in_flight(), 0);
+
+    let guard = bd
+        .begin(task, b.clone())
+        .expect("post-boundary rebind succeeds");
+    assert_eq!(guard.agent_id(), &b);
+    assert_eq!(bd.bound_agent(task), Some(b));
+}
+
+#[test]
+fn distinct_tasks_can_bind_different_agents_concurrently() {
+    let bd = TaskBoundary::new();
+    let t1 = TaskId::new();
+    let t2 = TaskId::new();
+    let a = AgentId("a".to_string());
+    let b = AgentId("b".to_string());
+
+    let _g1 = bd.begin(t1, a.clone()).unwrap();
+    let _g2 = bd.begin(t2, b.clone()).unwrap();
+
+    assert_eq!(bd.bound_agent(t1), Some(a));
+    assert_eq!(bd.bound_agent(t2), Some(b));
+    assert_eq!(bd.in_flight(), 2);
+}
+
+#[test]
+fn cloning_boundary_shares_state() {
+    let primary = TaskBoundary::new();
+    let secondary = primary.clone();
+    let task = TaskId::new();
+    let agent = AgentId("ag".to_string());
+
+    let _guard = primary.begin(task, agent.clone()).unwrap();
+    assert_eq!(secondary.bound_agent(task), Some(agent));
+
+    let err = secondary
+        .begin(task, AgentId("other".to_string()))
+        .expect_err("clone observes the primary's binding");
+    assert!(matches!(err, BoundaryError::AlreadyBound { .. }));
+}
+
+#[test]
+fn concurrent_begins_for_same_task_only_one_wins() {
+    // Drive many threads at the same TaskId; exactly one should succeed and
+    // every other should observe AlreadyBound. The successful agent is
+    // recorded as `current` in every losing error.
+    const THREADS: usize = 16;
+    let bd = TaskBoundary::new();
+    let task = TaskId::new();
+    let barrier = Arc::new(Barrier::new(THREADS));
+
+    let handles: Vec<_> = (0..THREADS)
+        .map(|i| {
+            let bd = bd.clone();
+            let barrier = barrier.clone();
+            let agent = AgentId(format!("agent-{i}"));
+            thread::spawn(move || {
+                barrier.wait();
+                bd.begin(task, agent)
+            })
+        })
+        .collect();
+
+    let mut wins = 0;
+    let mut losses = 0;
+    for h in handles {
+        match h.join().unwrap() {
+            Ok(_guard) => {
+                wins += 1;
+            }
+            Err(BoundaryError::AlreadyBound { task_id, .. }) => {
+                assert_eq!(task_id, task);
+                losses += 1;
+            }
+        }
+    }
+    assert_eq!(wins, 1, "exactly one bind should win the race");
+    assert_eq!(losses, THREADS - 1);
+}
+
+#[test]
+fn boundary_is_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<TaskBoundary>();
+    assert_send_sync::<orchestrator::BoundaryGuard>();
+}


### PR DESCRIPTION
## Summary

Implements [PDX-40](https://linear.app/pdx-software/issue/PDX-40/a24-implement-boundary-enforcement-no-mid-task-switching) — the orchestrator invariant that an agent cannot be swapped mid-task; switches happen only at task boundaries.

- New `crates/orchestrator/src/boundary.rs` exposing `TaskBoundary`, `BoundaryGuard`, `BoundaryError`.
- `TaskBoundary::begin(task_id, agent_id)` returns an RAII guard whose `Drop` releases the binding. Re-binding the same `TaskId` (to any agent — same or different) fails with `BoundaryError::AlreadyBound` until the guard drops.
- Synchronous `std::sync::Mutex` is deliberate: O(1), no `.await`, and the only option inside `Drop`. Lock poisoning is recovered transparently.
- Re-exported from `orchestrator` crate root; doesn't touch `router.rs`.
- Drive-by: `std::time::Instant` → `instant::Instant` in `budget.rs` to satisfy the workspace `disallowed_types` clippy lint (was failing on master).

## Test plan

- [x] `cargo clippy -p orchestrator --tests -- -D warnings` clean
- [x] `cargo test -p orchestrator --test boundary` — 8 passing (happy path; same/different-agent rebind errors; drop-and-rebind across boundary; multi-task isolation; cloned `TaskBoundary` shared state; 16-thread race asserting exactly one winner; `Send + Sync`).