### PR TITLE
feat(doppler): project/config picker primitives (PDX-51)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,6 +4217,8 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "mockall",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4216,6 +4216,7 @@ name = "doppler"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "instant",
  "mockall",
  "serde",
  "serde_json",

--- a/crates/doppler/Cargo.toml
+++ b/crates/doppler/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+instant = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror.workspace = true

--- a/crates/doppler/Cargo.toml
+++ b/crates/doppler/Cargo.toml
@@ -8,6 +8,8 @@ publish.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "process", "sync", "macros"] }
 tracing.workspace = true

--- a/crates/doppler/src/lib.rs
+++ b/crates/doppler/src/lib.rs
@@ -14,8 +14,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Output;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+use instant::Instant;
 use tokio::sync::RwLock;
 
 mod picker;

--- a/crates/doppler/src/lib.rs
+++ b/crates/doppler/src/lib.rs
@@ -18,9 +18,11 @@ use std::time::{Duration, Instant};
 
 use tokio::sync::RwLock;
 
+mod picker;
 mod runner;
 mod status;
 
+pub use picker::{bind_project, list_configs, list_projects, DopplerConfig, DopplerProject};
 pub use runner::{CommandRunner, TokioCommandRunner};
 pub use status::{parse_configure_all, read_status, DopplerStatus, ScopedBinding};
 

--- a/crates/doppler/src/picker.rs
+++ b/crates/doppler/src/picker.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// PDX-51 [A4.3]: Project / config picker.
+//
+// Listing helpers (`list_projects`, `list_configs`) wrap `doppler projects
+// --json` and `doppler configs --project X --json` so a UI surface can
+// render its own picker rather than embedding the CLI's interactive TUI.
+// The selection is persisted by shelling out to `doppler setup` via
+// [`bind_project`] — the dedicated CLI subcommand that updates
+// `.doppler.yaml` for the chosen scope.
+//
+// All three helpers stream their command through the existing
+// [`CommandRunner`] abstraction so tests can substitute a mock runner.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+use crate::{CommandRunner, DopplerError};
+
+/// A Doppler project, as returned by `doppler projects --json`.
+///
+/// We keep a deliberately narrow projection of the JSON: enough to render a
+/// picker (display name + slug for the underlying setup call), nothing more.
+/// Extra fields are tolerated via `#[serde(default)]` so a future CLI
+/// upgrade does not break this code.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct DopplerProject {
+    /// Stable, URL-safe identifier; this is what `doppler setup --project`
+    /// expects.
+    pub slug: String,
+    /// Human-friendly display name. Often equal to `slug`.
+    pub name: String,
+    /// Optional description shown in the dashboard. May be empty.
+    #[serde(default)]
+    pub description: String,
+}
+
+/// A Doppler config (environment), as returned by `doppler configs --json`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct DopplerConfig {
+    /// The config name; this is what `doppler setup --config` expects.
+    pub name: String,
+    /// `true` for the root config of an environment (e.g. `dev`, `stg`,
+    /// `prd`); `false` for branch configs descended from one of those.
+    #[serde(default)]
+    pub root: bool,
+    /// Environment slug (`dev`, `stg`, `prd`, …) the config lives under.
+    #[serde(default)]
+    pub environment: String,
+}
+
+/// List all Doppler projects visible to the authenticated user.
+///
+/// Runs `doppler projects --json` via `runner` and parses the result.
+/// Returns [`DopplerError::NotAuthenticated`] if the CLI reports a missing
+/// auth token, [`DopplerError::Unreachable`] for network errors, or
+/// [`DopplerError::NonZeroExit`] otherwise.
+pub async fn list_projects(
+    runner: Arc<dyn CommandRunner>,
+) -> Result<Vec<DopplerProject>, DopplerError> {
+    let output = runner.run(&["projects", "--json"], None).await?;
+    if !output.status.success() {
+        return Err(map_listing_error(&output));
+    }
+    serde_json::from_slice::<Vec<DopplerProject>>(&output.stdout).map_err(|e| {
+        DopplerError::NonZeroExit {
+            code: 0,
+            stderr: format!("failed to parse `doppler projects --json` output: {e}"),
+        }
+    })
+}
+
+/// List all configs (environments + branch configs) for `project`.
+///
+/// Runs `doppler configs --project <project> --json`.
+pub async fn list_configs(
+    runner: Arc<dyn CommandRunner>,
+    project: &str,
+) -> Result<Vec<DopplerConfig>, DopplerError> {
+    let output = runner
+        .run(&["configs", "--project", project, "--json"], None)
+        .await?;
+    if !output.status.success() {
+        return Err(map_listing_error(&output));
+    }
+    serde_json::from_slice::<Vec<DopplerConfig>>(&output.stdout).map_err(|e| {
+        DopplerError::NonZeroExit {
+            code: 0,
+            stderr: format!("failed to parse `doppler configs --json` output: {e}"),
+        }
+    })
+}
+
+/// Bind `project`/`config` to `scope` by shelling out to `doppler setup`.
+///
+/// Equivalent to running:
+///
+/// ```bash
+/// doppler setup --no-prompt --project <project> --config <config> --scope <scope>
+/// ```
+///
+/// `--no-prompt` keeps the CLI silent (no TUI), so this is safe to call from
+/// a GUI button. Doppler writes the binding to the directory's
+/// `.doppler.yaml`. After this returns, [`crate::read_status`] will report
+/// the new binding.
+pub async fn bind_project(
+    runner: Arc<dyn CommandRunner>,
+    project: &str,
+    config: &str,
+    scope: &Path,
+) -> Result<(), DopplerError> {
+    let scope_str = scope.to_str().ok_or_else(|| DopplerError::NonZeroExit {
+        code: 0,
+        stderr: format!("scope path is not valid utf-8: {}", scope.display()),
+    })?;
+    let output = runner
+        .run(
+            &[
+                "setup",
+                "--no-prompt",
+                "--project",
+                project,
+                "--config",
+                config,
+                "--scope",
+                scope_str,
+            ],
+            Some(scope),
+        )
+        .await?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(map_listing_error(&output))
+}
+
+/// Map a non-zero `doppler` invocation to one of the rich [`DopplerError`]
+/// variants by sniffing stderr. Mirrors the parser used in
+/// [`crate::parse_output`] but kept private to this module so the listing
+/// helpers can share it without taking a dependency on the secret-fetching
+/// path.
+fn map_listing_error(output: &std::process::Output) -> DopplerError {
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let lower = stderr.to_lowercase();
+    if lower.contains("not authenticated") || lower.contains("you must login") {
+        return DopplerError::NotAuthenticated;
+    }
+    if lower.contains("could not reach") || lower.contains("network") || lower.contains("dial tcp")
+    {
+        return DopplerError::Unreachable;
+    }
+    DopplerError::NonZeroExit {
+        code: output.status.code().unwrap_or(-1),
+        stderr,
+    }
+}

--- a/crates/doppler/tests/picker.rs
+++ b/crates/doppler/tests/picker.rs
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Integration tests for the project/config picker (PDX-51).
+
+use std::io;
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt as _;
+#[cfg(windows)]
+use std::os::windows::process::ExitStatusExt as _;
+use std::process::{ExitStatus, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use doppler::{
+    bind_project, list_configs, list_projects, CommandRunner, DopplerConfig, DopplerError,
+    DopplerProject,
+};
+
+/// Same scriptable mock as `tests/fetch.rs`, copied here to keep this test
+/// file standalone (Rust integration tests cannot share modules).
+struct MockRunner {
+    calls: AtomicUsize,
+    responses: Mutex<Vec<io::Result<Output>>>,
+    last_calls: Mutex<Vec<(Vec<String>, Option<PathBuf>)>>,
+}
+
+impl MockRunner {
+    fn new(responses: Vec<io::Result<Output>>) -> Arc<Self> {
+        Arc::new(Self {
+            calls: AtomicUsize::new(0),
+            responses: Mutex::new(responses),
+            last_calls: Mutex::new(Vec::new()),
+        })
+    }
+
+    fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+
+    fn last_args(&self) -> Vec<String> {
+        let calls = self.last_calls.lock().unwrap();
+        calls.last().map(|(a, _)| a.clone()).unwrap_or_default()
+    }
+
+    fn last_cwd(&self) -> Option<PathBuf> {
+        let calls = self.last_calls.lock().unwrap();
+        calls.last().and_then(|(_, c)| c.clone())
+    }
+}
+
+#[async_trait::async_trait]
+impl CommandRunner for MockRunner {
+    async fn run(&self, args: &[&str], cwd: Option<&Path>) -> io::Result<Output> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.last_calls.lock().unwrap().push((
+            args.iter().map(|s| s.to_string()).collect(),
+            cwd.map(|p| p.to_path_buf()),
+        ));
+        let mut responses = self.responses.lock().unwrap();
+        if responses.is_empty() {
+            return Err(io::Error::other("no more mock responses"));
+        }
+        responses.remove(0)
+    }
+}
+
+fn ok_output(stdout: &str) -> Output {
+    #[cfg(unix)]
+    let status = ExitStatus::from_raw(0);
+    #[cfg(windows)]
+    let status = ExitStatus::from_raw(0);
+    Output {
+        status,
+        stdout: stdout.as_bytes().to_vec(),
+        stderr: Vec::new(),
+    }
+}
+
+fn err_output(code: i32, stderr: &str) -> Output {
+    #[cfg(unix)]
+    let status = ExitStatus::from_raw(code << 8);
+    #[cfg(windows)]
+    let status = ExitStatus::from_raw(code as u32);
+    Output {
+        status,
+        stdout: Vec::new(),
+        stderr: stderr.as_bytes().to_vec(),
+    }
+}
+
+const PROJECTS_JSON: &str = r#"[
+  {"slug":"my-app","name":"my-app","description":"Production app"},
+  {"slug":"infra","name":"infra","description":""},
+  {"slug":"playground","name":"Playground"}
+]"#;
+
+const CONFIGS_JSON: &str = r#"[
+  {"name":"dev","root":true,"environment":"dev"},
+  {"name":"dev_alice","root":false,"environment":"dev"},
+  {"name":"prd","root":true,"environment":"prd"}
+]"#;
+
+#[tokio::test]
+async fn list_projects_parses_json_and_invokes_correct_command() {
+    let runner = MockRunner::new(vec![Ok(ok_output(PROJECTS_JSON))]);
+    let projects = list_projects(runner.clone() as Arc<dyn CommandRunner>)
+        .await
+        .expect("list_projects ok");
+
+    assert_eq!(runner.call_count(), 1);
+    assert_eq!(runner.last_args(), vec!["projects", "--json"]);
+    assert_eq!(runner.last_cwd(), None);
+
+    assert_eq!(
+        projects,
+        vec![
+            DopplerProject {
+                slug: "my-app".into(),
+                name: "my-app".into(),
+                description: "Production app".into(),
+            },
+            DopplerProject {
+                slug: "infra".into(),
+                name: "infra".into(),
+                description: String::new(),
+            },
+            DopplerProject {
+                slug: "playground".into(),
+                name: "Playground".into(),
+                description: String::new(),
+            },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn list_configs_passes_project_arg() {
+    let runner = MockRunner::new(vec![Ok(ok_output(CONFIGS_JSON))]);
+    let configs = list_configs(runner.clone() as Arc<dyn CommandRunner>, "my-app")
+        .await
+        .expect("list_configs ok");
+
+    assert_eq!(
+        runner.last_args(),
+        vec!["configs", "--project", "my-app", "--json"]
+    );
+    assert_eq!(
+        configs,
+        vec![
+            DopplerConfig {
+                name: "dev".into(),
+                root: true,
+                environment: "dev".into(),
+            },
+            DopplerConfig {
+                name: "dev_alice".into(),
+                root: false,
+                environment: "dev".into(),
+            },
+            DopplerConfig {
+                name: "prd".into(),
+                root: true,
+                environment: "prd".into(),
+            },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn list_projects_maps_unauthenticated_stderr() {
+    let runner = MockRunner::new(vec![Ok(err_output(1, "Doppler Error: not authenticated"))]);
+    let err = list_projects(runner as Arc<dyn CommandRunner>)
+        .await
+        .expect_err("expected NotAuthenticated");
+    assert!(matches!(err, DopplerError::NotAuthenticated));
+}
+
+#[tokio::test]
+async fn list_projects_maps_network_error() {
+    let runner = MockRunner::new(vec![Ok(err_output(
+        1,
+        "could not reach api.doppler.com: dial tcp",
+    ))]);
+    let err = list_projects(runner as Arc<dyn CommandRunner>)
+        .await
+        .expect_err("expected Unreachable");
+    assert!(matches!(err, DopplerError::Unreachable));
+}
+
+#[tokio::test]
+async fn list_projects_passes_through_other_nonzero_exit() {
+    let runner = MockRunner::new(vec![Ok(err_output(7, "weird unexpected failure"))]);
+    let err = list_projects(runner as Arc<dyn CommandRunner>)
+        .await
+        .expect_err("expected NonZeroExit");
+    match err {
+        DopplerError::NonZeroExit { code, stderr } => {
+            assert_eq!(code, 7);
+            assert!(stderr.contains("weird"));
+        }
+        other => panic!("expected NonZeroExit, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn list_projects_surfaces_parse_error_on_garbage_stdout() {
+    let runner = MockRunner::new(vec![Ok(ok_output("<<not json>>"))]);
+    let err = list_projects(runner as Arc<dyn CommandRunner>)
+        .await
+        .expect_err("expected parse error");
+    match err {
+        DopplerError::NonZeroExit { stderr, .. } => {
+            assert!(stderr.contains("failed to parse"));
+        }
+        other => panic!("expected parse error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn bind_project_invokes_doppler_setup_with_no_prompt_and_scope() {
+    let runner = MockRunner::new(vec![Ok(ok_output(""))]);
+    let scope = PathBuf::from("/home/u/repo");
+    bind_project(
+        runner.clone() as Arc<dyn CommandRunner>,
+        "my-app",
+        "dev",
+        &scope,
+    )
+    .await
+    .expect("bind ok");
+
+    assert_eq!(runner.call_count(), 1);
+    let args = runner.last_args();
+    // Order matters: --no-prompt must come before any positional arg pattern,
+    // and --scope must point at the requested directory.
+    assert_eq!(args[0], "setup");
+    assert!(args.contains(&"--no-prompt".to_string()));
+    let project_idx = args.iter().position(|s| s == "--project").unwrap();
+    assert_eq!(args[project_idx + 1], "my-app");
+    let config_idx = args.iter().position(|s| s == "--config").unwrap();
+    assert_eq!(args[config_idx + 1], "dev");
+    let scope_idx = args.iter().position(|s| s == "--scope").unwrap();
+    assert_eq!(args[scope_idx + 1], "/home/u/repo");
+    // `cwd` is also passed so the CLI writes `.doppler.yaml` in the right
+    // place even on older CLI versions that ignore --scope.
+    assert_eq!(runner.last_cwd().as_deref(), Some(scope.as_path()));
+}
+
+#[tokio::test]
+async fn bind_project_propagates_unauthenticated() {
+    let runner = MockRunner::new(vec![Ok(err_output(1, "Doppler Error: not authenticated"))]);
+    let err = bind_project(
+        runner as Arc<dyn CommandRunner>,
+        "my-app",
+        "dev",
+        Path::new("/tmp"),
+    )
+    .await
+    .expect_err("expected NotAuthenticated");
+    assert!(matches!(err, DopplerError::NotAuthenticated));
+}

--- a/crates/doppler/tests/status.rs
+++ b/crates/doppler/tests/status.rs
@@ -5,12 +5,12 @@ use std::io;
 use std::os::unix::process::ExitStatusExt as _;
 #[cfg(windows)]
 use std::os::windows::process::ExitStatusExt as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Output};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-use doppler::{parse_configure_all, read_status, CommandRunner, DopplerError, DopplerStatus, ScopedBinding};
+use doppler::{parse_configure_all, read_status, CommandRunner, DopplerError, DopplerStatus};
 
 // ---------------------------------------------------------------------------
 // MockRunner — identical pattern to tests/fetch.rs
@@ -31,6 +31,7 @@ impl MockRunner {
         })
     }
 
+    #[allow(dead_code)]
     fn call_count(&self) -> usize {
         self.calls.load(Ordering::SeqCst)
     }
@@ -42,7 +43,7 @@ impl MockRunner {
 
 #[async_trait::async_trait]
 impl CommandRunner for MockRunner {
-    async fn run(&self, args: &[&str]) -> io::Result<Output> {
+    async fn run(&self, args: &[&str], _cwd: Option<&Path>) -> io::Result<Output> {
         self.calls.fetch_add(1, Ordering::SeqCst);
         self.last_args
             .lock()


### PR DESCRIPTION
## Summary

Implements [PDX-51](https://linear.app/pdx-software/issue/PDX-51/a43-projectconfig-picker-shells-out-to-doppler-setup) — data-layer primitives for a Doppler project/config picker that ultimately shells out to `doppler setup` for binding.

- New `crates/doppler/src/picker.rs`:
  - `list_projects(runner)` wraps `doppler projects --json`.
  - `list_configs(runner, project)` wraps `doppler configs --project <X> --json`.
  - `bind_project(runner, project, config, scope)` shells out to `doppler setup --no-prompt --project <X> --config <Y> --scope <S>` with `cwd = scope` so older CLI versions that ignore `--scope` still target the right directory.
- Stderr sniffing maps known failure modes onto rich `DopplerError` variants.
- Adds `serde` (with `derive`) and `serde_json` to the doppler crate's main deps.
- Drive-by: `std::time::Instant` → `instant::Instant` in `lib.rs` (clippy `disallowed_types`); repair `tests/status.rs::MockRunner::run` to match the current `(args, cwd: Option<&Path>)` trait signature; drop unused `ScopedBinding` import; `#[allow(dead_code)]` on unused `call_count` helper.

## Scope decision

The settings-view picker UI that consumes these APIs (renders the project list as buttons → renders the config list as buttons → calls `bind_project`) lands in a follow-up so this PR stays focused on the testable data layer.

## Test plan

- [x] `cargo clippy -p doppler --tests -- -D warnings` clean
- [x] `cargo test -p doppler --test picker` — 8 passing