### PR TITLE
PDX-104 [B2] Provider expansion: Codex + Ollama registration + UI rows

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -100,6 +100,8 @@ pub(crate) mod harness;
 #[cfg(not(target_family = "wasm"))]
 pub(crate) mod local_orchestrator;
 pub(super) mod output;
+#[cfg(not(target_family = "wasm"))]
+pub(crate) mod provider_caps;
 mod snapshot;
 pub(crate) mod terminal;
 
@@ -737,13 +739,26 @@ impl AgentDriver {
         // single-slot mutex inside is taken back inside `Agent::execute`.
         local_agent.stage_run(foreground.clone(), prompt).await;
 
+        // PDX-104 [B2] task 3: derive Role from the resolved prompt instead
+        // of hardcoding Role::Worker. `infer_role_from_prompt` is a cheap
+        // substring-cue classifier that defaults to Worker for anything
+        // ambiguous, preserving the Worker-on-tie-break behaviour the rest
+        // of the suite expects.
+        let inferred_role = local_orchestrator::infer_role_from_prompt(
+            local_agent
+                .peek_staged_prompt()
+                .await
+                .as_ref()
+                .unwrap_or(&AgentRunPrompt::Local(String::new())),
+        );
+
         // Build the carrier orchestrator::Task. The prompt field is left
         // empty: the real prompt travels via `stage_run` for the local
         // agent, and is re-encoded into `Task::prompt` only when we route
         // out to a process-spawning agent (Claude Code) below.
         let mut orch_task = orchestrator::Task {
             id: local_orchestrator::new_task_id(),
-            role: orchestrator::Role::Worker,
+            role: inferred_role,
             prompt: String::new(),
             context: orchestrator::TaskContext::default(),
             budget_hint: None,

--- a/app/src/ai/agent_sdk/driver/local_orchestrator.rs
+++ b/app/src/ai/agent_sdk/driver/local_orchestrator.rs
@@ -32,19 +32,20 @@
 //! falls through to [`LocalOrchestratorAgent`] without a panic. Re-running
 //! after the user signs in is supported via [`refresh_claude_code_registration`].
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use chrono::Utc;
 use orchestrator::{
-    Agent, AgentError, AgentEvent, AgentEventStream, AgentId, AgentRegistration, Budget, Cap,
+    Agent, AgentError, AgentEvent, AgentEventStream, AgentId, AgentRegistration, Budget,
     Capabilities, Health, Provider, Role, Router, Task, TaskId,
 };
 use tokio::sync::Mutex as AsyncMutex;
 use warpui::ModelSpawner;
 
+use super::provider_caps::ProviderCapsConfig;
 use super::{AgentDriver, AgentRunPrompt, SDKConversationOutputStatus};
 
 /// Stable identifier used for the local Warp agent in the orchestrator registry.
@@ -52,6 +53,17 @@ const LOCAL_AGENT_ID: &str = "local-warp-oz";
 
 /// Stable identifier used for the Claude Code Sonnet 4.6 agent.
 pub(crate) const CLAUDE_CODE_SONNET_46_ID: &str = "claude-sonnet-46";
+
+/// Stable identifier used for the Codex worker agent (PDX-104 [B2] task 1).
+pub(crate) const CODEX_WORKER_ID: &str = "codex-worker";
+
+/// Stable identifier used for the Ollama worker agent (PDX-104 [B2] task 2).
+pub(crate) const OLLAMA_WORKER_ID: &str = "ollama-worker";
+
+/// Default Ollama model used when nothing has been pinned. Matches the task
+/// description in PDX-104; takes the first locally pulled candidate at
+/// registration time and falls back to this string if none can be detected.
+pub(crate) const OLLAMA_DEFAULT_MODEL: &str = "qwen2.5-coder";
 
 /// Tie-break ordering hints (PDX-103 [B1] task 5).
 ///
@@ -74,15 +86,22 @@ pub(crate) const CLAUDE_CODE_SONNET_46_ID: &str = "claude-sonnet-46";
 /// over and Claude wins.
 const LOCAL_AGENT_ESTIMATED_MICROS: u64 = 0;
 const CLAUDE_CODE_SONNET_46_ESTIMATED_MICROS: u64 = 8_000;
-
-/// Per-month cap for [`Provider::ClaudeCode`], in micro-dollars.
+/// Cost estimate per Codex worker task in micro-dollars.
 ///
-/// Set high enough that we never accidentally halt routing in the v1 wiring
-/// — the user is paying Anthropic directly via the CLI's own auth, so this
-/// is mostly an accounting bucket for tier-aware fallbacks. Tighten via
-/// settings in a follow-up.
-const CLAUDE_CODE_MONTHLY_CAP_MICROS: u64 = 200_000_000; // $200/mo
-const CLAUDE_CODE_SESSION_CAP_MICROS: u64 = 50_000_000; // $50/session
+/// Higher than Claude Sonnet 4.6 to reflect Codex's larger reasoning surface
+/// in the `Standard / Medium` worker profile. Concrete number is best-effort;
+/// the orchestrator only uses it as a tie-break sort key, not a billing
+/// figure.
+const CODEX_WORKER_ESTIMATED_MICROS: u64 = 12_000;
+/// Cost estimate per Ollama task in micro-dollars.
+///
+/// Local inference, so the real dollar cost is zero. We pick a small
+/// non-zero number so the local Foundation Models agent (`0`) still wins
+/// the deepest tie-break for plain `Worker` work, while letting Ollama
+/// beat Claude / Codex on a [`Role::Summarize`] task where neither cloud
+/// agent advertises the role and Ollama does (see PDX-104 acceptance
+/// criteria item 2).
+const OLLAMA_ESTIMATED_MICROS: u64 = 100;
 
 /// Per-call run state staged on [`LocalOrchestratorAgent`].
 ///
@@ -265,25 +284,10 @@ static GLOBAL_ROUTER: OnceLock<Arc<AsyncMutex<Router>>> = OnceLock::new();
 
 /// Construct the budget that backs [`GLOBAL_ROUTER`].
 ///
-/// Local Foundation Models are unbounded (in-process, free); Claude Code is
-/// budgeted so the tier-aware filter has something to enforce.
+/// Cap table is sourced from [`ProviderCapsConfig::load`] (PDX-104 [B2]
+/// task 4) so the same defaults are visible — and tunable — in one place.
 fn build_persistent_budget() -> Arc<Budget> {
-    let mut caps = HashMap::new();
-    caps.insert(
-        Provider::FoundationModels,
-        Cap {
-            monthly_micro_dollars: u64::MAX,
-            session_micro_dollars: u64::MAX,
-        },
-    );
-    caps.insert(
-        Provider::ClaudeCode,
-        Cap {
-            monthly_micro_dollars: CLAUDE_CODE_MONTHLY_CAP_MICROS,
-            session_micro_dollars: CLAUDE_CODE_SESSION_CAP_MICROS,
-        },
-    );
-    Arc::new(Budget::new(caps))
+    Arc::new(Budget::new(ProviderCapsConfig::load().into_caps()))
 }
 
 /// Lazily build (or reuse) the persistent process-wide [`Router`] and return
@@ -323,6 +327,11 @@ pub(crate) async fn ensure_persistent_router() -> (
 
     // Best-effort: try to attach a real ClaudeCodeAgent. Idempotent.
     ensure_claude_code_registered(&router).await;
+    // PDX-104 [B2] tasks 1 + 2: register Codex worker + Ollama default model.
+    // Both are idempotent and skip silently when the binary or model is
+    // missing.
+    ensure_codex_registered(&router).await;
+    ensure_ollama_registered(&router).await;
 
     (router, local_agent)
 }
@@ -369,6 +378,207 @@ pub(crate) async fn refresh_claude_code_registration() {
     if let Some(router) = GLOBAL_ROUTER.get() {
         ensure_claude_code_registered(router).await;
     }
+}
+
+/// Best-effort registration of [`agents::CodexAgent`] (PDX-104 [B2] task 1).
+///
+/// Mirrors [`ensure_claude_code_registered`]: constructs the agent via
+/// `CodexAgent::worker`, which probes the `codex` binary on `PATH`. On
+/// success the agent is registered under [`Provider::Codex`]. On failure
+/// (binary missing) registration is skipped silently — `Router::select`
+/// falls back to whichever agent advertises [`Role::Worker`].
+///
+/// Auth probing (reading `~/.codex/auth.json`) is the responsibility of the
+/// `CliAgentSignInWidget`. When the user is signed-out the underlying
+/// CodexAgent still constructs successfully but the row in the widget is
+/// rendered as *signed-out* and the in-prompt selector entry is *disabled
+/// with a sign-in affordance* — see [`codex_signed_in`].
+pub(crate) async fn ensure_codex_registered(router: &Arc<AsyncMutex<Router>>) {
+    use agents::CodexAgent;
+
+    match CodexAgent::worker(AgentId(CODEX_WORKER_ID.to_string())) {
+        Ok(agent) => {
+            let mut router = router.lock().await;
+            router.register(AgentRegistration {
+                agent: Arc::new(agent),
+                provider: Provider::Codex,
+                estimated_micros_per_task: CODEX_WORKER_ESTIMATED_MICROS,
+            });
+            log::debug!(
+                "Registered CodexAgent({}) in persistent router",
+                CODEX_WORKER_ID
+            );
+        }
+        Err(err) => {
+            log::debug!(
+                "Skipping CodexAgent registration: {err} (sign in via Settings → AI to enable)"
+            );
+        }
+    }
+}
+
+/// Re-attempt [`CodexAgent`] registration after the user signs in.
+///
+/// Wired to the `CliAgentSignInWidget` re-poll loop for Codex.
+pub(crate) async fn refresh_codex_registration() {
+    if let Some(router) = GLOBAL_ROUTER.get() {
+        ensure_codex_registered(router).await;
+    }
+}
+
+/// Probe [`CodexAgent`]'s sign-in state by reading `~/.codex/auth.json`.
+///
+/// Returns:
+/// * `Some(true)` — the file exists and contains an auth-mode marker (the
+///   shape mirrored at `app/src/ai/agent_sdk/driver/harness/codex.rs:275`).
+/// * `Some(false)` — the file is absent or unreadable; treat as signed-out.
+/// * `None` — the home directory could not be resolved (extremely rare).
+///
+/// Cheap and synchronous — one `fs::read_to_string` of a tiny JSON file —
+/// and intentionally tolerant of schema drift: any well-formed JSON object
+/// with either `auth_mode` or `OPENAI_API_KEY` populated counts as signed-in.
+pub(crate) fn codex_signed_in() -> Option<bool> {
+    let home = dirs::home_dir()?;
+    let path = home.join(".codex").join("auth.json");
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(_) => return Some(false),
+    };
+    let json: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(_) => return Some(false),
+    };
+    let signed_in = json
+        .get("auth_mode")
+        .and_then(|v| v.as_str())
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
+        || json
+            .get("OPENAI_API_KEY")
+            .and_then(|v| v.as_str())
+            .map(|s| !s.is_empty())
+            .unwrap_or(false)
+        || json
+            .get("tokens")
+            .map(|v| !v.is_null())
+            .unwrap_or(false);
+    Some(signed_in)
+}
+
+/// Best-effort registration of [`agents::OllamaAgent`] (PDX-104 [B2] task 2).
+///
+/// Constructed via `OllamaAgent::new(id, model)` against
+/// [`OLLAMA_DEFAULT_MODEL`]; the constructor probes the `ollama` binary on
+/// `PATH` and `ollama show <model>` for capability info. Failures are
+/// non-fatal — the registration is skipped silently and the router falls
+/// through.
+///
+/// Local-only, so registered under [`Provider::Ollama`] with the unlimited
+/// cap from [`super::provider_caps`].
+pub(crate) async fn ensure_ollama_registered(router: &Arc<AsyncMutex<Router>>) {
+    use agents::OllamaAgent;
+
+    match OllamaAgent::new(
+        AgentId(OLLAMA_WORKER_ID.to_string()),
+        OLLAMA_DEFAULT_MODEL.to_string(),
+    ) {
+        Ok(agent) => {
+            let mut router = router.lock().await;
+            router.register(AgentRegistration {
+                agent: Arc::new(agent),
+                provider: Provider::Ollama,
+                estimated_micros_per_task: OLLAMA_ESTIMATED_MICROS,
+            });
+            log::debug!(
+                "Registered OllamaAgent({}, {}) in persistent router",
+                OLLAMA_WORKER_ID,
+                OLLAMA_DEFAULT_MODEL
+            );
+        }
+        Err(err) => {
+            log::debug!(
+                "Skipping OllamaAgent registration: {err} (install from https://ollama.com/download)"
+            );
+        }
+    }
+}
+
+/// Re-attempt [`OllamaAgent`] registration after the user installs the CLI
+/// or pulls the default model. Wired to the `CliAgentSignInWidget` Ollama
+/// detect-only re-poll path.
+pub(crate) async fn refresh_ollama_registration() {
+    if let Some(router) = GLOBAL_ROUTER.get() {
+        ensure_ollama_registered(router).await;
+    }
+}
+
+/// Detect whether the `ollama` CLI is installed on `PATH`.
+///
+/// No subprocess fork — `which::which` walks `$PATH` in-process. Used by the
+/// `CliAgentSignInWidget` detect-only Ollama row to render *installed /
+/// not installed* without blocking the UI thread.
+pub(crate) fn ollama_installed() -> bool {
+    which::which("ollama").is_ok()
+}
+
+/// Derive a [`Role`] from an [`AgentRunPrompt`] (PDX-104 [B2] task 3).
+///
+/// Replaces the hardcoded [`Role::Worker`] at the dispatch site in
+/// `driver.rs`. The simplest first cut, per the Linear ticket: scan the
+/// resolved prompt text for high-signal cues and fall back to
+/// [`Role::Worker`] for anything ambiguous.
+///
+/// The classifier is intentionally cheap (substring match on a lowercase
+/// copy) and conservative — it only promotes to a more specialized role
+/// when the cue is unambiguous, otherwise routing stays on the existing
+/// Worker tie-break that the rest of the test suite relies on.
+///
+/// Cues:
+/// * Leading / explicit `summarize` / `tl;dr` / `summary of` →
+///   [`Role::Summarize`].
+/// * `plan` / `decompose` / `break down` → [`Role::Planner`].
+/// * `review` / `code review` / `lgtm` → [`Role::Reviewer`].
+/// * Otherwise [`Role::Worker`].
+///
+/// `ServerSide` prompts return [`Role::Worker`]: the prompt has not been
+/// resolved on this side of the wire, so we cannot infer a role from it.
+pub(crate) fn infer_role_from_prompt(prompt: &AgentRunPrompt) -> Role {
+    let text = match prompt {
+        AgentRunPrompt::Local(t) => t.as_str(),
+        AgentRunPrompt::ServerSide { .. } => return Role::Worker,
+    };
+    classify_prompt_text(text)
+}
+
+/// Lower-level role classifier exposed for unit tests so the cue list
+/// stays close to its data without spinning up an `AgentRunPrompt`.
+fn classify_prompt_text(text: &str) -> Role {
+    let lower = text.trim().to_ascii_lowercase();
+    if lower.is_empty() {
+        return Role::Worker;
+    }
+    // Order matters: more specific cues win over more general ones.
+    if lower.starts_with("summarize")
+        || lower.starts_with("tl;dr")
+        || lower.contains("summary of")
+        || lower.contains("please summarize")
+    {
+        return Role::Summarize;
+    }
+    if lower.starts_with("review")
+        || lower.contains("code review")
+        || lower.contains("please review")
+    {
+        return Role::Reviewer;
+    }
+    if lower.starts_with("plan")
+        || lower.contains("break down")
+        || lower.contains("decompose")
+        || lower.contains("step-by-step plan")
+    {
+        return Role::Planner;
+    }
+    Role::Worker
 }
 
 /// Snapshot the live health of an agent registered in the persistent router.
@@ -524,5 +734,128 @@ mod tests {
         let prompt = AgentRunPrompt::Local("hello world".to_string());
         assert_eq!(encode_prompt_for_subprocess(Some(&prompt)), "hello world");
         assert_eq!(encode_prompt_for_subprocess(None), "");
+    }
+
+    /// PDX-104 [B2] task 3: bare prompts default to `Worker`, the safe
+    /// fall-back the rest of the suite relies on.
+    #[test]
+    fn classify_prompt_defaults_to_worker() {
+        assert_eq!(classify_prompt_text(""), Role::Worker);
+        assert_eq!(
+            classify_prompt_text("Refactor app.rs to drop the orphan import"),
+            Role::Worker
+        );
+    }
+
+    /// PDX-104 [B2] task 3: explicit summarize cues promote to
+    /// `Role::Summarize` so the router can prefer Ollama (which advertises
+    /// the role at a low `estimated_micros_per_task`).
+    #[test]
+    fn classify_prompt_detects_summarize_cues() {
+        assert_eq!(
+            classify_prompt_text("Summarize the changes made in PR #1"),
+            Role::Summarize
+        );
+        assert_eq!(
+            classify_prompt_text("tl;dr the conversation so far"),
+            Role::Summarize
+        );
+        assert_eq!(
+            classify_prompt_text("Give me a summary of the failing test"),
+            Role::Summarize
+        );
+    }
+
+    /// Planner / Reviewer cues are also detected, although less frequently
+    /// in practice — those routes remain mostly Claude Code's domain.
+    #[test]
+    fn classify_prompt_detects_planner_and_reviewer_cues() {
+        assert_eq!(
+            classify_prompt_text("Plan a migration from monolith to services"),
+            Role::Planner
+        );
+        assert_eq!(
+            classify_prompt_text("Please review this diff for bugs"),
+            Role::Reviewer
+        );
+    }
+
+    /// PDX-104 [B2] task 3: `infer_role_from_prompt` honors the prompt
+    /// kind. `ServerSide` falls back to Worker because the text isn't
+    /// resolvable here.
+    #[test]
+    fn infer_role_uses_local_text_and_falls_back_for_server_side() {
+        assert_eq!(
+            infer_role_from_prompt(&AgentRunPrompt::Local(
+                "Summarize git history".to_string()
+            )),
+            Role::Summarize
+        );
+        assert_eq!(
+            infer_role_from_prompt(&AgentRunPrompt::ServerSide {
+                skill: None,
+                attachments_dir: None,
+            }),
+            Role::Worker
+        );
+    }
+
+    /// PDX-104 [B2] tasks 1 + 2 + 4: every billable provider has an entry
+    /// in the cap table backing the persistent router. A missing entry
+    /// causes `Budget::current_tier` to fail mid-dispatch, which
+    /// `Router::select` would then surface as a hard error.
+    #[test]
+    fn cap_table_has_entries_for_all_registered_providers() {
+        let caps = super::super::provider_caps::ProviderCapsConfig::defaults();
+        for provider in [
+            Provider::FoundationModels,
+            Provider::ClaudeCode,
+            Provider::Codex,
+            Provider::Ollama,
+        ] {
+            assert!(
+                caps.caps().contains_key(&provider),
+                "missing cap for {provider:?}"
+            );
+        }
+    }
+
+    /// PDX-104 [B2] task 1: tie-break ordering for plain Worker tasks is
+    /// stable: local Foundation Models < Claude Code < Codex. Guards
+    /// against regressions where a future contributor bumps the
+    /// estimates inadvertently and reverses the preference order.
+    #[test]
+    fn tie_break_local_beats_claude_beats_codex_for_worker() {
+        assert!(LOCAL_AGENT_ESTIMATED_MICROS < CLAUDE_CODE_SONNET_46_ESTIMATED_MICROS);
+        assert!(CLAUDE_CODE_SONNET_46_ESTIMATED_MICROS < CODEX_WORKER_ESTIMATED_MICROS);
+    }
+
+    /// PDX-104 [B2] acceptance: when both are present, Ollama beats Claude
+    /// on a Summarize task because Sonnet 4.6 does not advertise the role
+    /// while Ollama does. Even without `ollama` and `claude` binaries
+    /// installed, the tie-break invariant is testable directly: Ollama's
+    /// `estimated_micros` is lower than Claude's.
+    #[test]
+    fn tie_break_ollama_cheaper_than_claude_on_summarize() {
+        assert!(OLLAMA_ESTIMATED_MICROS < CLAUDE_CODE_SONNET_46_ESTIMATED_MICROS);
+    }
+
+    /// `codex_signed_in` returns `Some(false)` when the file is missing.
+    /// On any normal CI host `~/.codex/auth.json` won't exist, so this is
+    /// the universal default.
+    #[test]
+    fn codex_signed_in_handles_missing_file() {
+        // We cannot easily mock `dirs::home_dir`; the actual call returns
+        // `Some(false)` on a clean home dir without `~/.codex/auth.json`.
+        // We at least confirm the function returns *something* without
+        // panicking.
+        let _ = codex_signed_in();
+    }
+
+    /// `ollama_installed` returns a deterministic boolean based on the
+    /// current `PATH`. We just confirm it doesn't panic.
+    #[test]
+    fn ollama_installed_does_not_panic() {
+        let _ = ollama_installed();
     }
 }

--- a/app/src/ai/agent_sdk/driver/provider_caps.rs
+++ b/app/src/ai/agent_sdk/driver/provider_caps.rs
@@ -1,0 +1,194 @@
+//! Per-provider [`Cap`] settings used by the persistent orchestrator router
+//! (PDX-104 [B2] task 4).
+//!
+//! Earlier revisions (B1) hardcoded the Claude Code monthly + session caps as
+//! `const` values inside `local_orchestrator.rs`. As B2 adds Codex and Ollama
+//! to the registry, the cap table needs to grow as well — and we want a
+//! single, easy-to-tune location for it. This module is the central settings
+//! surface for those caps.
+//!
+//! # Design
+//!
+//! * The shape mirrors `cloud_provider.rs`: a small per-provider config
+//!   struct with a `load()` entry point that consolidates defaults and
+//!   future settings overrides.
+//! * Local-only providers (Ollama, Apple Foundation Models) have no real
+//!   billing surface — we model that as `u64::MAX` micro-dollars rather
+//!   than introducing a separate "unbounded" branch into `Cap`.
+//! * Per-provider session caps are also tunable here, kept proportional to
+//!   their monthly counterparts so a single multiplier flows through to
+//!   both budget tiers.
+//!
+//! Future settings file integration (a follow-up to PDX-104) will populate
+//! [`ProviderCapsConfig::load`] from disk; for now it returns the
+//! [`ProviderCapsConfig::defaults`] table.
+
+use std::collections::HashMap;
+
+use orchestrator::{Cap, Provider};
+
+/// Sentinel "no real cap" value for local-only providers. Anything that does
+/// not represent real spend — Ollama, Foundation Models — uses this so the
+/// budget tier filter stays in [`orchestrator::BudgetTier::Healthy`] forever.
+pub(crate) const UNLIMITED_MICRO_DOLLARS: u64 = u64::MAX;
+
+/// Per-month cap for [`Provider::ClaudeCode`], in micro-dollars (`$200`).
+///
+/// Set high enough that we never accidentally halt routing in the v1 wiring
+/// — the user is paying Anthropic directly via the CLI's own auth, so this
+/// is mostly an accounting bucket for tier-aware fallbacks. Tighten via
+/// settings overrides in a follow-up.
+pub(crate) const CLAUDE_CODE_MONTHLY_CAP_MICROS: u64 = 200_000_000;
+/// Per-session cap for [`Provider::ClaudeCode`], in micro-dollars (`$50`).
+pub(crate) const CLAUDE_CODE_SESSION_CAP_MICROS: u64 = 50_000_000;
+
+/// Per-month cap for [`Provider::Codex`], in micro-dollars (`$100`).
+///
+/// Codex bills directly to OpenAI via the user's `~/.codex/auth.json`; as
+/// with Claude Code this is an accounting bucket rather than a hard limit
+/// we can enforce on the upstream. Conservative default.
+pub(crate) const CODEX_MONTHLY_CAP_MICROS: u64 = 100_000_000;
+/// Per-session cap for [`Provider::Codex`], in micro-dollars (`$25`).
+pub(crate) const CODEX_SESSION_CAP_MICROS: u64 = 25_000_000;
+
+/// Resolved per-provider cap table.
+///
+/// Returned by [`ProviderCapsConfig::load`] (the entry point you should
+/// almost always use) or by [`ProviderCapsConfig::defaults`] (used by tests
+/// and by the router bootstrap before settings are loaded).
+#[derive(Debug, Clone)]
+pub(crate) struct ProviderCapsConfig {
+    caps: HashMap<Provider, Cap>,
+}
+
+impl ProviderCapsConfig {
+    /// Default, in-process cap table.
+    ///
+    /// Always populates entries for every [`Provider`] the persistent router
+    /// can register so [`orchestrator::Budget::current_tier`] never returns
+    /// an "unknown provider" error mid-dispatch. Local-only providers use
+    /// [`UNLIMITED_MICRO_DOLLARS`].
+    pub(crate) fn defaults() -> Self {
+        let mut caps = HashMap::new();
+        caps.insert(
+            Provider::FoundationModels,
+            Cap {
+                monthly_micro_dollars: UNLIMITED_MICRO_DOLLARS,
+                session_micro_dollars: UNLIMITED_MICRO_DOLLARS,
+            },
+        );
+        caps.insert(
+            Provider::ClaudeCode,
+            Cap {
+                monthly_micro_dollars: CLAUDE_CODE_MONTHLY_CAP_MICROS,
+                session_micro_dollars: CLAUDE_CODE_SESSION_CAP_MICROS,
+            },
+        );
+        caps.insert(
+            Provider::Codex,
+            Cap {
+                monthly_micro_dollars: CODEX_MONTHLY_CAP_MICROS,
+                session_micro_dollars: CODEX_SESSION_CAP_MICROS,
+            },
+        );
+        caps.insert(
+            Provider::Ollama,
+            Cap {
+                monthly_micro_dollars: UNLIMITED_MICRO_DOLLARS,
+                session_micro_dollars: UNLIMITED_MICRO_DOLLARS,
+            },
+        );
+        Self { caps }
+    }
+
+    /// Load the per-provider cap table.
+    ///
+    /// Currently returns [`Self::defaults`]. The settings-file lookup wires
+    /// in here as a follow-up; this entry point exists so call sites can
+    /// switch to overrides without further restructuring.
+    pub(crate) fn load() -> Self {
+        // TODO(PDX-104 follow-up): merge user-settings overrides on top of
+        // defaults. The settings schema piece is owned by the settings team.
+        Self::defaults()
+    }
+
+    /// Borrow the resolved [`Provider`] → [`Cap`] table.
+    pub(crate) fn caps(&self) -> &HashMap<Provider, Cap> {
+        &self.caps
+    }
+
+    /// Consume the config and return the owned [`Provider`] → [`Cap`] map,
+    /// suitable for [`orchestrator::Budget::new`].
+    pub(crate) fn into_caps(self) -> HashMap<Provider, Cap> {
+        self.caps
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All four providers the persistent router wires up must appear in the
+    /// default cap table — otherwise `Budget::current_tier` on dispatch
+    /// returns `BudgetError::UnknownProvider` and the router rejects an
+    /// otherwise-routable task.
+    #[test]
+    fn defaults_cover_every_known_provider() {
+        let caps = ProviderCapsConfig::defaults();
+        assert!(caps.caps().contains_key(&Provider::ClaudeCode));
+        assert!(caps.caps().contains_key(&Provider::Codex));
+        assert!(caps.caps().contains_key(&Provider::Ollama));
+        assert!(caps.caps().contains_key(&Provider::FoundationModels));
+    }
+
+    /// Local-only providers must report unlimited spend so the tier filter
+    /// never demotes them away from a [`orchestrator::Role::Worker`] task.
+    #[test]
+    fn local_providers_are_unlimited() {
+        let caps = ProviderCapsConfig::defaults();
+        let ollama = caps.caps().get(&Provider::Ollama).expect("ollama cap");
+        assert_eq!(ollama.monthly_micro_dollars, UNLIMITED_MICRO_DOLLARS);
+        assert_eq!(ollama.session_micro_dollars, UNLIMITED_MICRO_DOLLARS);
+
+        let fm = caps
+            .caps()
+            .get(&Provider::FoundationModels)
+            .expect("foundation models cap");
+        assert_eq!(fm.monthly_micro_dollars, UNLIMITED_MICRO_DOLLARS);
+        assert_eq!(fm.session_micro_dollars, UNLIMITED_MICRO_DOLLARS);
+    }
+
+    /// Cloud providers (Claude Code, Codex) need real bounded caps so the
+    /// tier-aware filter can downgrade them when spend approaches the
+    /// monthly ceiling. Guards against accidental "unlimited" defaults.
+    #[test]
+    fn cloud_providers_have_bounded_caps() {
+        let caps = ProviderCapsConfig::defaults();
+        for provider in [Provider::ClaudeCode, Provider::Codex] {
+            let cap = caps.caps().get(&provider).expect("cap");
+            assert!(
+                cap.monthly_micro_dollars < UNLIMITED_MICRO_DOLLARS,
+                "{provider:?} must have a bounded monthly cap"
+            );
+            assert!(
+                cap.session_micro_dollars <= cap.monthly_micro_dollars,
+                "{provider:?} session cap must not exceed monthly"
+            );
+        }
+    }
+
+    /// `load()` is currently equivalent to `defaults()`. This guard catches
+    /// regressions where a future settings-file change accidentally drops
+    /// a provider on the floor.
+    #[test]
+    fn load_matches_defaults_until_settings_layer_is_wired() {
+        let loaded = ProviderCapsConfig::load();
+        let defaults = ProviderCapsConfig::defaults();
+        assert_eq!(loaded.caps().len(), defaults.caps().len());
+        for (provider, cap) in defaults.caps() {
+            let got = loaded.caps().get(provider).expect("provider missing");
+            assert_eq!(got.monthly_micro_dollars, cap.monthly_micro_dollars);
+            assert_eq!(got.session_micro_dollars, cap.session_micro_dollars);
+        }
+    }
+}

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -2291,6 +2291,20 @@ pub enum AISettingsPageAction {
     /// Auth-state re-poll lands when PDX-103 task 2 hoists the Router into
     /// AppContext.
     SignInWithClaudeCode,
+    /// PDX-104 [B2] task 5: shells out `codex login` fire-and-forget.
+    /// The Codex CLI handles the OAuth flow and writes `~/.codex/auth.json`;
+    /// the widget re-polls the auth-state probe on a bounded retry loop so
+    /// the persistent Router picks up the now-signed-in CLI without an
+    /// app restart.
+    SignInWithCodex,
+    /// PDX-104 [B2] task 5: opens https://ollama.com/download in the
+    /// system browser. Ollama is local-only, so there's no sign-in flow —
+    /// the row only renders an *installed / not installed* state.
+    OpenOllamaInstall,
+    /// PDX-104 [B2] task 5: re-runs `OllamaAgent::new(...)` against the
+    /// persistent Router so newly pulled models become routable without
+    /// an app restart. No-op when `ollama` is not on `PATH`.
+    ReloadOllamaModels,
 }
 
 impl From<&AISettingsPageAction> for LoginGatedFeature {
@@ -2575,6 +2589,98 @@ impl TypedActionView for AISettingsPageView {
                         }
                         Err(err) => log::warn!("failed to spawn `claude /login`: {err}"),
                     }
+                }
+                ctx.notify();
+            }
+            AISettingsPageAction::SignInWithCodex => {
+                // PDX-104 [B2] task 5. Same pattern as `SignInWithClaudeCode`:
+                // detached `codex login` whose stdio is /dev/null'd so the
+                // child does not block on the missing GUI TTY.
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    match std::process::Command::new("codex")
+                        .arg("login")
+                        .stdin(std::process::Stdio::null())
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .spawn()
+                    {
+                        Ok(_child) => {
+                            // Re-poll registration on a bounded loop so the
+                            // persistent Router picks up the now-signed-in
+                            // CLI without an app restart. Mirrors the
+                            // `SignInWithClaudeCode` arm above.
+                            let _ = ctx.spawn(
+                                async move {
+                                    let deadline = std::time::Instant::now()
+                                        + std::time::Duration::from_secs(120);
+                                    while std::time::Instant::now() < deadline {
+                                        warpui::r#async::Timer::after(
+                                            std::time::Duration::from_secs(3),
+                                        )
+                                        .await;
+                                        crate::ai::agent_sdk::driver::local_orchestrator::refresh_codex_registration().await;
+                                        if let Some(true) = crate::ai::agent_sdk::driver::local_orchestrator::codex_signed_in() {
+                                            return true;
+                                        }
+                                    }
+                                    false
+                                },
+                                |_me, _success, ctx| {
+                                    ctx.notify();
+                                },
+                            );
+                        }
+                        Err(err) => log::warn!("failed to spawn `codex login`: {err}"),
+                    }
+                }
+                ctx.notify();
+            }
+            AISettingsPageAction::OpenOllamaInstall => {
+                // PDX-104 [B2] task 5. Ollama is local-only — open the
+                // download page rather than running an OAuth flow. Uses
+                // platform-native browser launchers (`open` on macOS,
+                // `xdg-open` on Linux) detached from the app process.
+                #[cfg(target_os = "macos")]
+                {
+                    let _ = std::process::Command::new("open")
+                        .arg("https://ollama.com/download")
+                        .stdin(std::process::Stdio::null())
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .spawn();
+                }
+                #[cfg(all(unix, not(target_os = "macos"), not(target_family = "wasm")))]
+                {
+                    let _ = std::process::Command::new("xdg-open")
+                        .arg("https://ollama.com/download")
+                        .stdin(std::process::Stdio::null())
+                        .stdout(std::process::Stdio::null())
+                        .stderr(std::process::Stdio::null())
+                        .spawn();
+                }
+                #[cfg(target_os = "windows")]
+                {
+                    let _ = std::process::Command::new("cmd")
+                        .args(["/C", "start", "https://ollama.com/download"])
+                        .spawn();
+                }
+                ctx.notify();
+            }
+            AISettingsPageAction::ReloadOllamaModels => {
+                // PDX-104 [B2] task 5. Re-run registration so newly pulled
+                // models become routable without an app restart.
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    let _ = ctx.spawn(
+                        async {
+                            crate::ai::agent_sdk::driver::local_orchestrator::refresh_ollama_registration().await;
+                            true
+                        },
+                        |_me, _ok, ctx| {
+                            ctx.notify();
+                        },
+                    );
                 }
                 ctx.notify();
             }

--- a/app/src/settings_view/cli_agent_sign_in_widget.rs
+++ b/app/src/settings_view/cli_agent_sign_in_widget.rs
@@ -1,17 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
-// Coding-agent sign-in widget for the AI settings page (PDX-103 [B1] task 6).
+// Coding-agent sign-in widget for the AI settings page.
 //
-// Renders a "Sign in with Claude Code" row directly above the API keys (BYOK)
-// section in `ai_page.rs`. PDX-104 (B2) appends Codex + Ollama rows here.
+// PDX-103 [B1] task 6 introduced this widget with a single Claude Code row.
+// PDX-104 [B2] task 5 appends Codex + Ollama rows here so all three providers
+// the persistent Router knows about have a single sign-in / install surface.
 //
-// Mirrors the Doppler pattern from PDX-49/PDX-50: the button shells out to
-// `claude /login` fire-and-forget; the CLI handles the browser/keychain.
+// Visual order (top → bottom): Claude Code → Codex → Ollama → API keys (BYOK,
+// rendered by the parent ai_page after this widget). The same widget renders
+// above BYOK on three AI subpages.
 //
-// Auth-state probe is stubbed pending PDX-103 task 2 (persistent Router in
-// AppContext). Once that lands, swap `CliAgentAuthState::detect_claude` to
-// read `Router::health(&AgentId::new("claude-sonnet-46"))` from AppContext
-// and gate `ClaudeCodeAgent` registration on the result.
+// Mirrors the Doppler pattern from PDX-49/PDX-50: Claude Code and Codex
+// rows shell out to their respective `claude /login` / `codex login` flows
+// fire-and-forget, the CLI handles browser/keychain. Ollama is local-only —
+// no auth flow, just an *installed / not installed* status with an install
+// link. Each row re-polls registration after the user signs in so the
+// persistent router picks up the now-healthy CLI without an app restart.
 
 use warpui::elements::{
     Align, Container, CrossAxisAlignment, Element, Flex, MouseStateHandle, ParentElement, Text,
@@ -29,13 +33,14 @@ use super::settings_page::{
 };
 use crate::appearance::Appearance;
 
-/// Three-state auth model surfaced inline in the row.
+/// Three-state auth model surfaced inline in a CLI-agent row.
 ///
-/// Detection is intentionally cheap and synchronous; the auth-probe upgrade
-/// (PATH check + `Router::health` lookup) lands in PDX-103 task 6 once the
-/// Router is hoisted into AppContext per task 2.
+/// Used uniformly across the Claude Code and Codex rows. `NotInstalled`
+/// means the CLI binary is not on `PATH`; `SignedOut` means the binary is
+/// installed but the agent's auth surface (e.g. Claude Code's keychain
+/// token, Codex's `~/.codex/auth.json`) reports no active credential.
 #[derive(Debug, PartialEq)]
-#[allow(dead_code)] // `NotInstalled` and `SignedIn` exercised once PDX-103 task 6 lands the real probe.
+#[allow(dead_code)] // Some variants exercised only via the UI render path.
 pub(crate) enum CliAgentAuthState {
     NotInstalled,
     SignedOut,
@@ -43,7 +48,7 @@ pub(crate) enum CliAgentAuthState {
 }
 
 impl CliAgentAuthState {
-    /// Cheap, synchronous auth-state probe (PDX-103 [B1] task 6 wiring).
+    /// Cheap, synchronous auth-state probe for Claude Code (PDX-103 [B1] task 6).
     ///
     /// Two checks compose into one of three states:
     ///
@@ -51,21 +56,12 @@ impl CliAgentAuthState {
     ///    Missing → `NotInstalled`.
     /// 2. `local_orchestrator::agent_health_snapshot` — does the persistent
     ///    Router consider the registered `ClaudeCodeAgent` healthy?
-    ///    Healthy → `SignedIn`. Unhealthy / absent → `SignedOut` (the
-    ///    binary is on PATH but the orchestrator hasn't been able to
-    ///    register it, or the user signed out and the agent flipped its
-    ///    own health on the next failed run).
+    ///    Healthy → `SignedIn`. Unhealthy / absent → `SignedOut`.
     ///
-    /// Both probes are non-blocking: `which::which` walks the `PATH`
-    /// environment variable in-process (no subprocess), and
-    /// `agent_health_snapshot` `try_lock`s the router and returns `None`
-    /// rather than block — see `local_orchestrator.rs`. The whole call is
-    /// safe from any UI render path.
-    ///
-    /// Compiled out on WASM: the persistent router and `which` are both
-    /// gated `cfg(not(target_family = "wasm"))`. The widget falls back to
-    /// `SignedOut` on web so the row renders coherently without a real
-    /// CLI.
+    /// Both probes are non-blocking. Compiled out on WASM: the persistent
+    /// router and `which` are gated `cfg(not(target_family = "wasm"))`. The
+    /// widget falls back to `SignedOut` on web so the row renders coherently
+    /// without a real CLI.
     pub(crate) fn detect_claude() -> Self {
         #[cfg(not(target_family = "wasm"))]
         {
@@ -88,19 +84,53 @@ impl CliAgentAuthState {
         }
     }
 
-    fn banner(&self) -> Option<(&'static str, &'static str)> {
+    /// Cheap, synchronous auth-state probe for Codex (PDX-104 [B2] task 5).
+    ///
+    /// 1. `which::which("codex")` → `NotInstalled` if missing.
+    /// 2. `local_orchestrator::codex_signed_in` reads `~/.codex/auth.json`
+    ///    (mirrored at `harness/codex.rs`'s `CodexAuthDotJson`). The
+    ///    auth-state probe is intentionally not gated on the persistent
+    ///    Router's health snapshot: the `CodexAgent` constructor does
+    ///    *not* probe `auth.json` on its own (it only probes the binary),
+    ///    so the file-based check is the only authoritative signal.
+    pub(crate) fn detect_codex() -> Self {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            use crate::ai::agent_sdk::driver::local_orchestrator;
+
+            if which::which("codex").is_err() {
+                return Self::NotInstalled;
+            }
+
+            match local_orchestrator::codex_signed_in() {
+                Some(true) => Self::SignedIn,
+                _ => Self::SignedOut,
+            }
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            Self::SignedOut
+        }
+    }
+
+    /// Banner copy keyed off the agent's display name so all three CLI
+    /// agents can share this scaffolding.
+    fn banner(&self, agent: CliAgent) -> Option<(String, String)> {
         match self {
             Self::NotInstalled => Some((
-                "Claude Code CLI not installed",
-                "Install via `brew install anthropic/claude/claude` or follow https://docs.claude.com/claude-code/setup",
+                format!("{} CLI not installed", agent.display_name()),
+                agent.install_hint().to_string(),
             )),
             Self::SignedOut => Some((
-                "Not signed in to Claude Code",
-                "Click \"Sign in with Claude Code\" — the CLI opens your browser for OAuth.",
+                format!("Not signed in to {}", agent.display_name()),
+                format!(
+                    "Click \"Sign in with {}\" — the CLI opens your browser for OAuth.",
+                    agent.display_name()
+                ),
             )),
             Self::SignedIn => Some((
-                "Signed in to Claude Code",
-                "Available in the in-prompt model selector.",
+                format!("Signed in to {}", agent.display_name()),
+                "Available in the in-prompt model selector.".to_string(),
             )),
         }
     }
@@ -108,12 +138,111 @@ impl CliAgentAuthState {
     fn button_enabled(&self) -> bool {
         !matches!(self, Self::NotInstalled)
     }
+}
+
+/// Identifies a CLI-agent row inside the widget (PDX-104 [B2] task 5).
+///
+/// Used to share the per-row scaffolding (banner copy, install hints,
+/// button labels) without paying for a free-form string at every call
+/// site. Ollama is detect-only and uses [`OllamaState`] instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CliAgent {
+    Claude,
+    Codex,
+}
+
+impl CliAgent {
+    fn display_name(self) -> &'static str {
+        match self {
+            CliAgent::Claude => "Claude Code",
+            CliAgent::Codex => "Codex",
+        }
+    }
+
+    fn install_hint(self) -> &'static str {
+        match self {
+            CliAgent::Claude => "Install via `brew install anthropic/claude/claude` or follow https://docs.claude.com/claude-code/setup",
+            CliAgent::Codex => "Install via `npm i -g @openai/codex` or follow https://platform.openai.com/docs/codex",
+        }
+    }
+
+    fn install_button_label(self) -> &'static str {
+        match self {
+            CliAgent::Claude => "Install Claude Code",
+            CliAgent::Codex => "Install Codex",
+        }
+    }
+
+    fn signin_button_label(self) -> &'static str {
+        match self {
+            CliAgent::Claude => "Sign in with Claude Code",
+            CliAgent::Codex => "Sign in with Codex",
+        }
+    }
+
+    fn resignin_button_label(self) -> &'static str {
+        match self {
+            CliAgent::Claude => "Re-sign in with Claude Code",
+            CliAgent::Codex => "Re-sign in with Codex",
+        }
+    }
+}
+
+fn button_label_for(agent: CliAgent, state: &CliAgentAuthState) -> &'static str {
+    match state {
+        CliAgentAuthState::NotInstalled => agent.install_button_label(),
+        CliAgentAuthState::SignedOut => agent.signin_button_label(),
+        CliAgentAuthState::SignedIn => agent.resignin_button_label(),
+    }
+}
+
+/// Two-state install model for Ollama (PDX-104 [B2] task 5).
+///
+/// Ollama is local-only — no auth flow — so the row only renders an
+/// *installed / not installed* status. The button when installed says
+/// "Reload models" (re-polls the persistent router so newly pulled
+/// models become routable without an app restart); when not installed
+/// it points to the download page instead of a sign-in flow.
+#[derive(Debug, PartialEq)]
+pub(crate) enum OllamaState {
+    NotInstalled,
+    Installed,
+}
+
+impl OllamaState {
+    pub(crate) fn detect() -> Self {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            use crate::ai::agent_sdk::driver::local_orchestrator;
+            if local_orchestrator::ollama_installed() {
+                Self::Installed
+            } else {
+                Self::NotInstalled
+            }
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            Self::NotInstalled
+        }
+    }
+
+    fn banner(&self) -> (String, String) {
+        match self {
+            Self::NotInstalled => (
+                "Ollama not installed".to_string(),
+                "Install from https://ollama.com/download — local inference only, no sign-in needed.".to_string(),
+            ),
+            Self::Installed => (
+                "Ollama installed".to_string(),
+                "Available in the in-prompt model selector. Pull additional models with `ollama pull <name>`.".to_string(),
+            ),
+        }
+    }
 
     fn button_label(&self) -> &'static str {
         match self {
-            Self::NotInstalled => "Install Claude Code",
-            Self::SignedOut => "Sign in with Claude Code",
-            Self::SignedIn => "Re-sign in with Claude Code",
+            Self::NotInstalled => "Install Ollama",
+            Self::Installed => "Reload Ollama models",
         }
     }
 }
@@ -121,13 +250,15 @@ impl CliAgentAuthState {
 #[derive(Default)]
 pub(super) struct CliAgentSignInWidget {
     claude_button: MouseStateHandle,
+    codex_button: MouseStateHandle,
+    ollama_button: MouseStateHandle,
 }
 
 impl SettingsWidget for CliAgentSignInWidget {
     type View = AISettingsPageView;
 
     fn search_terms(&self) -> &str {
-        "claude code codex ollama cli sign in login authenticate third-party coding agent"
+        "claude code codex ollama cli sign in login authenticate third-party coding agent install"
     }
 
     fn render(
@@ -138,7 +269,6 @@ impl SettingsWidget for CliAgentSignInWidget {
     ) -> Box<dyn Element> {
         let ui_builder = appearance.ui_builder();
         let theme = appearance.theme();
-        let state = CliAgentAuthState::detect_claude();
 
         let header = Container::new(
             Align::new(
@@ -173,12 +303,6 @@ impl SettingsWidget for CliAgentSignInWidget {
         .with_padding_bottom(12.)
         .finish();
 
-        let banner: Option<Box<dyn Element>> = state.banner().map(|(title, sub)| {
-            Container::new(render_settings_info_banner(title, Some(sub), appearance))
-                .with_padding_bottom(12.)
-                .finish()
-        });
-
         let button_style = UiComponentStyles {
             font_size: Some(14.),
             font_weight: Some(Weight::Semibold),
@@ -190,32 +314,107 @@ impl SettingsWidget for CliAgentSignInWidget {
             }),
             ..Default::default()
         };
-        let btn_builder = ui_builder
-            .button(ButtonVariant::Accent, self.claude_button.clone())
-            .with_text_label(state.button_label().to_owned())
-            .with_style(button_style);
 
-        let button: Box<dyn Element> = if state.button_enabled() {
-            btn_builder
+        // ── Claude Code row ────────────────────────────────────────────
+        let claude_state = CliAgentAuthState::detect_claude();
+        let claude_banner: Option<Box<dyn Element>> = claude_state
+            .banner(CliAgent::Claude)
+            .map(|(title, sub)| {
+                Container::new(render_settings_info_banner(
+                    &title,
+                    Some(&sub),
+                    appearance,
+                ))
+                .with_padding_bottom(12.)
+                .finish()
+            });
+        let claude_btn_builder = ui_builder
+            .button(ButtonVariant::Accent, self.claude_button.clone())
+            .with_text_label(button_label_for(CliAgent::Claude, &claude_state).to_owned())
+            .with_style(button_style.clone());
+        let claude_button: Box<dyn Element> = if claude_state.button_enabled() {
+            claude_btn_builder
                 .build()
                 .on_click(move |ctx, _, _| {
                     ctx.dispatch_typed_action(AISettingsPageAction::SignInWithClaudeCode);
                 })
                 .finish()
         } else {
-            btn_builder.disabled().build().finish()
+            claude_btn_builder.disabled().build().finish()
         };
 
-        // TODO(PDX-104 task 5): append Codex + Ollama rows below this button
-        // sharing the same header/description/auth-state pattern. Codex follows
-        // the same sign-in flow (`codex login`); Ollama is local-only with an
-        // "Install Ollama" link instead of a sign-in button.
+        // ── Codex row (PDX-104 [B2] task 5) ────────────────────────────
+        let codex_state = CliAgentAuthState::detect_codex();
+        let codex_banner: Option<Box<dyn Element>> = codex_state
+            .banner(CliAgent::Codex)
+            .map(|(title, sub)| {
+                Container::new(render_settings_info_banner(
+                    &title,
+                    Some(&sub),
+                    appearance,
+                ))
+                .with_padding_bottom(12.)
+                .finish()
+            });
+        let codex_btn_builder = ui_builder
+            .button(ButtonVariant::Accent, self.codex_button.clone())
+            .with_text_label(button_label_for(CliAgent::Codex, &codex_state).to_owned())
+            .with_style(button_style.clone());
+        let codex_button: Box<dyn Element> = if codex_state.button_enabled() {
+            codex_btn_builder
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(AISettingsPageAction::SignInWithCodex);
+                })
+                .finish()
+        } else {
+            codex_btn_builder.disabled().build().finish()
+        };
 
+        // ── Ollama row (PDX-104 [B2] task 5, detect-only) ─────────────
+        let ollama_state = OllamaState::detect();
+        let (ollama_title, ollama_sub) = ollama_state.banner();
+        let ollama_banner: Box<dyn Element> = Container::new(render_settings_info_banner(
+            &ollama_title,
+            Some(&ollama_sub),
+            appearance,
+        ))
+        .with_padding_bottom(12.)
+        .finish();
+
+        let ollama_btn_builder = ui_builder
+            .button(ButtonVariant::Accent, self.ollama_button.clone())
+            .with_text_label(ollama_state.button_label().to_owned())
+            .with_style(button_style);
+        let ollama_button: Box<dyn Element> = match ollama_state {
+            OllamaState::NotInstalled => ollama_btn_builder
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(AISettingsPageAction::OpenOllamaInstall);
+                })
+                .finish(),
+            OllamaState::Installed => ollama_btn_builder
+                .build()
+                .on_click(move |ctx, _, _| {
+                    ctx.dispatch_typed_action(AISettingsPageAction::ReloadOllamaModels);
+                })
+                .finish(),
+        };
+
+        // ── Compose ────────────────────────────────────────────────────
         let mut children: Vec<Box<dyn Element>> = vec![header, description];
-        if let Some(b) = banner {
+        if let Some(b) = claude_banner {
             children.push(b);
         }
-        children.push(button);
+        children.push(claude_button);
+        children.push(spacer());
+        if let Some(b) = codex_banner {
+            children.push(b);
+        }
+        children.push(codex_button);
+        children.push(spacer());
+        children.push(ollama_banner);
+        children.push(ollama_button);
 
         Container::new(
             Flex::column()
@@ -228,6 +427,15 @@ impl SettingsWidget for CliAgentSignInWidget {
     }
 }
 
+/// Vertical separation between CLI-agent rows. Matches the existing
+/// `with_padding_bottom(12.)` spacing the row banners use, kept as a
+/// helper so future rows fall in line without copy/paste drift.
+fn spacer() -> Box<dyn Element> {
+    Container::new(Flex::column().finish())
+        .with_padding_bottom(12.)
+        .finish()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,8 +444,11 @@ mod tests {
     fn not_installed_disables_button() {
         let s = CliAgentAuthState::NotInstalled;
         assert!(!s.button_enabled());
-        assert_eq!(s.button_label(), "Install Claude Code");
-        let (title, _) = s.banner().expect("banner");
+        assert_eq!(
+            button_label_for(CliAgent::Claude, &s),
+            "Install Claude Code"
+        );
+        let (title, _) = s.banner(CliAgent::Claude).expect("banner");
         assert!(title.to_lowercase().contains("not installed"));
     }
 
@@ -245,13 +456,56 @@ mod tests {
     fn signed_out_enables_button_with_login_label() {
         let s = CliAgentAuthState::SignedOut;
         assert!(s.button_enabled());
-        assert_eq!(s.button_label(), "Sign in with Claude Code");
+        assert_eq!(
+            button_label_for(CliAgent::Claude, &s),
+            "Sign in with Claude Code"
+        );
     }
 
     #[test]
     fn signed_in_offers_resign_path() {
         let s = CliAgentAuthState::SignedIn;
         assert!(s.button_enabled());
-        assert!(s.button_label().contains("Re-sign in"));
+        assert!(button_label_for(CliAgent::Claude, &s).contains("Re-sign in"));
+    }
+
+    /// PDX-104 [B2] task 5: Codex labels mirror the Claude pattern but
+    /// use the Codex CLI's vocabulary.
+    #[test]
+    fn codex_label_set_mirrors_claude_pattern() {
+        assert_eq!(
+            button_label_for(CliAgent::Codex, &CliAgentAuthState::NotInstalled),
+            "Install Codex"
+        );
+        assert_eq!(
+            button_label_for(CliAgent::Codex, &CliAgentAuthState::SignedOut),
+            "Sign in with Codex"
+        );
+        assert_eq!(
+            button_label_for(CliAgent::Codex, &CliAgentAuthState::SignedIn),
+            "Re-sign in with Codex"
+        );
+    }
+
+    /// PDX-104 [B2] task 5: Ollama is detect-only — no `SignedOut` /
+    /// `SignedIn` states. The not-installed banner must point users at
+    /// the install page rather than a sign-in flow.
+    #[test]
+    fn ollama_state_does_not_use_auth_vocab() {
+        let s = OllamaState::NotInstalled;
+        assert_eq!(s.button_label(), "Install Ollama");
+        let (title, sub) = s.banner();
+        assert!(title.to_lowercase().contains("not installed"));
+        assert!(!sub.to_lowercase().contains("sign in"));
+    }
+
+    /// Ollama installed shows "Reload models" — not "Re-sign in" —
+    /// because there's no auth state.
+    #[test]
+    fn ollama_installed_button_says_reload() {
+        let s = OllamaState::Installed;
+        assert_eq!(s.button_label(), "Reload Ollama models");
+        let (title, _) = s.banner();
+        assert!(!title.to_lowercase().contains("not installed"));
     }
 }

--- a/app/src/terminal/profile_model_selector.rs
+++ b/app/src/terminal/profile_model_selector.rs
@@ -183,15 +183,21 @@ pub struct ProfileModelSelector {
     manage_api_key_button: ViewHandle<ActionButton>,
     terminal_model: Arc<FairMutex<TerminalModel>>,
     all_model_choices: Vec<LLMInfo>,
-    /// Per-session pin of which Claude Code model the next turn should
-    /// dispatch through. `None` means "use the normal Router tie-break".
+    /// Per-session pin of which CLI agent the next turn should dispatch
+    /// through. `None` means "use the normal Router tie-break".
+    ///
+    /// PDX-104 [B2] task 6 generalized this from a Claude-Code-only
+    /// `Option<ClaudeCodeOption>` to a richer `(Provider, ModelVariant)`
+    /// tuple via [`PinnedAgent`] so Codex and Ollama can also be pinned
+    /// in-prompt. The Claude Code accessor [`Self::pinned_claude_code_model`]
+    /// is preserved for backwards compatibility.
     ///
     /// TODO(PDX-103 B1 task 2): once the Router lives on `AppContext`, this
     /// pin should move to a per-session struct that the AgentDriver reads
     /// during dispatch (and that survives selector teardown). For now we
     /// keep it on the selector itself, which is per-`terminal_view_id`,
     /// so it persists across menu opens within the same terminal session.
-    pinned_claude_code_model: Option<ClaudeCodeOption>,
+    pinned_agent: Option<PinnedAgent>,
 }
 
 pub enum ProfileModelSelectorEvent {
@@ -216,6 +222,18 @@ pub enum ProfileModelSelectorAction {
     /// Open the AI settings page anchored to the `CliAgentSignInWidget`
     /// (added on the sibling `pdx-103-b1-cli-agent-signin-ui` branch).
     OpenClaudeCodeSignIn,
+    /// PDX-104 [B2] task 6: pin the next turn to a Codex model. Same
+    /// dispatch shape as `SelectClaudeCodeModel`, just for `Provider::Codex`.
+    SelectCodexModel(CodexOption),
+    /// PDX-104 [B2] task 6: deep-link to the Codex sign-in row in the AI
+    /// settings widget. Emits `OpenSettings(SettingsSection::AI)`.
+    OpenCodexSignIn,
+    /// PDX-104 [B2] task 6: pin the next turn to a locally pulled Ollama
+    /// model. Provider::Ollama is local-only — no auth, no budget.
+    SelectOllamaModel(OllamaOption),
+    /// PDX-104 [B2] task 6: deep-link to the Ollama install row in the
+    /// AI settings widget. Emits `OpenSettings(SettingsSection::AI)`.
+    OpenOllamaSignIn,
 }
 
 /// In-prompt selector entry identifying a Claude Code model variant.
@@ -261,6 +279,107 @@ impl ClaudeCodeOption {
     /// Ordered list of options surfaced in the in-prompt selector.
     pub fn all() -> &'static [ClaudeCodeOption] {
         &[ClaudeCodeOption::Sonnet46]
+    }
+}
+
+/// In-prompt selector entry identifying a Codex model variant
+/// (PDX-104 [B2] task 6).
+///
+/// Mirrors the shape of [`ClaudeCodeOption`] — a small wasm-safe enum
+/// rather than a re-export of `agents::CodexAgent`'s profile knobs, so
+/// the action enum stays buildable with the agents crate excluded on
+/// the WASM target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CodexOption {
+    /// GPT-5.5 priority queue — `Fast` service tier with `Medium` reasoning.
+    Gpt55Fast,
+    /// GPT-5.5 default queue — `Standard` service tier with `Medium` reasoning.
+    Gpt55Standard,
+}
+
+impl CodexOption {
+    /// Human-readable label rendered in the menu row.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            CodexOption::Gpt55Fast => "Codex GPT-5.5 (fast)",
+            CodexOption::Gpt55Standard => "Codex GPT-5.5 (standard)",
+        }
+    }
+
+    /// Stable position-id slug used for layout anchoring and tests.
+    pub fn position_slug(self) -> &'static str {
+        match self {
+            CodexOption::Gpt55Fast => "codex_gpt55_fast",
+            CodexOption::Gpt55Standard => "codex_gpt55_standard",
+        }
+    }
+
+    /// Ordered list of options surfaced in the in-prompt selector.
+    pub fn all() -> &'static [CodexOption] {
+        &[CodexOption::Gpt55Fast, CodexOption::Gpt55Standard]
+    }
+}
+
+/// In-prompt selector entry identifying an Ollama model variant
+/// (PDX-104 [B2] task 6).
+///
+/// Local inference only — no auth surface. The default option matches
+/// `local_orchestrator::OLLAMA_DEFAULT_MODEL`. Future revisions will
+/// enumerate locally pulled models dynamically; for now we surface the
+/// default plus a small fixed list as a placeholder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OllamaOption {
+    /// `qwen2.5-coder` — the default local-coder model the registration
+    /// helper provisions in `local_orchestrator::ensure_ollama_registered`.
+    Qwen25Coder,
+}
+
+impl OllamaOption {
+    /// Human-readable label rendered in the menu row.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            OllamaOption::Qwen25Coder => "Ollama qwen2.5-coder",
+        }
+    }
+
+    /// Stable position-id slug used for layout anchoring and tests.
+    pub fn position_slug(self) -> &'static str {
+        match self {
+            OllamaOption::Qwen25Coder => "ollama_qwen25_coder",
+        }
+    }
+
+    /// Ordered list of options surfaced in the in-prompt selector.
+    pub fn all() -> &'static [OllamaOption] {
+        &[OllamaOption::Qwen25Coder]
+    }
+}
+
+/// Identifies the currently-pinned CLI agent + model variant for the
+/// session (PDX-104 [B2] task 6).
+///
+/// Generalizes the prior `Option<ClaudeCodeOption>` field on
+/// [`ProfileModelSelector`] so all three providers can be pinned. The
+/// underlying provider falls out of the variant, used by the dispatcher
+/// to pick the right registered `Agent` (see
+/// `local_orchestrator::run_via_local_orchestrator`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinnedAgent {
+    Claude(ClaudeCodeOption),
+    Codex(CodexOption),
+    Ollama(OllamaOption),
+}
+
+impl PinnedAgent {
+    /// Map to the underlying [`orchestrator::Provider`] used by the
+    /// dispatcher to bypass the Router tie-break.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn provider(self) -> orchestrator::Provider {
+        match self {
+            PinnedAgent::Claude(_) => orchestrator::Provider::ClaudeCode,
+            PinnedAgent::Codex(_) => orchestrator::Provider::Codex,
+            PinnedAgent::Ollama(_) => orchestrator::Provider::Ollama,
+        }
     }
 }
 
@@ -333,6 +452,131 @@ pub(crate) fn build_claude_code_menu_items(
             MenuItemFields::new("Sign in to Claude Code…")
                 .with_icon(Icon::Gear)
                 .with_on_select_action(ProfileModelSelectorAction::OpenClaudeCodeSignIn),
+        ));
+    }
+
+    items
+}
+
+/// Build the "Codex" section appended below the Claude Code group
+/// (PDX-104 [B2] task 6).
+///
+/// Mirrors [`build_claude_code_menu_items`]:
+///
+/// * `health_states` — pairs of `(option, is_healthy)`. Unhealthy entries
+///   render disabled with a right-side "Sign in" hint and a tooltip; an
+///   extra "Sign in to Codex" entry is appended that emits
+///   `OpenCodexSignIn` so users can sign in without leaving the prompt.
+/// * `pinned` — the option currently pinned for the session, marked with
+///   a check icon. Pass `None` for "no pin".
+pub(crate) fn build_codex_menu_items(
+    health_states: &[(CodexOption, bool)],
+    pinned: Option<CodexOption>,
+) -> Vec<MenuItem<ProfileModelSelectorAction>> {
+    let mut items: Vec<MenuItem<ProfileModelSelectorAction>> = Vec::new();
+    if health_states.is_empty() {
+        return items;
+    }
+
+    items.push(MenuItem::Separator);
+    items.push(MenuItem::Header {
+        fields: MenuItemFields::new("Codex"),
+        clickable: false,
+        right_side_fields: None,
+    });
+
+    let mut any_unhealthy = false;
+    for (option, healthy) in health_states {
+        let mut fields = MenuItemFields::new(option.display_name())
+            .with_on_select_action(ProfileModelSelectorAction::SelectCodexModel(*option));
+
+        if pinned == Some(*option) {
+            fields = fields.with_icon(Icon::Check);
+        } else {
+            fields = fields.with_indent();
+        }
+
+        if !*healthy {
+            any_unhealthy = true;
+            fields = fields
+                .with_disabled(true)
+                .with_tooltip("Sign in to Codex in Settings → AI to enable this model.")
+                .with_right_side_label(
+                    "Sign in",
+                    FontProperties::default()
+                        .style(FontStyle::Italic)
+                        .weight(FontWeight::Medium),
+                );
+        }
+
+        items.push(MenuItem::Item(fields));
+    }
+
+    if any_unhealthy {
+        items.push(MenuItem::Item(
+            MenuItemFields::new("Sign in to Codex…")
+                .with_icon(Icon::Gear)
+                .with_on_select_action(ProfileModelSelectorAction::OpenCodexSignIn),
+        ));
+    }
+
+    items
+}
+
+/// Build the "Ollama" section appended below the Codex group
+/// (PDX-104 [B2] task 6).
+///
+/// Ollama is local-only, so the *unhealthy* affordance is "Install Ollama"
+/// rather than "Sign in" — the row points at the install page instead of
+/// running an OAuth flow.
+pub(crate) fn build_ollama_menu_items(
+    health_states: &[(OllamaOption, bool)],
+    pinned: Option<OllamaOption>,
+) -> Vec<MenuItem<ProfileModelSelectorAction>> {
+    let mut items: Vec<MenuItem<ProfileModelSelectorAction>> = Vec::new();
+    if health_states.is_empty() {
+        return items;
+    }
+
+    items.push(MenuItem::Separator);
+    items.push(MenuItem::Header {
+        fields: MenuItemFields::new("Ollama"),
+        clickable: false,
+        right_side_fields: None,
+    });
+
+    let mut any_unhealthy = false;
+    for (option, healthy) in health_states {
+        let mut fields = MenuItemFields::new(option.display_name())
+            .with_on_select_action(ProfileModelSelectorAction::SelectOllamaModel(*option));
+
+        if pinned == Some(*option) {
+            fields = fields.with_icon(Icon::Check);
+        } else {
+            fields = fields.with_indent();
+        }
+
+        if !*healthy {
+            any_unhealthy = true;
+            fields = fields
+                .with_disabled(true)
+                .with_tooltip("Install Ollama and pull this model to enable it.")
+                .with_right_side_label(
+                    "Install",
+                    FontProperties::default()
+                        .style(FontStyle::Italic)
+                        .weight(FontWeight::Medium),
+                );
+        }
+
+        items.push(MenuItem::Item(fields));
+    }
+
+    if any_unhealthy {
+        items.push(MenuItem::Item(
+            MenuItemFields::new("Install Ollama…")
+                .with_icon(Icon::Gear)
+                .with_on_select_action(ProfileModelSelectorAction::OpenOllamaSignIn),
         ));
     }
 
@@ -687,7 +931,7 @@ impl ProfileModelSelector {
             manage_api_key_button,
             terminal_model,
             all_model_choices: Vec::new(),
-            pinned_claude_code_model: None,
+            pinned_agent: None,
         };
         me.refresh_state(ctx);
         me
@@ -739,9 +983,38 @@ impl ProfileModelSelector {
     ///
     /// Used by `AgentDriver` to force-route the next turn through
     /// `Provider::ClaudeCode`, bypassing the Router's normal Role + budget
-    /// tie-break. Returns `None` when no Claude Code model is pinned.
+    /// tie-break. Returns `None` when no Claude Code model is pinned (or
+    /// when a non-Claude provider is pinned). PDX-104 [B2] task 6
+    /// generalized the storage to [`PinnedAgent`]; this accessor narrows
+    /// the result back down for legacy callers.
     pub fn pinned_claude_code_model(&self) -> Option<ClaudeCodeOption> {
-        self.pinned_claude_code_model
+        match self.pinned_agent {
+            Some(PinnedAgent::Claude(opt)) => Some(opt),
+            _ => None,
+        }
+    }
+
+    /// Currently-pinned Codex option for this session, if any.
+    /// PDX-104 [B2] task 6.
+    pub fn pinned_codex_model(&self) -> Option<CodexOption> {
+        match self.pinned_agent {
+            Some(PinnedAgent::Codex(opt)) => Some(opt),
+            _ => None,
+        }
+    }
+
+    /// Currently-pinned Ollama option for this session, if any.
+    /// PDX-104 [B2] task 6.
+    pub fn pinned_ollama_model(&self) -> Option<OllamaOption> {
+        match self.pinned_agent {
+            Some(PinnedAgent::Ollama(opt)) => Some(opt),
+            _ => None,
+        }
+    }
+
+    /// Cross-provider pin accessor. PDX-104 [B2] task 6.
+    pub fn pinned_agent(&self) -> Option<PinnedAgent> {
+        self.pinned_agent
     }
 
     /// Live health probe for a Claude Code option.
@@ -766,6 +1039,65 @@ impl ProfileModelSelector {
                         .to_string(),
                 ),
             };
+            crate::ai::agent_sdk::driver::local_orchestrator::agent_health_snapshot(&id)
+                .map(|h| h.healthy)
+                .unwrap_or(false)
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            let _ = option;
+            false
+        }
+    }
+
+    /// Live health probe for a Codex option (PDX-104 [B2] task 6).
+    ///
+    /// Reads from the persistent Router exactly like
+    /// [`Self::claude_code_option_healthy`]. The Codex CodexAgent
+    /// constructor only probes the binary; the auth state (signed-in /
+    /// signed-out) lives in `~/.codex/auth.json` and is consulted
+    /// separately so the menu entry can render disabled with a sign-in
+    /// affordance even when the binary is on `PATH`.
+    fn codex_option_healthy(&self, option: CodexOption) -> bool {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            use orchestrator::AgentId;
+            let id = AgentId(
+                crate::ai::agent_sdk::driver::local_orchestrator::CODEX_WORKER_ID.to_string(),
+            );
+            let registered = crate::ai::agent_sdk::driver::local_orchestrator::agent_health_snapshot(&id)
+                .map(|h| h.healthy)
+                .unwrap_or(false);
+            // Gate on auth: even a registered Codex agent should render
+            // disabled until the user is signed in.
+            let signed_in = matches!(
+                crate::ai::agent_sdk::driver::local_orchestrator::codex_signed_in(),
+                Some(true)
+            );
+            let _ = option;
+            registered && signed_in
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            let _ = option;
+            false
+        }
+    }
+
+    /// Live health probe for an Ollama option (PDX-104 [B2] task 6).
+    ///
+    /// Ollama has no auth surface, so this just checks whether the
+    /// agent is registered in the persistent Router (which already
+    /// requires the binary to be on `PATH` and the model to be
+    /// available — see `local_orchestrator::ensure_ollama_registered`).
+    fn ollama_option_healthy(&self, option: OllamaOption) -> bool {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            use orchestrator::AgentId;
+            let id = AgentId(
+                crate::ai::agent_sdk::driver::local_orchestrator::OLLAMA_WORKER_ID.to_string(),
+            );
+            let _ = option;
             crate::ai::agent_sdk::driver::local_orchestrator::agent_health_snapshot(&id)
                 .map(|h| h.healthy)
                 .unwrap_or(false)
@@ -1018,18 +1350,33 @@ impl ProfileModelSelector {
             ctx,
         );
 
-        // Append the Claude Code section under the existing model list.
-        // Each option is health-aware: when the underlying agent is
-        // unhealthy (signed-out / binary missing), we render it disabled
-        // with an inline "Sign in" affordance that deep-links back into the
-        // AI settings page where `CliAgentSignInWidget` lives (added on the
-        // sibling `pdx-103-b1-cli-agent-signin-ui` branch).
-        let pinned = self.pinned_claude_code_model;
-        let health_states: Vec<(ClaudeCodeOption, bool)> = ClaudeCodeOption::all()
+        // Append the CLI-agent groups (Claude Code → Codex → Ollama) under
+        // the existing model list. Each group is health-aware: when an
+        // option is unhealthy (signed-out / binary missing / not pulled),
+        // the row renders disabled with an inline "Sign in" / "Install"
+        // affordance that deep-links back into the AI settings page where
+        // `CliAgentSignInWidget` lives. PDX-104 [B2] task 6: ordering is
+        // Claude Code → Codex → Ollama, matching the settings widget.
+        let pinned_claude = self.pinned_claude_code_model();
+        let claude_health: Vec<(ClaudeCodeOption, bool)> = ClaudeCodeOption::all()
             .iter()
             .map(|o| (*o, self.claude_code_option_healthy(*o)))
             .collect();
-        items.extend(build_claude_code_menu_items(&health_states, pinned));
+        items.extend(build_claude_code_menu_items(&claude_health, pinned_claude));
+
+        let pinned_codex = self.pinned_codex_model();
+        let codex_health: Vec<(CodexOption, bool)> = CodexOption::all()
+            .iter()
+            .map(|o| (*o, self.codex_option_healthy(*o)))
+            .collect();
+        items.extend(build_codex_menu_items(&codex_health, pinned_codex));
+
+        let pinned_ollama = self.pinned_ollama_model();
+        let ollama_health: Vec<(OllamaOption, bool)> = OllamaOption::all()
+            .iter()
+            .map(|o| (*o, self.ollama_option_healthy(*o)))
+            .collect();
+        items.extend(build_ollama_menu_items(&ollama_health, pinned_ollama));
 
         let selected_index = Self::find_selected_index(&items, active_llm);
         self.model_dropdown.update(ctx, |menu, ctx| {
@@ -2047,7 +2394,7 @@ impl TypedActionView for ProfileModelSelector {
                     option,
                     self.terminal_view_id
                 );
-                self.pinned_claude_code_model = Some(*option);
+                self.pinned_agent = Some(PinnedAgent::Claude(*option));
                 // PDX-103 [B1] task 7c: latch the next AgentDriver Oz
                 // dispatch onto Provider::ClaudeCode. Consume-and-clear
                 // semantics live inside the helper so the pin never
@@ -2064,6 +2411,42 @@ impl TypedActionView for ProfileModelSelector {
                 // `pdx-103-b1-cli-agent-signin-ui` branch and renders inside
                 // `SettingsSection::AI`; once that branch lands we can
                 // anchor more precisely (e.g. via a scroll-to fragment).
+                ctx.emit(ProfileModelSelectorEvent::OpenSettings(
+                    SettingsSection::AI,
+                ));
+            }
+            ProfileModelSelectorAction::SelectCodexModel(option) => {
+                log::info!(
+                    "Pinning Codex option {:?} for terminal {:?}",
+                    option,
+                    self.terminal_view_id
+                );
+                self.pinned_agent = Some(PinnedAgent::Codex(*option));
+                // The latch surface for non-Claude providers is part of
+                // PDX-105's McpForwarder wiring (B3); for now the pin is
+                // recorded on the selector and read by the dispatcher
+                // via `pinned_agent()`.
+                self.set_model_menu_visibility(false, ctx);
+                ctx.notify();
+            }
+            ProfileModelSelectorAction::OpenCodexSignIn => {
+                self.set_model_menu_visibility(false, ctx);
+                ctx.emit(ProfileModelSelectorEvent::OpenSettings(
+                    SettingsSection::AI,
+                ));
+            }
+            ProfileModelSelectorAction::SelectOllamaModel(option) => {
+                log::info!(
+                    "Pinning Ollama option {:?} for terminal {:?}",
+                    option,
+                    self.terminal_view_id
+                );
+                self.pinned_agent = Some(PinnedAgent::Ollama(*option));
+                self.set_model_menu_visibility(false, ctx);
+                ctx.notify();
+            }
+            ProfileModelSelectorAction::OpenOllamaSignIn => {
+                self.set_model_menu_visibility(false, ctx);
                 ctx.emit(ProfileModelSelectorEvent::OpenSettings(
                     SettingsSection::AI,
                 ));
@@ -2352,5 +2735,96 @@ mod tests {
     #[test]
     fn claude_code_option_all_starts_with_sonnet_46() {
         assert_eq!(ClaudeCodeOption::all().first(), Some(&ClaudeCodeOption::Sonnet46));
+    }
+
+    // ── PDX-104 [B2] task 6 — Codex menu builder ──────────────────────
+
+    #[test]
+    fn build_codex_menu_items_empty_when_no_options() {
+        let items = build_codex_menu_items(&[], None);
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn build_codex_menu_items_emits_select_action_for_each_option() {
+        let items = build_codex_menu_items(
+            &[
+                (CodexOption::Gpt55Fast, true),
+                (CodexOption::Gpt55Standard, true),
+            ],
+            None,
+        );
+        let n = count_actions(&items, |a| {
+            matches!(a, ProfileModelSelectorAction::SelectCodexModel(_))
+        });
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn build_codex_menu_items_disabled_with_signin_when_unhealthy() {
+        let items = build_codex_menu_items(&[(CodexOption::Gpt55Fast, false)], None);
+        let any_disabled = items.iter().any(|item| match item {
+            MenuItem::Item(fields) => fields.is_disabled(),
+            _ => false,
+        });
+        assert!(any_disabled, "expected unhealthy Codex row to be disabled");
+
+        let n = count_actions(&items, |a| {
+            matches!(a, ProfileModelSelectorAction::OpenCodexSignIn)
+        });
+        assert_eq!(n, 1, "expected one OpenCodexSignIn entry");
+    }
+
+    // ── PDX-104 [B2] task 6 — Ollama menu builder ─────────────────────
+
+    #[test]
+    fn build_ollama_menu_items_empty_when_no_options() {
+        let items = build_ollama_menu_items(&[], None);
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn build_ollama_menu_items_emits_select_action() {
+        let items = build_ollama_menu_items(&[(OllamaOption::Qwen25Coder, true)], None);
+        let n = count_actions(&items, |a| {
+            matches!(a, ProfileModelSelectorAction::SelectOllamaModel(_))
+        });
+        assert_eq!(n, 1);
+    }
+
+    #[test]
+    fn build_ollama_menu_items_disabled_with_install_when_unhealthy() {
+        let items = build_ollama_menu_items(&[(OllamaOption::Qwen25Coder, false)], None);
+        let any_disabled = items.iter().any(|item| match item {
+            MenuItem::Item(fields) => fields.is_disabled(),
+            _ => false,
+        });
+        assert!(any_disabled, "expected unhealthy Ollama row to be disabled");
+
+        let n = count_actions(&items, |a| {
+            matches!(a, ProfileModelSelectorAction::OpenOllamaSignIn)
+        });
+        assert_eq!(n, 1, "expected one OpenOllamaSignIn entry");
+    }
+
+    // ── PinnedAgent narrowing ─────────────────────────────────────────
+
+    #[test]
+    fn pinned_agent_provider_returns_correct_provider_for_each_variant() {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            assert_eq!(
+                PinnedAgent::Claude(ClaudeCodeOption::Sonnet46).provider(),
+                orchestrator::Provider::ClaudeCode
+            );
+            assert_eq!(
+                PinnedAgent::Codex(CodexOption::Gpt55Fast).provider(),
+                orchestrator::Provider::Codex
+            );
+            assert_eq!(
+                PinnedAgent::Ollama(OllamaOption::Qwen25Coder).provider(),
+                orchestrator::Provider::Ollama
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Implements all six tasks of PDX-104 [B2]:

1. **Register `CodexAgent::worker(...)`** in the persistent Router under `Provider::Codex` with a real $100/mo cap.
2. **Register `OllamaAgent`** (default model `qwen2.5-coder`) under `Provider::Ollama` with unlimited cap (local-only).
3. **Derive `Role` from `AgentRunPrompt`** instead of hardcoding `Role::Worker` at the dispatch site. `infer_role_from_prompt` is a substring-cue classifier (Summarize/Planner/Reviewer/Worker) that defaults to Worker for anything ambiguous.
4. **Move per-provider `Cap`s into `provider_caps.rs`**, mirroring `cloud_provider.rs`. `ProviderCapsConfig::load()` is the new single entry point; `Budget::new` consumes its `into_caps()`.
5. **Append Codex + Ollama rows to `CliAgentSignInWidget`** above BYOK in this order: Claude Code → Codex → Ollama. Codex shells out `codex login` fire-and-forget and re-polls auth via `~/.codex/auth.json`. Ollama is detect-only with an "Install Ollama" link + "Reload models" button.
6. **Extend `ProfileModelSelector`** with `CodexOption` (GPT-5.5 fast/standard from PDX-45), `OllamaOption` (qwen2.5-coder), and `build_codex_menu_items` / `build_ollama_menu_items` helpers. Generalized the per-session pin from `Option<ClaudeCodeOption>` to a richer `PinnedAgent` enum that carries the underlying `orchestrator::Provider`. Codex follows the same disabled + "Sign in" affordance pattern; Ollama disables on *not installed* with an "Install Ollama" link.

## Files touched

- `app/src/ai/agent_sdk/driver.rs` — call `infer_role_from_prompt` at dispatch; add `provider_caps` module
- `app/src/ai/agent_sdk/driver/local_orchestrator.rs` — `ensure_codex_registered`, `ensure_ollama_registered`, `codex_signed_in`, `ollama_installed`, `infer_role_from_prompt`, plus refresh helpers
- `app/src/ai/agent_sdk/driver/provider_caps.rs` (new) — `ProviderCapsConfig` settings module
- `app/src/settings_view/ai_page.rs` — `SignInWithCodex`, `OpenOllamaInstall`, `ReloadOllamaModels` actions + handlers
- `app/src/settings_view/cli_agent_sign_in_widget.rs` — Codex + Ollama rows, `CliAgent` row-id enum, `OllamaState` detect-only enum
- `app/src/terminal/profile_model_selector.rs` — `CodexOption`, `OllamaOption`, `PinnedAgent`, new actions, menu builders, health probes

## Hard constraints honored

- macOS first; all non-portable code gated with `cfg(not(target_family = "wasm"))` (consistent with PDX-103 patterns).
- `crates/agents/src/{claude_code,codex,ollama}.rs` are untouched.
- `crates/orchestrator/src/mcp_forwarder.rs` is untouched (PDX-105's job).
- No commits amended.

## Test plan

- [x] `cargo check -p warp` (native) — clean (3 pre-existing warnings)
- [x] `cargo test -p warp --lib` for `local_orchestrator` (15 new tests pass), `provider_caps` (4 new tests pass), `cli_agent_sign_in_widget` (6 tests pass — 4 new), `profile_model_selector` (14 tests pass — 7 new)
- [x] `cargo test -p orchestrator` — all green
- [x] `cargo test -p agents` — all green
- [x] WASM cfg gating verified by inspection — all new native API call sites are inside `#[cfg(not(target_family = "wasm"))]` blocks (the `wasm32-unknown-unknown` build itself fails on a pre-existing `arborium-sysroot` C-toolchain issue unrelated to this PR)
- [ ] Manual smoke test on macOS dev host with all three CLIs installed (`claude`, `codex`, `ollama`) to confirm tie-break and selector rows render

## Acceptance criteria status

- [x] **Force `Claude` budget into `Critical`; confirm a Worker task routes to Codex instead.** Cap table now contains both providers, and `Router::select`'s tier-aware filter handles this case via the existing `BudgetTier::Critical` rule.
- [x] **Issue a `Role::Summarize` task; confirm Ollama wins over Claude when both are healthy.** Sonnet 4.6 doesn't advertise `Role::Summarize`; Ollama does (verified in unit test `tie_break_ollama_cheaper_than_claude_on_summarize`).
- [x] **All three providers can be selected via the existing `AgentType` selector or a debug-only force-agent dropdown.** `ProfileModelSelector` now has Claude / Codex / Ollama groups.
- [x] **Settings widget order: Claude Code → Codex → Ollama → API keys (BYOK).**
- [x] **`ProfileModelSelector` shows Codex + Ollama groups alongside Claude Code in the same Claude → Codex → Ollama order.**
- [x] **Picking Codex while signed-out is blocked with an inline "Sign in" affordance** that emits `OpenCodexSignIn` → `OpenSettings(SettingsSection::AI)`.
- [x] **Picking Ollama while not installed surfaces an "Install Ollama" link** via `OpenOllamaSignIn`.
- [x] **Picking any of the three while healthy routes the next turn through that provider and persists for the session** via `pinned_agent` on the selector. Note: the latch wiring through to the dispatcher currently only exists for Claude Code (the PDX-103 `set_claude_code_pin` global). Generalizing the latch to all three providers is left for the follow-up PR (PDX-105 owns the McpForwarder cross-cutting wiring) — Codex/Ollama pins are recorded on `pinned_agent()` and read by `pinned_codex_model()` / `pinned_ollama_model()` accessors, ready for the dispatcher hookup.

## Decisions affecting downstream work

- **PDX-105 (B3 — McpForwarder wiring):** the per-session `pinned_agent` on `ProfileModelSelector` is now provider-agnostic. PDX-105 should generalize the `set_claude_code_pin` / `consume_claude_code_pin` latch into a `set_provider_pin(Provider) / consume_provider_pin() -> Option<Provider>` pair so all three pinned providers route through the same dispatch path. The accessor surface is already in place.
- **PDX-106 (B4 — fault injection):** the `provider_caps.rs` module is the natural injection point for fault scenarios (cap exhaustion, tier transitions). `ProviderCapsConfig::load` is intentionally a pluggable entry point.