### PR TITLE
feat(orchestrator): dispatcher with worktree-per-worker + concurrency caps (PDX-42)

### DIFF
--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -16,8 +16,10 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 futures-core = "0.3.31"
 futures-util = { workspace = true }
+async-stream = { workspace = true }
 instant = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "macros", "sync"] }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 async-stream = { workspace = true }
+futures-util = { workspace = true }

--- a/crates/orchestrator/src/dispatcher.rs
+++ b/crates/orchestrator/src/dispatcher.rs
@@ -1,0 +1,359 @@
+//! Concurrency-capped, worktree-per-worker task dispatcher.
+//!
+//! The [`Dispatcher`] composes the [`Router`] with a pluggable
+//! [`WorktreeProvisioner`] and a pair of [`Semaphore`]s — one global, one
+//! per [`Provider`] — so that callers can fire-and-forget [`Task`]s and
+//! trust the orchestrator to cap parallelism and isolate every worker in
+//! its own working directory.
+//!
+//! # What this module does
+//!
+//! [`Dispatcher::dispatch`] runs the following pipeline for each task:
+//!
+//! 1. Acquire a slot from the global concurrency [`Semaphore`]; if all
+//!    slots are taken the call awaits.
+//! 2. Ask the [`Router`] to select an [`Agent`].
+//! 3. Look up the chosen agent's [`Provider`] in the dispatcher's
+//!    registration map and acquire a slot from that provider's
+//!    [`Semaphore`]; per-provider caps are independent.
+//! 4. Provision a fresh worktree via the [`WorktreeProvisioner`]; rewrite
+//!    `task.context.cwd` to point at that worktree so the worker sees its
+//!    own checkout.
+//! 5. Hand the task to [`Agent::execute`] and wrap the resulting event
+//!    stream in a guard that releases all four resources (global permit,
+//!    per-provider permit, worktree, and any future boundary guard) when
+//!    the wrapping stream is dropped — i.e. when the caller stops consuming
+//!    events.
+//!
+//! # What this module does *not* do
+//!
+//! - It does not enforce mid-task agent stability — that's
+//!   [`crate::boundary::TaskBoundary`], wired in once both PDX-40 and
+//!   PDX-42 land on master.
+//! - It does not invoke `git worktree` itself. The [`WorktreeProvisioner`]
+//!   trait is the seam where the real implementation (or a test stub)
+//!   plugs in.
+//!
+//! [`Agent`]: crate::Agent
+//! [`Agent::execute`]: crate::Agent::execute
+//! [`Router`]: crate::router::Router
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_stream::stream;
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use thiserror::Error;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::{
+    AgentEventStream, AgentId, AgentRegistration, Provider, Router, RouterError, Task, TaskId,
+};
+
+/// Information about a freshly provisioned worktree.
+///
+/// The dispatcher owns this value for the lifetime of the dispatched task
+/// and hands it back to the [`WorktreeProvisioner`] for cleanup once the
+/// task's event stream is dropped.
+#[derive(Debug, Clone)]
+pub struct Worktree {
+    /// Absolute path to the worktree's working directory.
+    pub path: PathBuf,
+    /// Branch checked out in the worktree.
+    pub branch: String,
+}
+
+/// Errors a [`WorktreeProvisioner`] may surface.
+#[derive(Debug, Error)]
+pub enum WorktreeError {
+    /// Provisioning failed — the underlying error message is opaque to the
+    /// dispatcher.
+    #[error("worktree provisioning failed: {0}")]
+    Provision(String),
+}
+
+/// Pluggable strategy for creating and tearing down per-task worktrees.
+///
+/// Real implementations shell out to `git worktree add` / `git worktree
+/// remove`. Tests use an in-memory stub that records calls. The trait is
+/// async on the create path and synchronous on release because the release
+/// happens inside [`Drop`] where awaiting is impossible.
+#[async_trait]
+pub trait WorktreeProvisioner: Send + Sync {
+    /// Provision a worktree for `task_id`. Implementations should produce a
+    /// unique path per call so concurrent dispatches do not collide.
+    async fn provision(&self, task_id: TaskId) -> Result<Worktree, WorktreeError>;
+
+    /// Best-effort synchronous release. Implementations that need async
+    /// cleanup should spawn a detached task here and return immediately —
+    /// the dispatcher does not wait.
+    fn release(&self, worktree: Worktree);
+}
+
+/// Concurrency configuration for a [`Dispatcher`].
+#[derive(Debug, Clone)]
+pub struct DispatcherConfig {
+    /// Maximum number of in-flight tasks across all providers.
+    pub global_concurrency: usize,
+    /// Per-provider maximum. Providers absent from the map default to
+    /// [`DispatcherConfig::default_per_provider`].
+    pub per_provider_concurrency: HashMap<Provider, usize>,
+    /// Default per-provider cap when a provider has no explicit entry.
+    pub default_per_provider: usize,
+}
+
+impl DispatcherConfig {
+    /// Convenience constructor with sensible defaults: 8 global slots,
+    /// 4 per provider.
+    pub fn with_defaults() -> Self {
+        Self {
+            global_concurrency: 8,
+            per_provider_concurrency: HashMap::new(),
+            default_per_provider: 4,
+        }
+    }
+}
+
+/// Errors returned by [`Dispatcher::dispatch`].
+#[derive(Debug, Error)]
+pub enum DispatchError {
+    /// The router failed to select an agent for this task.
+    #[error("router error: {0}")]
+    Routing(#[from] RouterError),
+    /// The dispatcher's registration map has no provider entry for the
+    /// agent the router selected. Indicates a misconfiguration: every
+    /// agent registered with the router should also be registered with
+    /// the dispatcher.
+    #[error("no provider mapping registered for agent {0}")]
+    UnknownAgent(AgentId),
+    /// Provisioning the worktree failed.
+    #[error("worktree error: {0}")]
+    Worktree(#[from] WorktreeError),
+    /// The agent itself failed before producing a stream.
+    #[error("agent execution failed: {0}")]
+    Agent(#[from] crate::AgentError),
+}
+
+/// Concurrency-capped, worktree-aware task dispatcher.
+///
+/// Construct via [`DispatcherBuilder`] in production and via [`Dispatcher::new`]
+/// in tests. The dispatcher is cheap to clone (everything inside is `Arc`-shared).
+#[derive(Clone)]
+pub struct Dispatcher {
+    router: Arc<Router>,
+    provisioner: Arc<dyn WorktreeProvisioner>,
+    agent_provider: Arc<HashMap<AgentId, Provider>>,
+    global_sema: Arc<Semaphore>,
+    provider_sema: Arc<HashMap<Provider, Arc<Semaphore>>>,
+    default_per_provider_sema: Arc<Semaphore>,
+}
+
+/// Outcome of a successful [`Dispatcher::dispatch`] call.
+///
+/// The `events` stream owns the dispatched task's resources (semaphore
+/// permits, worktree, etc.) — dropping the stream releases everything.
+/// `agent` and `worktree_path` are exposed for telemetry; they are clones
+/// of the underlying values and do not affect resource lifetime.
+pub struct DispatchOutcome {
+    /// The agent the router selected.
+    pub agent: AgentId,
+    /// Path of the worktree provisioned for this task.
+    pub worktree_path: PathBuf,
+    /// Stream of [`crate::AgentEvent`]s emitted by the agent. Holds all
+    /// per-task resources internally.
+    pub events: AgentEventStream,
+}
+
+impl Dispatcher {
+    /// Build a [`Dispatcher`] from a pre-populated [`Router`] plus the
+    /// agent → provider mapping that mirrors the router's registrations.
+    ///
+    /// Prefer [`DispatcherBuilder`] for the common case where you control
+    /// both the router and the agent registrations.
+    pub fn new(
+        router: Arc<Router>,
+        provisioner: Arc<dyn WorktreeProvisioner>,
+        agent_provider: HashMap<AgentId, Provider>,
+        config: DispatcherConfig,
+    ) -> Self {
+        let global_sema = Arc::new(Semaphore::new(config.global_concurrency.max(1)));
+        let mut provider_sema = HashMap::with_capacity(config.per_provider_concurrency.len());
+        for (p, n) in &config.per_provider_concurrency {
+            provider_sema.insert(*p, Arc::new(Semaphore::new((*n).max(1))));
+        }
+        let default_per_provider_sema =
+            Arc::new(Semaphore::new(config.default_per_provider.max(1)));
+        Self {
+            router,
+            provisioner,
+            agent_provider: Arc::new(agent_provider),
+            global_sema,
+            provider_sema: Arc::new(provider_sema),
+            default_per_provider_sema,
+        }
+    }
+
+    /// Available global slots, primarily for tests and observability.
+    pub fn available_global_slots(&self) -> usize {
+        self.global_sema.available_permits()
+    }
+
+    /// Available slots for `provider`. Returns the default-pool count when
+    /// the provider has no explicit entry.
+    pub fn available_provider_slots(&self, provider: Provider) -> usize {
+        match self.provider_sema.get(&provider) {
+            Some(s) => s.available_permits(),
+            None => self.default_per_provider_sema.available_permits(),
+        }
+    }
+
+    /// Dispatch `task`. Awaits a global slot, selects an agent, awaits the
+    /// chosen provider's slot, provisions a worktree, and hands the task
+    /// to the agent. The returned [`DispatchOutcome::events`] stream owns
+    /// all per-task resources; drop it to release them.
+    pub async fn dispatch(&self, mut task: Task) -> Result<DispatchOutcome, DispatchError> {
+        let task_id = task.id;
+
+        // 1. Global slot.
+        let global_permit = self
+            .global_sema
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("global semaphore is never closed");
+
+        // 2. Router selects an agent.
+        let agent_arc = self.router.select(&task).await?.clone();
+        let agent_id = agent_arc.id();
+
+        // 3. Look up the provider for that agent and grab its slot.
+        let provider = self
+            .agent_provider
+            .get(&agent_id)
+            .copied()
+            .ok_or_else(|| DispatchError::UnknownAgent(agent_id.clone()))?;
+        let provider_sema = match self.provider_sema.get(&provider) {
+            Some(s) => s.clone(),
+            None => self.default_per_provider_sema.clone(),
+        };
+        let provider_permit = provider_sema
+            .acquire_owned()
+            .await
+            .expect("provider semaphore is never closed");
+
+        // 4. Worktree.
+        let worktree = self.provisioner.provision(task_id).await?;
+        task.context.cwd = worktree.path.clone();
+        let worktree_path = worktree.path.clone();
+        let release_guard = WorktreeReleaseGuard::new(self.provisioner.clone(), worktree);
+
+        // 5. Hand off to the agent.
+        let agent_stream = agent_arc.execute(task).await?;
+
+        // 6. Wrap the stream so all resources release when the consumer
+        //    drops it (early termination) or when the stream completes.
+        let outcome_stream = stream! {
+            // Capture every per-task resource. They drop when this async
+            // block is dropped, which happens when the caller drops the
+            // returned stream.
+            let _global = global_permit;
+            let _provider = provider_permit;
+            let _release = release_guard;
+            let mut inner = agent_stream;
+            while let Some(event) = inner.next().await {
+                yield event;
+            }
+        };
+
+        Ok(DispatchOutcome {
+            agent: agent_id,
+            worktree_path,
+            events: Box::pin(outcome_stream),
+        })
+    }
+}
+
+/// Builder that wires a [`Router`] and a [`Dispatcher`] from the same set
+/// of [`AgentRegistration`]s, so the agent → provider mapping cannot drift.
+pub struct DispatcherBuilder {
+    router: Router,
+    agent_provider: HashMap<AgentId, Provider>,
+    provisioner: Arc<dyn WorktreeProvisioner>,
+    config: DispatcherConfig,
+}
+
+impl DispatcherBuilder {
+    /// Start a new builder seeded with the given [`Router`] and worktree
+    /// provisioner. Use [`DispatcherBuilder::register`] to add agents; the
+    /// builder mirrors each registration into both the router and the
+    /// dispatcher's provider map.
+    pub fn new(router: Router, provisioner: Arc<dyn WorktreeProvisioner>) -> Self {
+        Self {
+            router,
+            agent_provider: HashMap::new(),
+            provisioner,
+            config: DispatcherConfig::with_defaults(),
+        }
+    }
+
+    /// Override the default [`DispatcherConfig`].
+    pub fn with_config(mut self, config: DispatcherConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Register an agent with both the router and the dispatcher's
+    /// agent → provider map. Mirrors [`Router::register`]'s
+    /// "last-registration-wins" semantic for the same [`AgentId`].
+    pub fn register(mut self, registration: AgentRegistration) -> Self {
+        let id = registration.agent.id();
+        let provider = registration.provider;
+        self.router.register(registration);
+        self.agent_provider.insert(id, provider);
+        self
+    }
+
+    /// Finalize the dispatcher.
+    pub fn build(self) -> Dispatcher {
+        Dispatcher::new(
+            Arc::new(self.router),
+            self.provisioner,
+            self.agent_provider,
+            self.config,
+        )
+    }
+}
+
+/// RAII guard that releases a worktree on drop unless explicitly disarmed.
+struct WorktreeReleaseGuard {
+    provisioner: Arc<dyn WorktreeProvisioner>,
+    worktree: Option<Worktree>,
+}
+
+impl WorktreeReleaseGuard {
+    fn new(provisioner: Arc<dyn WorktreeProvisioner>, worktree: Worktree) -> Self {
+        Self {
+            provisioner,
+            worktree: Some(worktree),
+        }
+    }
+}
+
+impl Drop for WorktreeReleaseGuard {
+    fn drop(&mut self) {
+        if let Some(wt) = self.worktree.take() {
+            self.provisioner.release(wt);
+        }
+    }
+}
+
+// `OwnedSemaphorePermit` already implements `Send`, but tying it explicitly
+// to this module's public surface lets `cargo doc` show that the permits
+// flow out via the wrapped stream.
+#[allow(dead_code)]
+const _ASSERT_PERMITS_SEND: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<OwnedSemaphorePermit>();
+};

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -37,6 +37,7 @@
 
 pub mod boundary;
 pub mod budget;
+pub mod dispatcher;
 pub mod handoff;
 pub mod mcp_forwarder;
 pub mod router;
@@ -45,6 +46,10 @@ pub use boundary::{BoundaryError, BoundaryGuard, TaskBoundary};
 pub use budget::{
     evaluate_charge, Budget, BudgetError, BudgetSnapshot, BudgetTier, Cap, CustomProviderId,
     Provider,
+};
+pub use dispatcher::{
+    DispatchError, DispatchOutcome, Dispatcher, DispatcherBuilder, DispatcherConfig, Worktree,
+    WorktreeError, WorktreeProvisioner,
 };
 pub use handoff::{
     format_handoff_prompt, HandoffState, HandoffSummarizer, HandoffSummary,

--- a/crates/orchestrator/tests/dispatcher.rs
+++ b/crates/orchestrator/tests/dispatcher.rs
@@ -1,0 +1,500 @@
+//! Integration tests for the dispatcher.
+//!
+//! Uses a `MockProvisioner` (records provision/release calls in memory)
+//! and a `MockAgent` (controllable hold-then-emit behavior) so concurrency
+//! caps and worktree lifecycle can be verified deterministically.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc,
+};
+use std::time::Duration;
+
+use async_stream::stream;
+use async_trait::async_trait;
+use chrono::Utc;
+use futures_util::StreamExt;
+use orchestrator::{
+    Agent, AgentEvent, AgentEventStream, AgentId, AgentRegistration, Budget, Cap, Capabilities,
+    DispatchError, DispatcherBuilder, DispatcherConfig, Health, Provider, Role, Router, Task,
+    TaskContext, TaskId, Worktree, WorktreeError, WorktreeProvisioner,
+};
+use tokio::sync::{Mutex, Notify};
+
+#[derive(Debug, Default)]
+struct ProvisionerLog {
+    provisioned: Vec<TaskId>,
+    released: Vec<PathBuf>,
+}
+
+struct MockProvisioner {
+    log: Arc<Mutex<ProvisionerLog>>,
+    counter: AtomicU32,
+    base: PathBuf,
+}
+
+impl MockProvisioner {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            log: Arc::new(Mutex::new(ProvisionerLog::default())),
+            counter: AtomicU32::new(0),
+            base: PathBuf::from("/tmp/dispatcher-test-worktrees"),
+        })
+    }
+
+    fn log(&self) -> Arc<Mutex<ProvisionerLog>> {
+        self.log.clone()
+    }
+}
+
+#[async_trait]
+impl WorktreeProvisioner for MockProvisioner {
+    async fn provision(&self, task_id: TaskId) -> Result<Worktree, WorktreeError> {
+        let n = self.counter.fetch_add(1, Ordering::SeqCst);
+        let mut log = self.log.lock().await;
+        log.provisioned.push(task_id);
+        Ok(Worktree {
+            path: self.base.join(format!("wt-{n}")),
+            branch: format!("wt-branch-{n}"),
+        })
+    }
+    fn release(&self, worktree: Worktree) {
+        // Avoid blocking inside Drop: try_lock first; if contended, push
+        // best-effort via a parking_lot-style spin would over-engineer the
+        // test. Tests await on empty lock before asserting.
+        if let Ok(mut log) = self.log.try_lock() {
+            log.released.push(worktree.path);
+        } else {
+            // Fall back: spawn a tiny task on the current runtime that
+            // performs the release async-ly. Tests use `flush_releases`
+            // below to wait for cleanup.
+            let log = self.log.clone();
+            tokio::spawn(async move {
+                let mut g = log.lock().await;
+                g.released.push(worktree.path);
+            });
+        }
+    }
+}
+
+/// Wait up to ~500 ms for the provisioner to record `expected` releases.
+async fn wait_for_releases(log: &Arc<Mutex<ProvisionerLog>>, expected: usize) {
+    for _ in 0..50 {
+        {
+            let g = log.lock().await;
+            if g.released.len() >= expected {
+                return;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let g = log.lock().await;
+    panic!(
+        "expected {} releases, only saw {} ({:?})",
+        expected,
+        g.released.len(),
+        g.released
+    );
+}
+
+/// Agent that tracks how many concurrent executions are in flight,
+/// and waits on a [`Notify`] before emitting Completed. Tests use this to
+/// verify concurrency caps.
+struct GatedAgent {
+    id: AgentId,
+    capabilities: Capabilities,
+    in_flight: Arc<AtomicU32>,
+    max_observed: Arc<AtomicU32>,
+    release: Arc<Notify>,
+    started: Arc<Notify>,
+}
+
+impl GatedAgent {
+    fn new(
+        id: &str,
+        in_flight: Arc<AtomicU32>,
+        max_observed: Arc<AtomicU32>,
+        release: Arc<Notify>,
+        started: Arc<Notify>,
+    ) -> Self {
+        Self {
+            id: AgentId(id.to_string()),
+            capabilities: Capabilities {
+                roles: [Role::Worker].into_iter().collect::<HashSet<_>>(),
+                max_context_tokens: 8_192,
+                supports_tools: false,
+                supports_vision: false,
+            },
+            in_flight,
+            max_observed,
+            release,
+            started,
+        }
+    }
+}
+
+#[async_trait]
+impl Agent for GatedAgent {
+    fn id(&self) -> AgentId {
+        self.id.clone()
+    }
+    fn capabilities(&self) -> &Capabilities {
+        &self.capabilities
+    }
+    fn health(&self) -> Health {
+        Health {
+            healthy: true,
+            last_check: Utc::now(),
+            error_rate: 0.0,
+        }
+    }
+    async fn execute(
+        &self,
+        task: Task,
+    ) -> Result<AgentEventStream, orchestrator::AgentError> {
+        let in_flight = self.in_flight.clone();
+        let max_observed = self.max_observed.clone();
+        let release = self.release.clone();
+        let started = self.started.clone();
+        let task_id = task.id;
+        let s = stream! {
+            // Track max concurrency.
+            let n = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            max_observed.fetch_max(n, Ordering::SeqCst);
+            yield AgentEvent::Started { task_id };
+            started.notify_one();
+            // Hold the slot until the test releases.
+            release.notified().await;
+            yield AgentEvent::Completed { task_id, summary: None };
+            in_flight.fetch_sub(1, Ordering::SeqCst);
+        };
+        Ok(Box::pin(s))
+    }
+}
+
+/// Always-completes agent for the simpler happy-path tests.
+struct ImmediateAgent {
+    id: AgentId,
+    capabilities: Capabilities,
+}
+
+impl ImmediateAgent {
+    fn new(id: &str) -> Self {
+        Self {
+            id: AgentId(id.to_string()),
+            capabilities: Capabilities {
+                roles: [Role::Worker].into_iter().collect::<HashSet<_>>(),
+                max_context_tokens: 8_192,
+                supports_tools: false,
+                supports_vision: false,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl Agent for ImmediateAgent {
+    fn id(&self) -> AgentId {
+        self.id.clone()
+    }
+    fn capabilities(&self) -> &Capabilities {
+        &self.capabilities
+    }
+    fn health(&self) -> Health {
+        Health {
+            healthy: true,
+            last_check: Utc::now(),
+            error_rate: 0.0,
+        }
+    }
+    async fn execute(
+        &self,
+        task: Task,
+    ) -> Result<AgentEventStream, orchestrator::AgentError> {
+        let task_id = task.id;
+        let cwd = task.context.cwd.clone();
+        let s = stream! {
+            yield AgentEvent::Started { task_id };
+            yield AgentEvent::OutputChunk { text: cwd.display().to_string() };
+            yield AgentEvent::Completed { task_id, summary: None };
+        };
+        Ok(Box::pin(s))
+    }
+}
+
+fn ample_budget(providers: &[Provider]) -> Arc<Budget> {
+    let mut caps = HashMap::new();
+    for p in providers {
+        caps.insert(
+            *p,
+            Cap {
+                monthly_micro_dollars: 1_000_000_000,
+                session_micro_dollars: 1_000_000_000,
+            },
+        );
+    }
+    Arc::new(Budget::new(caps))
+}
+
+fn worker_task() -> Task {
+    Task {
+        id: TaskId::new(),
+        role: Role::Worker,
+        prompt: "do work".to_string(),
+        context: TaskContext {
+            cwd: PathBuf::from("/should/be/overridden"),
+            env: HashMap::new(),
+            metadata: HashMap::new(),
+        },
+        budget_hint: None,
+    }
+}
+
+#[tokio::test]
+async fn dispatch_provisions_worktree_and_overrides_cwd() {
+    let provisioner = MockProvisioner::new();
+    let log = provisioner.log();
+
+    let dispatcher = DispatcherBuilder::new(
+        Router::new(ample_budget(&[Provider::ClaudeCode])),
+        provisioner.clone(),
+    )
+    .register(AgentRegistration {
+        agent: Arc::new(ImmediateAgent::new("immediate")),
+        provider: Provider::ClaudeCode,
+        estimated_micros_per_task: 100,
+    })
+    .build();
+
+    let outcome = dispatcher
+        .dispatch(worker_task())
+        .await
+        .expect("dispatch succeeds");
+
+    assert_eq!(outcome.agent.0, "immediate");
+    assert!(outcome
+        .worktree_path
+        .starts_with("/tmp/dispatcher-test-worktrees"));
+
+    // Drain stream and assert the agent saw the patched cwd.
+    let events: Vec<_> = outcome.events.collect().await;
+    let chunk = events.iter().find_map(|e| match e {
+        AgentEvent::OutputChunk { text } => Some(text.clone()),
+        _ => None,
+    });
+    assert_eq!(
+        chunk.as_deref(),
+        Some(outcome.worktree_path.display().to_string().as_str())
+    );
+
+    wait_for_releases(&log, 1).await;
+    let g = log.lock().await;
+    assert_eq!(g.provisioned.len(), 1);
+    assert_eq!(g.released.len(), 1);
+    assert_eq!(g.released[0], outcome.worktree_path);
+}
+
+#[tokio::test]
+async fn global_concurrency_cap_blocks_extra_dispatches() {
+    let provisioner = MockProvisioner::new();
+    let in_flight = Arc::new(AtomicU32::new(0));
+    let max_observed = Arc::new(AtomicU32::new(0));
+    let release = Arc::new(Notify::new());
+    let started = Arc::new(Notify::new());
+
+    let dispatcher = DispatcherBuilder::new(
+        Router::new(ample_budget(&[Provider::ClaudeCode])),
+        provisioner.clone(),
+    )
+    .with_config(DispatcherConfig {
+        global_concurrency: 2,
+        per_provider_concurrency: HashMap::new(),
+        default_per_provider: 8,
+    })
+    .register(AgentRegistration {
+        agent: Arc::new(GatedAgent::new(
+            "gated",
+            in_flight.clone(),
+            max_observed.clone(),
+            release.clone(),
+            started.clone(),
+        )),
+        provider: Provider::ClaudeCode,
+        estimated_micros_per_task: 100,
+    })
+    .build();
+
+    // Spawn 5 dispatches; cap is 2, so only 2 should be active at any time.
+    let dispatcher = Arc::new(dispatcher);
+    let mut handles = vec![];
+    for _ in 0..5 {
+        let d = dispatcher.clone();
+        handles.push(tokio::spawn(async move {
+            let outcome = d.dispatch(worker_task()).await.expect("dispatch");
+            // Drain events; this releases the worktree on stream end.
+            let _: Vec<_> = outcome.events.collect().await;
+        }));
+    }
+
+    // Wait for first batch of starts then release sequentially.
+    started.notified().await;
+    started.notified().await;
+    // Give the dispatcher a moment to (correctly) NOT start a third before
+    // we release one slot.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        max_observed.load(Ordering::SeqCst) <= 2,
+        "max_observed={}, expected <=2",
+        max_observed.load(Ordering::SeqCst)
+    );
+
+    // Release them all.
+    for _ in 0..5 {
+        release.notify_one();
+        // Each release lets one task complete and frees a slot.
+        // The next task will start; await its start signal.
+        let _ = tokio::time::timeout(Duration::from_secs(1), started.notified()).await;
+    }
+
+    for h in handles {
+        h.await.unwrap();
+    }
+    assert!(max_observed.load(Ordering::SeqCst) <= 2);
+    assert_eq!(in_flight.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn per_provider_cap_independently_throttles() {
+    let provisioner = MockProvisioner::new();
+    let in_flight_a = Arc::new(AtomicU32::new(0));
+    let in_flight_b = Arc::new(AtomicU32::new(0));
+    let max_a = Arc::new(AtomicU32::new(0));
+    let max_b = Arc::new(AtomicU32::new(0));
+    let release = Arc::new(Notify::new());
+    let started = Arc::new(Notify::new());
+
+    let mut per = HashMap::new();
+    per.insert(Provider::ClaudeCode, 1);
+    per.insert(Provider::Codex, 2);
+
+    let dispatcher = DispatcherBuilder::new(
+        Router::new(ample_budget(&[Provider::ClaudeCode, Provider::Codex])),
+        provisioner.clone(),
+    )
+    .with_config(DispatcherConfig {
+        global_concurrency: 16,
+        per_provider_concurrency: per,
+        default_per_provider: 4,
+    })
+    .register(AgentRegistration {
+        // Cheap so the router prefers this for ClaudeCode-routed tasks.
+        agent: Arc::new(GatedAgent::new(
+            "claude-agent",
+            in_flight_a.clone(),
+            max_a.clone(),
+            release.clone(),
+            started.clone(),
+        )),
+        provider: Provider::ClaudeCode,
+        estimated_micros_per_task: 100,
+    })
+    .register(AgentRegistration {
+        agent: Arc::new(GatedAgent::new(
+            "codex-agent",
+            in_flight_b.clone(),
+            max_b.clone(),
+            release.clone(),
+            started.clone(),
+        )),
+        provider: Provider::Codex,
+        // Higher cost so router never picks this for the same role —
+        // separate test would otherwise use a different role per agent.
+        estimated_micros_per_task: 1_000_000,
+    })
+    .build();
+
+    // The router will pick claude-agent for every Worker task because it's
+    // cheaper. So we exercise the per-provider cap on ClaudeCode.
+    let dispatcher = Arc::new(dispatcher);
+    let mut handles = vec![];
+    for _ in 0..3 {
+        let d = dispatcher.clone();
+        handles.push(tokio::spawn(async move {
+            let outcome = d.dispatch(worker_task()).await.expect("dispatch");
+            let _: Vec<_> = outcome.events.collect().await;
+        }));
+    }
+
+    // Cap on ClaudeCode is 1; only one should be active.
+    let _ = tokio::time::timeout(Duration::from_secs(1), started.notified()).await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        max_a.load(Ordering::SeqCst) <= 1,
+        "ClaudeCode cap of 1 violated: max_a={}",
+        max_a.load(Ordering::SeqCst)
+    );
+
+    // Release them all sequentially.
+    for _ in 0..3 {
+        release.notify_one();
+        let _ = tokio::time::timeout(Duration::from_secs(1), started.notified()).await;
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+    assert!(max_a.load(Ordering::SeqCst) <= 1);
+    assert_eq!(in_flight_a.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn dispatch_returns_routing_error_when_no_capable_agent() {
+    let provisioner = MockProvisioner::new();
+    let log = provisioner.log();
+    let dispatcher = DispatcherBuilder::new(
+        Router::new(ample_budget(&[Provider::ClaudeCode])),
+        provisioner.clone(),
+    )
+    .build();
+
+    let result = dispatcher.dispatch(worker_task()).await;
+    let err = match result {
+        Ok(_) => panic!("expected routing error, got Ok"),
+        Err(e) => e,
+    };
+    assert!(matches!(err, DispatchError::Routing(_)));
+    // No worktree should have been provisioned.
+    let g = log.lock().await;
+    assert_eq!(g.provisioned.len(), 0);
+    assert_eq!(g.released.len(), 0);
+}
+
+#[tokio::test]
+async fn early_drop_of_stream_releases_worktree() {
+    let provisioner = MockProvisioner::new();
+    let log = provisioner.log();
+    let dispatcher = DispatcherBuilder::new(
+        Router::new(ample_budget(&[Provider::ClaudeCode])),
+        provisioner.clone(),
+    )
+    .register(AgentRegistration {
+        agent: Arc::new(ImmediateAgent::new("immediate")),
+        provider: Provider::ClaudeCode,
+        estimated_micros_per_task: 100,
+    })
+    .build();
+
+    // Dispatch and immediately drop the outcome (specifically the events
+    // stream) without consuming events. Resources should still release.
+    {
+        let outcome = dispatcher.dispatch(worker_task()).await.expect("dispatch");
+        // Take the first event then drop.
+        let mut events = outcome.events;
+        let _first = events.next().await;
+        drop(events);
+    }
+
+    wait_for_releases(&log, 1).await;
+    assert_eq!(dispatcher.available_global_slots(), 8); // default config
+}


### PR DESCRIPTION
## Summary

Implements [PDX-42](https://linear.app/pdx-software/issue/PDX-42/a26-implement-dispatcher-with-worktree-per-worker-and-concurrency-caps) — concurrency-capped, worktree-per-worker task dispatcher.

- New `crates/orchestrator/src/dispatcher.rs` exposing `Dispatcher`, `DispatcherBuilder`, `DispatcherConfig`, `DispatchOutcome`, `DispatchError`, `Worktree`, `WorktreeProvisioner`, `WorktreeError`.
- `dispatch(task)` pipeline: await global semaphore → `Router::select` → await per-provider semaphore → provision worktree → rewrite `task.context.cwd` → `Agent::execute` → return wrapped stream that owns all per-task resources.
- Dropping the returned `DispatchOutcome::events` stream — early or natural — releases both semaphore permits and triggers `WorktreeProvisioner::release` (synchronous, best-effort, the only viable shape inside `Drop`).
- `DispatcherBuilder` mirrors each `AgentRegistration` into both the router and the dispatcher's `AgentId → Provider` map so the two cannot drift. Avoids any edit to `router.rs`.
- Boundary enforcement (PDX-40's `TaskBoundary`) is deliberately not wired in here — both branches landed separately; integration commit can pick whichever lands second.
- Adds `async-stream` and `futures-util` to the orchestrator crate's main deps.
- Drive-by: `std::time::Instant` → `instant::Instant` in `budget.rs` to satisfy the workspace `disallowed_types` clippy lint.

## Test plan

- [x] `cargo clippy -p orchestrator --tests -- -D warnings` clean
- [x] `cargo test -p orchestrator --test dispatcher` — 5 passing (worktree provisioned and `cwd` overridden; global cap=2 holds across 5 dispatches; per-provider cap=1 holds across 3 dispatches; routing error → no worktree leak; early-drop releases worktree).