### PR TITLE
feat(doppler): 401-triggered re-fetch logic (PDX-54)

### DIFF
--- a/crates/doppler/src/lib.rs
+++ b/crates/doppler/src/lib.rs
@@ -20,10 +20,14 @@ use instant::Instant;
 use tokio::sync::RwLock;
 
 mod picker;
+mod refetch;
 mod runner;
 mod status;
 
 pub use picker::{bind_project, list_configs, list_projects, DopplerConfig, DopplerProject};
+pub use refetch::{
+    with_refetch_on_unauthorized, with_refetch_on_unauthorized_using_runner, RefetchError,
+};
 pub use runner::{CommandRunner, TokioCommandRunner};
 pub use status::{parse_configure_all, read_status, DopplerStatus, ScopedBinding};
 

--- a/crates/doppler/src/refetch.rs
+++ b/crates/doppler/src/refetch.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// PDX-54 [A4.6]: 401-triggered re-fetch logic.
+//
+// When a downstream provider returns 401, the cached secret is presumed
+// stale (rotated upstream, revoked, etc.). This module provides:
+//
+// * `DopplerClient::refetch` — the primitive: drop the cache entry, then
+//   re-`get` from the CLI. Use it directly when the caller wants to drive
+//   its own retry logic.
+//
+// * `with_refetch_on_unauthorized` — a higher-order helper that runs the
+//   caller's operation, and if the operation returns an error the caller
+//   classifies as "unauthorized", invalidates and refetches the secret
+//   exactly once before retrying. The single-retry budget bounds the
+//   damage when the credential really is broken — we never loop forever.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use thiserror::Error;
+
+use crate::{CommandRunner, DopplerClient, DopplerError, SecretValue};
+
+/// Error returned by [`with_refetch_on_unauthorized`].
+///
+/// Generic over the provider's error type `E` — typically the HTTP client
+/// error type the caller already uses.
+#[derive(Debug, Error)]
+pub enum RefetchError<E>
+where
+    E: std::error::Error + 'static,
+{
+    /// The Doppler CLI itself failed (initial fetch or refetch).
+    #[error("doppler error: {0}")]
+    Doppler(#[source] DopplerError),
+    /// The provider operation failed and the failure was *not* classified
+    /// as unauthorized, or it was unauthorized but the post-refetch retry
+    /// also failed.
+    #[error("provider error: {0}")]
+    Provider(#[source] E),
+}
+
+impl<E: std::error::Error + 'static> From<DopplerError> for RefetchError<E> {
+    fn from(value: DopplerError) -> Self {
+        RefetchError::Doppler(value)
+    }
+}
+
+impl DopplerClient {
+    /// Drop the cached entry for `(cwd, name)` and re-fetch from the CLI.
+    ///
+    /// The new value replaces any existing cache entry. Use this when an
+    /// out-of-band signal (e.g. a 401 from a downstream provider) has
+    /// invalidated the cached secret.
+    pub async fn refetch(
+        &self,
+        name: &str,
+        cwd: Option<&Path>,
+    ) -> Result<SecretValue, DopplerError> {
+        // `invalidate` is synchronous and lock-free under contention, so
+        // the next `get` cannot return a stale entry.
+        self.invalidate(name, cwd);
+        self.get(name, cwd).await
+    }
+}
+
+/// Run `op(secret)` once, and if it returns an error the caller classifies
+/// as unauthorized, refetch the secret and retry exactly once.
+///
+/// `is_unauthorized` is a predicate the caller supplies to inspect the
+/// provider's error type — typically `|e| e.status() == 401` or similar.
+/// The closure may also be lifted out of an enum variant (`matches!(e,
+/// MyError::Unauthorized)`) for clients that have already classified the
+/// failure mode.
+///
+/// Returns:
+/// - `Ok(t)` from the first successful call (no refetch).
+/// - `Ok(t)` from the post-refetch retry.
+/// - `Err(RefetchError::Doppler(_))` if Doppler itself fails (initial
+///   `get` or refetch).
+/// - `Err(RefetchError::Provider(_))` for the original error if it was not
+///   unauthorized, or for the second-attempt error if the retry also
+///   failed.
+///
+/// `op` is called at most twice. If both attempts return unauthorized,
+/// the second error is the one returned — letting the caller observe
+/// "we already tried fresh credentials and it's still 401".
+pub async fn with_refetch_on_unauthorized<Op, Fut, T, E>(
+    client: &DopplerClient,
+    name: &str,
+    cwd: Option<&Path>,
+    op: Op,
+    is_unauthorized: impl Fn(&E) -> bool,
+) -> Result<T, RefetchError<E>>
+where
+    Op: Fn(SecretValue) -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+    E: std::error::Error + 'static,
+{
+    // First attempt with whatever the cache currently holds.
+    let first = client.get(name, cwd).await?;
+    match op(first).await {
+        Ok(t) => return Ok(t),
+        Err(e) if is_unauthorized(&e) => {
+            tracing::debug!("doppler: refetching {name} after 401 from provider");
+            // Fall through to the refetch + retry path. The original
+            // error `e` is intentionally dropped — only the retry's
+            // outcome propagates.
+            let _ = e;
+        }
+        Err(e) => return Err(RefetchError::Provider(e)),
+    }
+
+    let fresh = client.refetch(name, cwd).await?;
+    op(fresh).await.map_err(RefetchError::Provider)
+}
+
+/// Convenience: build a [`DopplerClient`] with the supplied runner and
+/// then run [`with_refetch_on_unauthorized`] against it. Lets tests
+/// construct a client per-test without the surrounding ceremony.
+pub async fn with_refetch_on_unauthorized_using_runner<Op, Fut, T, E>(
+    runner: Arc<dyn CommandRunner>,
+    ttl: std::time::Duration,
+    name: &str,
+    cwd: Option<&Path>,
+    op: Op,
+    is_unauthorized: impl Fn(&E) -> bool,
+) -> Result<T, RefetchError<E>>
+where
+    Op: Fn(SecretValue) -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+    E: std::error::Error + 'static,
+{
+    let client = DopplerClient::with_runner(ttl, runner);
+    with_refetch_on_unauthorized(&client, name, cwd, op, is_unauthorized).await
+}

--- a/crates/doppler/tests/refetch.rs
+++ b/crates/doppler/tests/refetch.rs
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Integration tests for the 401-triggered refetch logic (PDX-54).
+
+use std::io;
+use std::path::Path;
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt as _;
+#[cfg(windows)]
+use std::os::windows::process::ExitStatusExt as _;
+use std::process::{ExitStatus, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use doppler::{
+    with_refetch_on_unauthorized, CommandRunner, DopplerClient, RefetchError, SecretValue,
+};
+
+struct MockRunner {
+    calls: AtomicUsize,
+    responses: Mutex<Vec<io::Result<Output>>>,
+}
+
+impl MockRunner {
+    fn new(responses: Vec<io::Result<Output>>) -> Arc<Self> {
+        Arc::new(Self {
+            calls: AtomicUsize::new(0),
+            responses: Mutex::new(responses),
+        })
+    }
+    fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl CommandRunner for MockRunner {
+    async fn run(&self, _args: &[&str], _cwd: Option<&Path>) -> io::Result<Output> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let mut responses = self.responses.lock().unwrap();
+        if responses.is_empty() {
+            return Err(io::Error::other("no more mock responses"));
+        }
+        responses.remove(0)
+    }
+}
+
+fn ok_output(stdout: &str) -> Output {
+    #[cfg(unix)]
+    let status = ExitStatus::from_raw(0);
+    #[cfg(windows)]
+    let status = ExitStatus::from_raw(0);
+    Output {
+        status,
+        stdout: stdout.as_bytes().to_vec(),
+        stderr: Vec::new(),
+    }
+}
+
+#[derive(Debug, thiserror::Error, Clone)]
+enum FakeProviderError {
+    #[error("unauthorized")]
+    Unauthorized,
+    #[error("server error: {0}")]
+    Server(String),
+}
+
+fn is_unauthorized(e: &FakeProviderError) -> bool {
+    matches!(e, FakeProviderError::Unauthorized)
+}
+
+/// Counts how many times `op` was called and what secrets it saw.
+struct OpRecorder {
+    calls: AtomicUsize,
+    secrets_seen: Mutex<Vec<String>>,
+}
+
+impl OpRecorder {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            calls: AtomicUsize::new(0),
+            secrets_seen: Mutex::new(vec![]),
+        })
+    }
+    fn record(&self, secret: &SecretValue) {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.secrets_seen
+            .lock()
+            .unwrap()
+            .push(secret.expose().to_string());
+    }
+    fn count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+    fn secrets(&self) -> Vec<String> {
+        self.secrets_seen.lock().unwrap().clone()
+    }
+}
+
+#[tokio::test]
+async fn happy_path_calls_op_once_no_refetch() {
+    let runner = MockRunner::new(vec![Ok(ok_output("token-v1\n"))]);
+    let client =
+        DopplerClient::with_runner(Duration::from_secs(60), runner.clone() as Arc<dyn CommandRunner>);
+    let recorder = OpRecorder::new();
+
+    let result: Result<u32, _> = with_refetch_on_unauthorized(
+        &client,
+        "API_KEY",
+        None,
+        |secret| {
+            let recorder = recorder.clone();
+            async move {
+                recorder.record(&secret);
+                Ok::<u32, FakeProviderError>(42)
+            }
+        },
+        is_unauthorized,
+    )
+    .await;
+
+    assert_eq!(result.unwrap(), 42);
+    assert_eq!(recorder.count(), 1);
+    assert_eq!(recorder.secrets(), vec!["token-v1"]);
+    assert_eq!(runner.call_count(), 1, "no refetch should occur on success");
+}
+
+#[tokio::test]
+async fn unauthorized_then_success_invalidates_and_refetches_once() {
+    // First Doppler fetch returns "stale-token"; after 401, refetch returns
+    // "fresh-token" and the second op call succeeds.
+    let runner = MockRunner::new(vec![
+        Ok(ok_output("stale-token\n")),
+        Ok(ok_output("fresh-token\n")),
+    ]);
+    let client =
+        DopplerClient::with_runner(Duration::from_secs(60), runner.clone() as Arc<dyn CommandRunner>);
+    let recorder = OpRecorder::new();
+
+    let result: Result<u32, _> = with_refetch_on_unauthorized(
+        &client,
+        "API_KEY",
+        None,
+        |secret| {
+            let recorder = recorder.clone();
+            async move {
+                recorder.record(&secret);
+                if secret.expose() == "stale-token" {
+                    Err(FakeProviderError::Unauthorized)
+                } else {
+                    Ok(7)
+                }
+            }
+        },
+        is_unauthorized,
+    )
+    .await;
+
+    assert_eq!(result.unwrap(), 7);
+    assert_eq!(recorder.count(), 2);
+    assert_eq!(recorder.secrets(), vec!["stale-token", "fresh-token"]);
+    assert_eq!(
+        runner.call_count(),
+        2,
+        "should have spawned doppler twice: initial + refetch"
+    );
+
+    // The cache must now hold the fresh token, not the stale one. A
+    // subsequent direct `get` should return fresh-token without spawning
+    // doppler again.
+    let cached = client.get("API_KEY", None).await.expect("cache hit");
+    assert_eq!(cached.expose(), "fresh-token");
+    assert_eq!(runner.call_count(), 2, "cache hit must not respawn");
+}
+
+#[tokio::test]
+async fn unauthorized_twice_returns_provider_error_from_second_attempt() {
+    let runner = MockRunner::new(vec![
+        Ok(ok_output("token-1\n")),
+        Ok(ok_output("token-2\n")),
+    ]);
+    let client =
+        DopplerClient::with_runner(Duration::from_secs(60), runner.clone() as Arc<dyn CommandRunner>);
+    let recorder = OpRecorder::new();
+
+    let result: Result<u32, _> = with_refetch_on_unauthorized(
+        &client,
+        "API_KEY",
+        None,
+        |secret| {
+            let recorder = recorder.clone();
+            async move {
+                recorder.record(&secret);
+                Err::<u32, _>(FakeProviderError::Unauthorized)
+            }
+        },
+        is_unauthorized,
+    )
+    .await;
+
+    match result {
+        Err(RefetchError::Provider(FakeProviderError::Unauthorized)) => {}
+        other => panic!("expected Provider(Unauthorized), got {other:?}"),
+    }
+    assert_eq!(recorder.count(), 2);
+    assert_eq!(runner.call_count(), 2, "exactly one refetch (no infinite loop)");
+}
+
+#[tokio::test]
+async fn non_unauthorized_error_short_circuits_no_refetch() {
+    let runner = MockRunner::new(vec![Ok(ok_output("ok-token\n"))]);
+    let client =
+        DopplerClient::with_runner(Duration::from_secs(60), runner.clone() as Arc<dyn CommandRunner>);
+    let recorder = OpRecorder::new();
+
+    let result: Result<u32, _> = with_refetch_on_unauthorized(
+        &client,
+        "API_KEY",
+        None,
+        |secret| {
+            let recorder = recorder.clone();
+            async move {
+                recorder.record(&secret);
+                Err::<u32, _>(FakeProviderError::Server("500".to_string()))
+            }
+        },
+        is_unauthorized,
+    )
+    .await;
+
+    match result {
+        Err(RefetchError::Provider(FakeProviderError::Server(msg))) => assert_eq!(msg, "500"),
+        other => panic!("expected Provider(Server), got {other:?}"),
+    }
+    assert_eq!(recorder.count(), 1, "non-401 must not retry");
+    assert_eq!(runner.call_count(), 1, "no refetch on non-401 error");
+}
+
+#[tokio::test]
+async fn doppler_failure_during_initial_get_propagates_as_doppler_error() {
+    // No mock responses queued → MockRunner returns io::Error → DopplerError::Spawn.
+    let runner = MockRunner::new(vec![]);
+    let client =
+        DopplerClient::with_runner(Duration::from_secs(60), runner.clone() as Arc<dyn CommandRunner>);
+    let recorder = OpRecorder::new();
+
+    let result: Result<u32, _> = with_refetch_on_unauthorized(
+        &client,
+        "API_KEY",
+        None,
+        |secret| {
+            let recorder = recorder.clone();
+            async move {
+                recorder.record(&secret);
+                Ok::<u32, FakeProviderError>(0)
+            }
+        },
+        is_unauthorized,
+    )
+    .await;
+
+    assert!(matches!(result, Err(RefetchError::Doppler(_))));
+    assert_eq!(recorder.count(), 0, "op must not run when initial doppler fetch fails");
+}
+
+#[tokio::test]
+async fn doppler_failure_during_refetch_propagates_as_doppler_error() {
+    // Initial fetch succeeds; refetch fails (no second response queued).
+    let runner = MockRunner::new(vec![Ok(ok_output("first-token\n"))]);
+    let client =
+        DopplerClient::with_runner(Duration::from_secs(60), runner.clone() as Arc<dyn CommandRunner>);
+    let recorder = OpRecorder::new();
+
+    let result: Result<u32, _> = with_refetch_on_unauthorized(
+        &client,
+        "API_KEY",
+        None,
+        |secret| {
+            let recorder = recorder.clone();
+            async move {
+                recorder.record(&secret);
+                Err::<u32, _>(FakeProviderError::Unauthorized)
+            }
+        },
+        is_unauthorized,
+    )
+    .await;
+
+    assert!(matches!(result, Err(RefetchError::Doppler(_))));
+    // Op called exactly once (initial); refetch step never makes it back to op.
+    assert_eq!(recorder.count(), 1);
+    assert_eq!(runner.call_count(), 2, "refetch attempt does spawn doppler once");
+}
+
+#[tokio::test]
+async fn refetch_method_invalidates_cache_and_returns_fresh_value() {
+    let runner = MockRunner::new(vec![
+        Ok(ok_output("v1\n")),
+        Ok(ok_output("v2\n")),
+    ]);
+    let client =
+        DopplerClient::with_runner(Duration::from_secs(60), runner.clone() as Arc<dyn CommandRunner>);
+
+    let v1 = client.get("API_KEY", None).await.unwrap();
+    assert_eq!(v1.expose(), "v1");
+    assert_eq!(runner.call_count(), 1);
+
+    // Refetch should return v2 even though cache had v1.
+    let v2 = client.refetch("API_KEY", None).await.unwrap();
+    assert_eq!(v2.expose(), "v2");
+    assert_eq!(runner.call_count(), 2);
+
+    // Subsequent get must read v2 from cache.
+    let cached = client.get("API_KEY", None).await.unwrap();
+    assert_eq!(cached.expose(), "v2");
+    assert_eq!(runner.call_count(), 2, "cache hit, no respawn");
+}
+
+#[tokio::test]
+async fn refetch_path_in_helper_uses_fresh_secret() {
+    // Pre-populate the cache via a normal `get`. Then exercise the helper —
+    // the first op call should see the cached value, and after the 401 the
+    // second op call should see the freshly fetched value.
+    let runner = MockRunner::new(vec![
+        Ok(ok_output("cached\n")),
+        Ok(ok_output("post-401\n")),
+    ]);
+    let client =
+        DopplerClient::with_runner(Duration::from_secs(60), runner.clone() as Arc<dyn CommandRunner>);
+
+    // Warm the cache.
+    let warm = client.get("API_KEY", None).await.unwrap();
+    assert_eq!(warm.expose(), "cached");
+    assert_eq!(runner.call_count(), 1);
+
+    let recorder = OpRecorder::new();
+    let result: Result<u32, _> = with_refetch_on_unauthorized(
+        &client,
+        "API_KEY",
+        None,
+        |secret| {
+            let recorder = recorder.clone();
+            async move {
+                recorder.record(&secret);
+                if secret.expose() == "cached" {
+                    Err(FakeProviderError::Unauthorized)
+                } else {
+                    Ok(99)
+                }
+            }
+        },
+        is_unauthorized,
+    )
+    .await;
+
+    assert_eq!(result.unwrap(), 99);
+    assert_eq!(recorder.secrets(), vec!["cached", "post-401"]);
+    assert_eq!(runner.call_count(), 2, "1 warm + 1 refetch");
+}


### PR DESCRIPTION
## Summary

Implements [PDX-54](https://linear.app/pdx-software/issue/PDX-54/a46-401-triggered-re-fetch-logic) — when a downstream provider returns 401, invalidate the cached secret and refetch via Doppler before retrying.

- **Primitive** — `DopplerClient::refetch(name, cwd)`: drops the cache entry, re-`get`s from the CLI.
- **Higher-order helper** — `with_refetch_on_unauthorized(client, name, cwd, op, is_unauthorized)`: runs `op(secret)` once, and if it returns an error the caller classifies as unauthorized, invalidates and retries exactly once with the fresh secret. Single-retry budget — no infinite loops.
- `is_unauthorized` is a caller-supplied predicate (`Fn(&E) -> bool`) so no coupling between Doppler and the caller's HTTP error type.
- `RefetchError<E>` distinguishes Doppler-side from provider-side failures.
- Drive-by: `std::time::Instant` → `instant::Instant` in `lib.rs`; same `tests/status.rs` repair as PDX-51.

## Test plan

- [x] `cargo clippy -p doppler --tests -- -D warnings` clean
- [x] `cargo test -p doppler --test refetch` — 8 passing