### PR TITLE
feat(orchestrator): handoff summarizer routed to cheapest model (PDX-41)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9224,9 +9224,11 @@ dependencies = [
 name = "orchestrator"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "chrono",
  "futures-core",
+ "futures-util",
  "instant",
  "serde",
  "serde_json",

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -15,7 +15,9 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 futures-core = "0.3.31"
+futures-util = { workspace = true }
 instant = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros", "sync"] }
+async-stream = { workspace = true }

--- a/crates/orchestrator/src/handoff.rs
+++ b/crates/orchestrator/src/handoff.rs
@@ -1,0 +1,260 @@
+//! Task-state summarization at handoff.
+//!
+//! When the dispatcher passes a [`Task`] from one [`Agent`] to another at a
+//! task boundary, the receiving agent needs a concise summary of what the
+//! prior agent attempted, learned, and left pending. Producing that summary
+//! is itself an LLM call — and one we explicitly want to route to the
+//! cheapest available model rather than the agent the task was using.
+//!
+//! # Cheapest-model selection
+//!
+//! Selection is layered on top of [`Router`]: the summarizer constructs a
+//! synthetic [`Task`] with [`Role::Summarize`] and asks the router to
+//! select an agent for it. The router's existing sort key
+//! `(tier, estimated_micros_per_task, agent.id())` does the work — the
+//! lowest-cost healthy summarize-capable agent wins.
+//!
+//! In the production registry, `Provider::FoundationModels` is registered
+//! at zero cost (on-device, no billing) and `Provider::ClaudeCode` at the
+//! Haiku price point. With both healthy, Foundation Models wins; if the
+//! local runtime is unhealthy, the router transparently falls back to
+//! Haiku 4.5. This matches the master plan's
+//! "Foundation Models or Haiku 4.5" requirement without requiring the
+//! summarizer to know about either provider directly.
+//!
+//! [`Router`]: crate::router::Router
+//! [`Task`]: crate::Task
+//! [`Agent`]: crate::Agent
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use thiserror::Error;
+
+use crate::{
+    AgentError, AgentEvent, AgentId, Role, Router, RouterError, Task, TaskContext, TaskId,
+};
+
+/// State captured at a task handoff, fed to the summarizer.
+///
+/// `task` and `events` describe what happened up to the handoff point;
+/// `from_agent` and `to_role` are advisory hints used by
+/// [`format_handoff_prompt`] to phrase the request.
+#[derive(Debug, Clone)]
+pub struct HandoffState {
+    /// The task being handed off.
+    pub task: Task,
+    /// Events emitted by the prior agent during its execution attempt.
+    pub events: Vec<AgentEvent>,
+    /// Identifier of the agent that was running the task before the handoff.
+    pub from_agent: Option<AgentId>,
+    /// Role the task is being handed off to (e.g. `Reviewer`).
+    pub to_role: Option<Role>,
+}
+
+/// Result of a successful summarization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HandoffSummary {
+    /// The summary text the model produced.
+    pub text: String,
+    /// Identifier of the agent (and therefore model) that produced the
+    /// summary, for telemetry and provenance.
+    pub model: AgentId,
+}
+
+/// Errors a [`HandoffSummarizer`] can return.
+#[derive(Debug, Error)]
+pub enum SummarizerError {
+    /// The router could not select a summarize-capable agent.
+    #[error("router error: {0}")]
+    Routing(#[from] RouterError),
+    /// The selected agent failed to start or complete the summarization.
+    #[error("summarizer agent {agent} failed: {source}")]
+    Execute {
+        /// The agent that produced the failure.
+        agent: AgentId,
+        /// Underlying agent failure.
+        #[source]
+        source: AgentError,
+    },
+    /// The summarizer agent terminated without producing any output.
+    #[error("summarizer agent {0} produced no summary text")]
+    Empty(AgentId),
+}
+
+/// Asynchronously produce a [`HandoffSummary`] from a [`HandoffState`].
+///
+/// Implementations are expected to delegate to whichever model is cheapest
+/// at the moment of the call; the canonical implementation is
+/// [`RouterHandoffSummarizer`].
+#[async_trait]
+pub trait HandoffSummarizer: Send + Sync {
+    /// Produce a summary of `state`. Errors propagate the underlying
+    /// routing or agent failure.
+    async fn summarize(&self, state: HandoffState) -> Result<HandoffSummary, SummarizerError>;
+}
+
+/// [`HandoffSummarizer`] that delegates to the cheapest healthy
+/// [`Role::Summarize`] agent registered with a [`Router`].
+///
+/// The struct is cheap to clone — it holds an [`Arc<Router>`] and nothing
+/// else, so dispatcher code can hand a fresh `Self` to each task without
+/// rebuilding routing state.
+#[derive(Clone)]
+pub struct RouterHandoffSummarizer {
+    router: Arc<Router>,
+}
+
+impl RouterHandoffSummarizer {
+    /// Construct a new summarizer that routes through `router`.
+    pub fn new(router: Arc<Router>) -> Self {
+        Self { router }
+    }
+}
+
+#[async_trait]
+impl HandoffSummarizer for RouterHandoffSummarizer {
+    async fn summarize(&self, state: HandoffState) -> Result<HandoffSummary, SummarizerError> {
+        let prompt = format_handoff_prompt(&state);
+        // Reuse the original task's context (cwd, env) so the summarizer
+        // has the same on-disk view, but generate a fresh `TaskId` so the
+        // summary call doesn't collide with the boundary tracker on the
+        // original task.
+        let task = Task {
+            id: TaskId::new(),
+            role: Role::Summarize,
+            prompt,
+            context: TaskContext {
+                cwd: state.task.context.cwd.clone(),
+                env: state.task.context.env.clone(),
+                metadata: state.task.context.metadata.clone(),
+            },
+            // Conservative budget hint: summaries are short by construction.
+            budget_hint: Some(2_000),
+        };
+
+        let agent = self.router.select(&task).await?.clone();
+        let agent_id = agent.id();
+        let mut stream = agent
+            .execute(task)
+            .await
+            .map_err(|source| SummarizerError::Execute {
+                agent: agent_id.clone(),
+                source,
+            })?;
+
+        // Concatenate `OutputChunk`s and prefer the explicit `Completed`
+        // summary if the agent supplied one. A `Failed` event is escalated
+        // to `SummarizerError::Execute` so callers don't have to inspect
+        // events themselves.
+        let mut buffer = String::new();
+        let mut completed_summary: Option<String> = None;
+        while let Some(event) = stream.next().await {
+            match event {
+                AgentEvent::OutputChunk { text } => buffer.push_str(&text),
+                AgentEvent::Completed { summary, .. } => {
+                    completed_summary = summary;
+                    break;
+                }
+                AgentEvent::Failed { error, .. } => {
+                    return Err(SummarizerError::Execute {
+                        agent: agent_id,
+                        source: AgentError::Other(error),
+                    });
+                }
+                AgentEvent::Started { .. }
+                | AgentEvent::ToolCall { .. }
+                | AgentEvent::ToolResult { .. } => {}
+            }
+        }
+
+        let text = completed_summary.unwrap_or_else(|| buffer.trim().to_string());
+        if text.is_empty() {
+            return Err(SummarizerError::Empty(agent_id));
+        }
+        Ok(HandoffSummary {
+            text,
+            model: agent_id,
+        })
+    }
+}
+
+/// Build the default prompt fed to the summarizer agent.
+///
+/// Format:
+/// 1. One-line goal restatement.
+/// 2. Optional `From agent` / `Handing off to` lines.
+/// 3. Bullet-list of events (one line per event, truncated to keep prompt
+///    bounded).
+/// 4. Closing instruction asking for a structured summary.
+///
+/// The output is deterministic for a given [`HandoffState`] so callers can
+/// snapshot-test it.
+pub fn format_handoff_prompt(state: &HandoffState) -> String {
+    use std::fmt::Write as _;
+
+    let mut s = String::with_capacity(512);
+    s.push_str(
+        "You are a concise task-handoff summarizer. Summarize the state of the following task in <= 200 words.\n\n",
+    );
+    let _ = writeln!(s, "Goal: {}", first_line(&state.task.prompt));
+    if let Some(from) = &state.from_agent {
+        let _ = writeln!(s, "From agent: {}", from);
+    }
+    if let Some(role) = state.to_role {
+        let _ = writeln!(s, "Handing off to role: {:?}", role);
+    }
+    s.push('\n');
+    s.push_str("Events so far:\n");
+    if state.events.is_empty() {
+        s.push_str("- (none)\n");
+    } else {
+        for event in &state.events {
+            describe_event(&mut s, event);
+        }
+    }
+    s.push('\n');
+    s.push_str(
+        "Produce a structured summary with sections: Goal, Progress, Pending, Hand-off notes.",
+    );
+    s
+}
+
+fn describe_event(out: &mut String, event: &AgentEvent) {
+    use std::fmt::Write as _;
+    match event {
+        AgentEvent::Started { task_id } => {
+            let _ = writeln!(out, "- Started task {task_id}");
+        }
+        AgentEvent::OutputChunk { text } => {
+            let _ = writeln!(out, "- Output: {}", first_line(text));
+        }
+        AgentEvent::ToolCall { name, .. } => {
+            let _ = writeln!(out, "- Tool call: {name}");
+        }
+        AgentEvent::ToolResult { name, .. } => {
+            let _ = writeln!(out, "- Tool result: {name}");
+        }
+        AgentEvent::Completed { summary, .. } => {
+            let _ = writeln!(
+                out,
+                "- Completed: {}",
+                summary.as_deref().unwrap_or("(no agent summary)")
+            );
+        }
+        AgentEvent::Failed { error, .. } => {
+            let _ = writeln!(out, "- Failed: {}", first_line(error));
+        }
+    }
+}
+
+/// Return the first non-empty line of `s`, trimmed, or `"(empty)"` if `s`
+/// is empty / whitespace-only. Used by the prompt builder to keep events
+/// to one line each.
+fn first_line(s: &str) -> &str {
+    s.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("(empty)")
+}

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -37,6 +37,7 @@
 
 pub mod boundary;
 pub mod budget;
+pub mod handoff;
 pub mod mcp_forwarder;
 pub mod router;
 
@@ -44,6 +45,10 @@ pub use boundary::{BoundaryError, BoundaryGuard, TaskBoundary};
 pub use budget::{
     evaluate_charge, Budget, BudgetError, BudgetSnapshot, BudgetTier, Cap, CustomProviderId,
     Provider,
+};
+pub use handoff::{
+    format_handoff_prompt, HandoffState, HandoffSummarizer, HandoffSummary,
+    RouterHandoffSummarizer, SummarizerError,
 };
 pub use mcp_forwarder::{ForwardingTarget, McpForwarder};
 pub use router::{AgentRegistration, Router, RouterError};

--- a/crates/orchestrator/tests/handoff.rs
+++ b/crates/orchestrator/tests/handoff.rs
@@ -1,0 +1,420 @@
+//! Integration tests for the handoff summarizer.
+//!
+//! These tests use a tiny stub agent (`SummarizerStub`) registered with a
+//! real [`Router`] so we exercise the cheapest-model selection path
+//! end-to-end without spinning up a subprocess.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc,
+};
+
+use async_stream::stream;
+use async_trait::async_trait;
+use chrono::Utc;
+use orchestrator::{
+    format_handoff_prompt, Agent, AgentEvent, AgentEventStream, AgentId, AgentRegistration,
+    Budget, Cap, Capabilities, HandoffState, HandoffSummarizer, Health, Provider, Role, Router,
+    RouterHandoffSummarizer, SummarizerError, Task, TaskContext, TaskId,
+};
+
+/// Stub summarizer agent. Records how many times it has been invoked, then
+/// emits a canned event sequence ending with `Completed { summary: <text> }`.
+struct SummarizerStub {
+    id: AgentId,
+    capabilities: Capabilities,
+    health: Health,
+    summary_text: String,
+    invocations: Arc<AtomicU32>,
+}
+
+impl SummarizerStub {
+    fn new(id: &str, healthy: bool, summary_text: &str) -> (Self, Arc<AtomicU32>) {
+        let invocations = Arc::new(AtomicU32::new(0));
+        let stub = Self {
+            id: AgentId(id.to_string()),
+            capabilities: Capabilities {
+                roles: [Role::Summarize].into_iter().collect::<HashSet<_>>(),
+                max_context_tokens: 8_192,
+                supports_tools: false,
+                supports_vision: false,
+            },
+            health: Health {
+                healthy,
+                last_check: Utc::now(),
+                error_rate: 0.0,
+            },
+            summary_text: summary_text.to_string(),
+            invocations: invocations.clone(),
+        };
+        (stub, invocations)
+    }
+}
+
+#[async_trait]
+impl Agent for SummarizerStub {
+    fn id(&self) -> AgentId {
+        self.id.clone()
+    }
+    fn capabilities(&self) -> &Capabilities {
+        &self.capabilities
+    }
+    fn health(&self) -> Health {
+        self.health.clone()
+    }
+    async fn execute(
+        &self,
+        task: Task,
+    ) -> Result<AgentEventStream, orchestrator::AgentError> {
+        self.invocations.fetch_add(1, Ordering::SeqCst);
+        let summary = self.summary_text.clone();
+        let task_id = task.id;
+        let s = stream! {
+            yield AgentEvent::Started { task_id };
+            yield AgentEvent::Completed { task_id, summary: Some(summary) };
+        };
+        Ok(Box::pin(s))
+    }
+}
+
+/// Stub that emits `OutputChunk`s but no Completed-summary; the summarizer
+/// must fall back to concatenating the chunks.
+struct ChunkOnlyStub {
+    id: AgentId,
+    capabilities: Capabilities,
+    health: Health,
+    chunks: Vec<String>,
+}
+
+impl ChunkOnlyStub {
+    fn new(id: &str, chunks: Vec<&str>) -> Self {
+        Self {
+            id: AgentId(id.to_string()),
+            capabilities: Capabilities {
+                roles: [Role::Summarize].into_iter().collect::<HashSet<_>>(),
+                max_context_tokens: 8_192,
+                supports_tools: false,
+                supports_vision: false,
+            },
+            health: Health {
+                healthy: true,
+                last_check: Utc::now(),
+                error_rate: 0.0,
+            },
+            chunks: chunks.into_iter().map(str::to_string).collect(),
+        }
+    }
+}
+
+#[async_trait]
+impl Agent for ChunkOnlyStub {
+    fn id(&self) -> AgentId {
+        self.id.clone()
+    }
+    fn capabilities(&self) -> &Capabilities {
+        &self.capabilities
+    }
+    fn health(&self) -> Health {
+        self.health.clone()
+    }
+    async fn execute(
+        &self,
+        task: Task,
+    ) -> Result<AgentEventStream, orchestrator::AgentError> {
+        let chunks = self.chunks.clone();
+        let task_id = task.id;
+        let s = stream! {
+            yield AgentEvent::Started { task_id };
+            for chunk in chunks {
+                yield AgentEvent::OutputChunk { text: chunk };
+            }
+            yield AgentEvent::Completed { task_id, summary: None };
+        };
+        Ok(Box::pin(s))
+    }
+}
+
+/// Stub that fails its task with `AgentEvent::Failed`.
+struct FailingStub {
+    id: AgentId,
+    capabilities: Capabilities,
+    health: Health,
+}
+
+impl FailingStub {
+    fn new(id: &str) -> Self {
+        Self {
+            id: AgentId(id.to_string()),
+            capabilities: Capabilities {
+                roles: [Role::Summarize].into_iter().collect::<HashSet<_>>(),
+                max_context_tokens: 8_192,
+                supports_tools: false,
+                supports_vision: false,
+            },
+            health: Health {
+                healthy: true,
+                last_check: Utc::now(),
+                error_rate: 0.0,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl Agent for FailingStub {
+    fn id(&self) -> AgentId {
+        self.id.clone()
+    }
+    fn capabilities(&self) -> &Capabilities {
+        &self.capabilities
+    }
+    fn health(&self) -> Health {
+        self.health.clone()
+    }
+    async fn execute(
+        &self,
+        task: Task,
+    ) -> Result<AgentEventStream, orchestrator::AgentError> {
+        let task_id = task.id;
+        let s = stream! {
+            yield AgentEvent::Failed {
+                task_id,
+                error: "stub failure".to_string(),
+            };
+        };
+        Ok(Box::pin(s))
+    }
+}
+
+fn ample_budget(providers: &[Provider]) -> Arc<Budget> {
+    let mut caps = HashMap::new();
+    for p in providers {
+        caps.insert(
+            *p,
+            Cap {
+                monthly_micro_dollars: 1_000_000_000,
+                session_micro_dollars: 1_000_000_000,
+            },
+        );
+    }
+    Arc::new(Budget::new(caps))
+}
+
+fn handoff_state_for(prompt: &str) -> HandoffState {
+    HandoffState {
+        task: Task {
+            id: TaskId::new(),
+            role: Role::Worker,
+            prompt: prompt.to_string(),
+            context: TaskContext {
+                cwd: PathBuf::from("/tmp"),
+                env: HashMap::new(),
+                metadata: HashMap::new(),
+            },
+            budget_hint: None,
+        },
+        events: vec![],
+        from_agent: Some(AgentId("worker-1".to_string())),
+        to_role: Some(Role::Reviewer),
+    }
+}
+
+#[tokio::test]
+async fn router_summarizer_uses_completed_summary() {
+    let budget = ample_budget(&[Provider::FoundationModels]);
+    let mut router = Router::new(budget);
+    let (stub, invocations) =
+        SummarizerStub::new("foundation-models", true, "Goal: …\nProgress: …");
+    router.register(AgentRegistration {
+        agent: Arc::new(stub),
+        provider: Provider::FoundationModels,
+        estimated_micros_per_task: 0,
+    });
+
+    let summarizer = RouterHandoffSummarizer::new(Arc::new(router));
+    let summary = summarizer
+        .summarize(handoff_state_for("ship the feature"))
+        .await
+        .expect("summarize succeeds");
+
+    assert_eq!(invocations.load(Ordering::SeqCst), 1);
+    assert_eq!(summary.model.0, "foundation-models");
+    assert_eq!(summary.text, "Goal: …\nProgress: …");
+}
+
+#[tokio::test]
+async fn router_summarizer_picks_cheapest_when_multiple_summarizers_registered() {
+    // Three healthy summarize-capable agents at three cost points. The
+    // summarizer must pick the cheapest one (Foundation Models @ $0).
+    let budget = ample_budget(&[
+        Provider::FoundationModels,
+        Provider::ClaudeCode,
+        Provider::Codex,
+    ]);
+    let mut router = Router::new(budget);
+
+    let (cheap, cheap_calls) = SummarizerStub::new("foundation-models", true, "cheap-result");
+    let (mid, mid_calls) = SummarizerStub::new("haiku-4-5", true, "mid-result");
+    let (expensive, expensive_calls) =
+        SummarizerStub::new("sonnet-expensive", true, "expensive-result");
+
+    router.register(AgentRegistration {
+        agent: Arc::new(cheap),
+        provider: Provider::FoundationModels,
+        estimated_micros_per_task: 0,
+    });
+    router.register(AgentRegistration {
+        agent: Arc::new(mid),
+        provider: Provider::ClaudeCode,
+        estimated_micros_per_task: 800,
+    });
+    router.register(AgentRegistration {
+        agent: Arc::new(expensive),
+        provider: Provider::Codex,
+        estimated_micros_per_task: 50_000,
+    });
+
+    let summarizer = RouterHandoffSummarizer::new(Arc::new(router));
+    let summary = summarizer
+        .summarize(handoff_state_for("anything"))
+        .await
+        .expect("summarize succeeds");
+
+    assert_eq!(summary.model.0, "foundation-models");
+    assert_eq!(cheap_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(mid_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(expensive_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn router_summarizer_falls_back_to_haiku_when_foundation_models_unhealthy() {
+    // Foundation Models is registered but unhealthy (stub default in
+    // production). The summarizer must transparently pick Haiku.
+    let budget = ample_budget(&[Provider::FoundationModels, Provider::ClaudeCode]);
+    let mut router = Router::new(budget);
+
+    let (fm, fm_calls) = SummarizerStub::new("foundation-models", false, "should-not-run");
+    let (haiku, haiku_calls) = SummarizerStub::new("haiku-4-5", true, "haiku-result");
+
+    router.register(AgentRegistration {
+        agent: Arc::new(fm),
+        provider: Provider::FoundationModels,
+        estimated_micros_per_task: 0,
+    });
+    router.register(AgentRegistration {
+        agent: Arc::new(haiku),
+        provider: Provider::ClaudeCode,
+        estimated_micros_per_task: 800,
+    });
+
+    let summarizer = RouterHandoffSummarizer::new(Arc::new(router));
+    let summary = summarizer
+        .summarize(handoff_state_for("anything"))
+        .await
+        .expect("summarize succeeds");
+
+    assert_eq!(summary.model.0, "haiku-4-5");
+    assert_eq!(summary.text, "haiku-result");
+    assert_eq!(fm_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(haiku_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn router_summarizer_concatenates_chunks_when_no_completed_summary() {
+    let budget = ample_budget(&[Provider::FoundationModels]);
+    let mut router = Router::new(budget);
+    router.register(AgentRegistration {
+        agent: Arc::new(ChunkOnlyStub::new(
+            "chunk-only",
+            vec!["Goal: ", "ship\n", "Progress: ", "drafted PR"],
+        )),
+        provider: Provider::FoundationModels,
+        estimated_micros_per_task: 0,
+    });
+
+    let summarizer = RouterHandoffSummarizer::new(Arc::new(router));
+    let summary = summarizer
+        .summarize(handoff_state_for("ship"))
+        .await
+        .expect("summarize succeeds");
+
+    assert_eq!(summary.text, "Goal: ship\nProgress: drafted PR");
+}
+
+#[tokio::test]
+async fn router_summarizer_propagates_failed_event_as_execute_error() {
+    let budget = ample_budget(&[Provider::FoundationModels]);
+    let mut router = Router::new(budget);
+    router.register(AgentRegistration {
+        agent: Arc::new(FailingStub::new("flaky")),
+        provider: Provider::FoundationModels,
+        estimated_micros_per_task: 0,
+    });
+
+    let summarizer = RouterHandoffSummarizer::new(Arc::new(router));
+    let err = summarizer
+        .summarize(handoff_state_for("ship"))
+        .await
+        .expect_err("expected Execute error");
+    match err {
+        SummarizerError::Execute { agent, .. } => assert_eq!(agent.0, "flaky"),
+        other => panic!("expected Execute, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn router_summarizer_returns_routing_when_no_summarize_capable_agent() {
+    let budget = ample_budget(&[Provider::ClaudeCode]);
+    let router = Router::new(budget);
+
+    let summarizer = RouterHandoffSummarizer::new(Arc::new(router));
+    let err = summarizer
+        .summarize(handoff_state_for("anything"))
+        .await
+        .expect_err("expected Routing error");
+    assert!(matches!(err, SummarizerError::Routing(_)));
+}
+
+#[test]
+fn format_handoff_prompt_is_deterministic_and_contains_key_fields() {
+    let mut state = handoff_state_for("Refactor authentication subsystem");
+    state.events = vec![
+        AgentEvent::Started {
+            task_id: state.task.id,
+        },
+        AgentEvent::OutputChunk {
+            text: "Inspecting auth.rs\nmore detail".to_string(),
+        },
+        AgentEvent::ToolCall {
+            name: "read_file".to_string(),
+            args: serde_json::json!({"path": "auth.rs"}),
+        },
+        AgentEvent::Completed {
+            task_id: state.task.id,
+            summary: Some("Drafted refactor outline".to_string()),
+        },
+    ];
+
+    let a = format_handoff_prompt(&state);
+    let b = format_handoff_prompt(&state);
+    assert_eq!(a, b, "prompt must be deterministic");
+
+    assert!(a.contains("Refactor authentication subsystem"));
+    assert!(a.contains("From agent: worker-1"));
+    assert!(a.contains("Reviewer"));
+    assert!(a.contains("Tool call: read_file"));
+    assert!(a.contains("Drafted refactor outline"));
+    // Output chunk truncated to first non-empty line.
+    assert!(a.contains("Output: Inspecting auth.rs"));
+    assert!(!a.contains("more detail"));
+    assert!(a.contains("Goal, Progress, Pending, Hand-off notes"));
+}
+
+#[test]
+fn format_handoff_prompt_handles_empty_events() {
+    let state = handoff_state_for("ship");
+    let p = format_handoff_prompt(&state);
+    assert!(p.contains("- (none)"));
+}


### PR DESCRIPTION
## Summary

Implements [PDX-41](https://linear.app/pdx-software/issue/PDX-41/a25-implement-handoff-summarizer-cheapest-available-model) — task-state summarization at handoff using the cheapest available model.

- New `crates/orchestrator/src/handoff.rs` exposing `HandoffState`, `HandoffSummary`, `HandoffSummarizer` trait, `RouterHandoffSummarizer`, and `format_handoff_prompt`.
- The summarizer builds a synthetic `Task { role: Summarize }` and asks the existing `Router::select` to pick an agent. The router's `(tier, estimated_micros_per_task, agent.id())` sort key naturally selects the cheapest healthy summarize-capable agent — Foundation Models at \$0 first, falling back to Haiku 4.5 when FM is unhealthy.
- `format_handoff_prompt` is deterministic so prompts can be snapshot-tested.
- Stream consumption prefers `Completed { summary: Some(_) }` if supplied, otherwise concatenates `OutputChunk`s; `Failed` events escalate to `SummarizerError::Execute`.
- Drops `futures-util` (main) and `async-stream` (dev) workspace deps onto the orchestrator crate.
- Drive-by: `std::time::Instant` → `instant::Instant` in `budget.rs` to satisfy the workspace `disallowed_types` clippy lint.

## Test plan

- [x] `cargo clippy -p orchestrator --tests -- -D warnings` clean
- [x] `cargo test -p orchestrator --test handoff` — 8 passing (happy path; cheapest-of-three; FM→Haiku fallback; chunk concatenation; `Failed` → `Execute`; routing error when no summarizer; deterministic prompt; empty-events prompt path).