### PR TITLE
PDX-73 [A7.5] Five hand-written starter skills

### DIFF
--- a/templates/helm-starter-skills/README.md
+++ b/templates/helm-starter-skills/README.md
@@ -1,0 +1,78 @@
+# helm-starter-skills
+
+Five hand-authored starter skills that exercise the patterns Helm projects actually need. Drop this bundle into a project's skills root (`~/.warp/skills/` for global, `<repo>/.agents/skills/` for repo-local) and the `crates/skills` loader will pick them up.
+
+## What's in the box
+
+| Skill ID                  | Pattern                                                                |
+| ------------------------- | ---------------------------------------------------------------------- |
+| `ai-gateway-routing`      | Route every model call through Cloudflare AI Gateway dynamic routes.   |
+| `drizzle-migration`       | Define a schema, generate SQL, apply locally + remotely on D1.         |
+| `wrangler-deploy`         | Deploy a Worker, set secrets from Doppler, wire the CI deploy job.     |
+| `doppler-secret-fetch`    | Inject secrets via the Doppler CLI with cwd-based scoping.             |
+| `warp-new-scaffolding`    | Scaffold a project from a template with variables and post-init hooks. |
+
+Each skill lives in its own subdirectory as `SKILL.md` with YAML front matter that matches the `SkillFrontMatter` schema in `crates/skills/src/lib.rs` (`name`, `description`, `roles`, `tags`).
+
+## Layout
+
+```
+templates/helm-starter-skills/
+├── README.md
+├── template.toml
+├── ai-gateway-routing/SKILL.md
+├── drizzle-migration/SKILL.md
+├── wrangler-deploy/SKILL.md
+├── doppler-secret-fetch/SKILL.md
+└── warp-new-scaffolding/SKILL.md
+```
+
+## Installing
+
+### Per-repo (recommended for project-specific patterns)
+
+```bash
+cp -R templates/helm-starter-skills/*/  .agents/skills/
+```
+
+The skills loader walks `<repo>/.agents/skills/` recursively for any `*.md` file, so each `SKILL.md` is picked up automatically. Repo-local skills override user-global skills with the same name.
+
+### User-global (recommended for cross-repo patterns)
+
+```bash
+mkdir -p ~/.warp/skills
+cp -R templates/helm-starter-skills/*/  ~/.warp/skills/
+```
+
+### Via `warp new`
+
+This bundle is itself a Helm template, so it can be scaffolded:
+
+```bash
+warp new helm-starter-skills .agents/skills/
+```
+
+## Authoring conventions
+
+These five skills follow a deliberate style — when you write more, match it:
+
+1. **Specific behaviors over platitudes.** Good: "Block any PR that adds a `process.env.X` read without a corresponding `doppler secrets set X`." Bad: "Be careful with secrets."
+2. **Front matter has `name`, `description`, `roles`, `tags`** — `name` matches the directory.
+3. **Each skill ends with an "Anti-patterns" section** that lists the exact things to block in review. Reviewers and agents both consume this.
+4. **Copy-pasteable code blocks**, not pseudocode. If a code block can't be pasted into a real shell or file, rewrite it.
+5. **One skill = one pattern.** Don't bundle "all of Cloudflare" into a single skill. Split.
+
+## Schema reference
+
+Front matter is parsed by `serde_yaml` against `SkillFrontMatter`:
+
+```rust
+pub struct SkillFrontMatter {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub roles: Vec<String>,   // empty = applies to all roles
+    pub tags: Vec<String>,
+}
+```
+
+Runtime stats (`last_used`, `success_rate`, `total_tokens`, `tool_call_count`) and user overrides (`user_tags`, `user_description`) live in `SkillMetadata`, which is stored separately by `MetadataStore` — never in the markdown file. Don't put those fields in front matter.

--- a/templates/helm-starter-skills/ai-gateway-routing/SKILL.md
+++ b/templates/helm-starter-skills/ai-gateway-routing/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: ai-gateway-routing
+description: Route every LLM, embedding, image, audio, and video model call through a Cloudflare AI Gateway dynamic route. Never call providers (OpenAI, Anthropic, Workers AI) directly from a Worker, Node script, or one-off.
+roles: []
+tags: [cloudflare, ai-gateway, llm, embeddings, secrets]
+---
+
+# ai-gateway-routing
+
+All model traffic in this org goes through Cloudflare AI Gateway *dynamic routes*. Direct provider calls bypass caching, rate limits, observability, cost routing, fallbacks, and BYOK virtual keys, and they hardcode model choice — treat any direct call as a bug to fix.
+
+This applies even when the existing code calls a provider directly. Route it through the gateway and pick the dynamic route by **capability**, not by provider model id.
+
+## When to use
+
+- You are about to import `openai`, `@anthropic-ai/sdk`, `replicate`, `fal`, or any provider SDK.
+- You are reaching for `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` in env.
+- You are constructing a URL like `https://api.openai.com/...` or `https://api.anthropic.com/...`.
+- You see existing code that does any of the above — fix it.
+
+Stop and route through the gateway instead.
+
+## Endpoint
+
+OpenAI-compatible universal endpoint:
+
+```
+https://gateway.ai.cloudflare.com/v1/${CF_ACCOUNT_ID}/${CF_GATEWAY_ID}/compat/chat/completions
+```
+
+Default `CF_GATEWAY_ID = "x"` in this account.
+
+## Headers
+
+```
+Content-Type: application/json
+cf-aig-authorization: Bearer ${CF_AIG_TOKEN}
+cf-aig-zdr: true
+```
+
+Pull `CF_AIG_TOKEN` from Doppler — never inline it.
+
+## Dynamic routes (pick by capability)
+
+| Slug                   | Use for                              |
+| ---------------------- | ------------------------------------ |
+| `dynamic/text_gen`     | chat / text completion (default LLM) |
+| `dynamic/research_gen` | deep-reasoning completions          |
+| `dynamic/ai_embed`     | embeddings                           |
+| `dynamic/image_gen`    | image generation                     |
+| `dynamic/audio_gen`    | TTS / audio                          |
+| `dynamic/stt_gen`      | speech-to-text                       |
+| `dynamic/video_gen`    | video generation                     |
+
+Pass the slug as the `model` field in the OpenAI-compatible body. Never pass a raw `openai/gpt-…` or `anthropic/claude-…` id — the route handles model selection inside Cloudflare.
+
+## Inside a Worker (preferred)
+
+Use the `AI` binding so the call is in-region and skips the public internet:
+
+```ts
+// wrangler.toml: [ai] binding = "AI"
+const res = await env.AI.run(
+  "dynamic/text_gen",
+  { messages: [{ role: "user", content: "Summarise this PR." }] },
+  { gateway: { id: "x" } },
+);
+```
+
+For embeddings:
+
+```ts
+const { data } = await env.AI.run(
+  "dynamic/ai_embed",
+  { input: ["chunk one", "chunk two"] },
+  { gateway: { id: "x" } },
+);
+```
+
+## From a Node script (build, seed, migration, eval)
+
+No SDK, no provider key. Plain `fetch` to the universal endpoint:
+
+```ts
+const res = await fetch(
+  `https://gateway.ai.cloudflare.com/v1/${process.env.CF_ACCOUNT_ID}/x/compat/chat/completions`,
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "cf-aig-authorization": `Bearer ${process.env.CF_AIG_TOKEN}`,
+      "cf-aig-zdr": "true",
+    },
+    body: JSON.stringify({
+      model: "dynamic/text_gen",
+      messages: [{ role: "user", content: "Hello" }],
+    }),
+  },
+);
+const json = await res.json();
+```
+
+Run the script under Doppler so the token is present:
+
+```bash
+doppler run --scope . -- node scripts/seed.ts
+```
+
+## Canonical reference implementation
+
+Read and reuse — don't reinvent:
+
+- `cloudos/shared/gateway/src/routes.ts` — `chatCompletion`, `researchCompletion`
+- `cloudos/shared/gateway/src/gateway.ts` — request shaping, retry, ZDR
+- `cloudos/shared/gateway/src/llm.ts` — `gatewayEmbedding`
+
+## Anti-patterns (block these in review)
+
+- `import OpenAI from "openai"` in any file in this monorepo.
+- `import Anthropic from "@anthropic-ai/sdk"` in any file in this monorepo.
+- `process.env.OPENAI_API_KEY` or `process.env.ANTHROPIC_API_KEY` reads.
+- Hardcoded `model: "gpt-4o"` / `model: "claude-3-5-sonnet"` strings.
+- A `fetch` to `api.openai.com` or `api.anthropic.com`.
+
+If you see one of these, flag it and replace with a `dynamic/*` call.

--- a/templates/helm-starter-skills/doppler-secret-fetch/SKILL.md
+++ b/templates/helm-starter-skills/doppler-secret-fetch/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: doppler-secret-fetch
+description: Inject secrets into a build script or runtime via the Doppler CLI with cwd-based scoping. Never read raw .env files, never paste secret values into shells, never log secrets.
+roles: []
+tags: [doppler, secrets, cli, security]
+---
+
+# doppler-secret-fetch
+
+Doppler is the source of truth for every secret in this org. The Doppler CLI uses **cwd-based scopes** (`--scope .`) so that the project/config combo is decided by where the command is run, not by a global default. This makes it safe for an agent to run `doppler run` in any worktree without leaking secrets across projects.
+
+## When to use
+
+- A build script, migration, or seed needs `CF_AIG_TOKEN`, database URLs, API keys, etc.
+- A Worker dev session needs secrets injected (`wrangler dev`).
+- A one-off Node/Python script needs to talk to a service.
+- You're tempted to write `process.env.MY_KEY = "..."` or read a `.env` file. Don't — use Doppler.
+
+## One-time setup (per laptop, per project)
+
+```bash
+# Sign in non-interactively if you have a personal token; otherwise interactive
+doppler login --yes --scope .
+
+# Bind this project directory to a Doppler project + config
+doppler setup --scope . --project helm --config dev
+```
+
+`--scope .` writes the binding to `.doppler.yaml` in the current directory (gitignored). Subsequent `doppler` commands run from this tree (or below) automatically pick the right project + config.
+
+**Critical**: never pass `--project` / `--config` ad-hoc to `doppler run` — that bypasses cwd scoping and can silently fetch the wrong environment. Always rely on the bound scope.
+
+## Running a command with secrets injected
+
+```bash
+doppler run --scope . -- npm run build
+doppler run --scope . -- node scripts/seed.ts
+doppler run --scope . -- npx wrangler dev
+```
+
+Everything after `--` runs as a child process with all secrets in this Doppler config exported as env vars. The child sees `CF_AIG_TOKEN`, `DATABASE_URL`, etc. as if they had been `export`ed.
+
+## Reading a single secret in a script
+
+```bash
+TOKEN=$(doppler secrets get CF_AIG_TOKEN --plain --scope .)
+```
+
+`--plain` strips the JSON wrapper. Use this only when piping into another tool (e.g. `wrangler secret put`). Never log `$TOKEN`.
+
+## Listing what's available without revealing values
+
+```bash
+doppler secrets --scope .                # names + last-modified, NO values
+doppler secrets --only-names --scope .   # just names
+```
+
+The Helm Doppler MCP (`crates/doppler_mcp`) exposes only this metadata view to agents — secret values never traverse the MCP boundary. If an agent needs a value, it must shell out to `doppler run` or `doppler secrets get` itself, with the user's local `doppler` auth.
+
+## Per-environment configs
+
+```
+helm/
+  ├─ dev          # local dev
+  ├─ staging      # staging deploy
+  └─ production   # prod deploy
+```
+
+Bind each worktree / CI environment to the right config:
+
+```bash
+doppler setup --scope . --project helm --config dev          # local
+doppler setup --scope . --project helm --config staging      # staging branch
+```
+
+CI uses a service token (`DOPPLER_TOKEN` env var) instead of `doppler login`:
+
+```yaml
+# GitHub Actions
+- run: doppler run -- npm run deploy
+  env:
+    DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_TOKEN }}
+```
+
+The service token is scoped to one config (e.g. `production`), so even if it leaks it cannot read other environments.
+
+## Adding a new secret
+
+```bash
+doppler secrets set CF_AIG_TOKEN --scope .
+# prompts for value, never echoed
+```
+
+Or from a file:
+
+```bash
+doppler secrets set CF_AIG_TOKEN < /path/to/token-file --scope .
+```
+
+After setting in `dev`, promote to `staging` / `production` via the Doppler dashboard or:
+
+```bash
+doppler secrets download --scope . --no-file --format json | \
+  doppler secrets upload --config staging
+```
+
+## Anti-patterns
+
+- Committing `.env`, `.env.local`, `.dev.vars` with real values. Block the PR — these go in `.gitignore`.
+- `export OPENAI_API_KEY=sk-...` in a shell rc file. Use Doppler.
+- Hardcoding a secret in `wrangler.toml`, `Cargo.toml`, `package.json`, or any source file. Block the PR.
+- `doppler run --project foo --config bar -- cmd` from a shared script. Use `--scope .` and rely on the bound config so different worktrees stay separated.
+- Logging `process.env` or `doppler secrets download` output to stdout / a log file.
+- Block any PR that adds a new `process.env.X` read without a corresponding `doppler secrets set X` documented in the PR or the project README.

--- a/templates/helm-starter-skills/drizzle-migration/SKILL.md
+++ b/templates/helm-starter-skills/drizzle-migration/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: drizzle-migration
+description: Define a Drizzle schema, generate a migration, and apply it to a Cloudflare D1 database via wrangler. Always commit the generated SQL alongside the schema change.
+roles: []
+tags: [drizzle, d1, cloudflare, migrations, sql]
+---
+
+# drizzle-migration
+
+This skill covers the end-to-end loop: change `schema.ts`, generate a SQL migration, apply it locally, apply it remotely, and ship the generated file in the same PR as the schema.
+
+## When to use
+
+- Adding, renaming, or dropping a table or column in a D1 database.
+- Adding an index or foreign key.
+- A reviewer asked "where's the migration?" on a schema change PR.
+
+## Required files
+
+```
+db/
+  schema.ts              # Drizzle schema — single source of truth
+  migrations/
+    0000_<slug>.sql      # generated, checked in
+    meta/
+      _journal.json      # generated, checked in
+drizzle.config.ts        # tells drizzle-kit where things live
+```
+
+## drizzle.config.ts
+
+```ts
+import type { Config } from "drizzle-kit";
+
+export default {
+  schema: "./db/schema.ts",
+  out: "./db/migrations",
+  dialect: "sqlite",
+  driver: "d1-http",
+} satisfies Config;
+```
+
+## Defining a table
+
+```ts
+// db/schema.ts
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const skills = sqliteTable("skills", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  description: text("description"),
+  tokenBudget: integer("token_budget").notNull().default(0),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+});
+```
+
+## Generate the migration
+
+```bash
+npx drizzle-kit generate
+```
+
+This writes a new `0000N_<slug>.sql` plus updates `meta/_journal.json`. **Read the generated SQL before committing** — drizzle-kit cannot read your mind on renames and will sometimes emit `DROP COLUMN` + `ADD COLUMN` instead of a rename.
+
+If a rename is wrong, hand-edit the generated SQL to use `ALTER TABLE ... RENAME COLUMN`. D1 supports it.
+
+## Apply locally (Miniflare-backed D1)
+
+```bash
+npx wrangler d1 migrations apply <DB_NAME> --local
+```
+
+`<DB_NAME>` matches `database_name` in `wrangler.toml`:
+
+```toml
+[[d1_databases]]
+binding = "DB"
+database_name = "helm-prod"
+database_id = "<uuid>"
+migrations_dir = "db/migrations"
+```
+
+## Apply remotely
+
+```bash
+npx wrangler d1 migrations apply <DB_NAME> --remote
+```
+
+Run this from CI on merge to `main`, not from a developer laptop. See the `wrangler-deploy` skill for the GitHub Actions wiring.
+
+## Commit checklist
+
+- [ ] `db/schema.ts` reflects the desired final state.
+- [ ] `db/migrations/000N_<slug>.sql` is checked in.
+- [ ] `db/migrations/meta/_journal.json` is checked in.
+- [ ] The generated SQL has been read and is correct (especially renames).
+- [ ] Local apply succeeded against a fresh D1.
+- [ ] PR description names the migration file by number, e.g. "Adds migration `0007_add_skills_token_budget.sql`".
+
+## Anti-patterns
+
+- Editing a previously-shipped migration. Once `0000N_*.sql` lands on `main`, it is immutable. Add `0000N+1_*.sql` instead.
+- Running `wrangler d1 execute` with raw SQL to "fix" a schema drift. The next migration apply will fail. Always go through drizzle-kit.
+- Committing schema changes without the generated SQL. Block the PR.
+- Letting a destructive migration (`DROP TABLE`, `DROP COLUMN`) merge without a one-line note in the PR description explaining the data path.

--- a/templates/helm-starter-skills/template.toml
+++ b/templates/helm-starter-skills/template.toml
@@ -1,0 +1,4 @@
+name = "helm-starter-skills"
+description = "Five hand-authored starter skills covering AI Gateway routing, Drizzle migrations, wrangler deploy, Doppler-backed secrets, and warp new scaffolding."
+version = "0.1.0"
+author = "helm-team"

--- a/templates/helm-starter-skills/warp-new-scaffolding/SKILL.md
+++ b/templates/helm-starter-skills/warp-new-scaffolding/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: warp-new-scaffolding
+description: Scaffold a new project from a Helm template using `warp new <template>`. Covers variable prompts, `{{placeholder}}` substitution, post-init hooks, and what to do when a hook fails.
+roles: []
+tags: [warp, templates, scaffolding, cli, helm]
+---
+
+# warp-new-scaffolding
+
+`warp new <template>` instantiates a project from a template directory. The engine copies files, substitutes `{{variable}}` placeholders in paths and contents, and then runs declared post-init hooks (e.g. `git init`, `npm install`, `doppler setup`).
+
+Source crates: `crates/templates` (loader + substitution), `crates/template_hooks` (hook runner), `crates/warp_cli/src/new.rs` (CLI entry point).
+
+## When to use
+
+- Bootstrapping a new MCP server, Worker, or full-stack project from a vetted starter.
+- Adding a new template to `templates/` for others to use.
+
+## Discovering templates
+
+```bash
+warp new --list
+```
+
+Templates are loaded from:
+
+- `templates/` in the warp repo (built-ins like `helm-mcp-project`, `helm-starter-skills`).
+- `~/.warp/templates/` for user-installed templates.
+
+## Instantiating
+
+```bash
+warp new helm-mcp-project ./my-mcp
+```
+
+The CLI:
+
+1. Loads `templates/helm-mcp-project/template.toml`.
+2. Prompts for each variable in `[[variables]]` whose `required = true` and has no default.
+3. Walks the template tree, substituting `{{variable_name}}` in **both file paths and file contents**.
+4. Writes the result to `./my-mcp`.
+5. Runs each command in `[hooks].post_init` from `./my-mcp` in order. If any command exits non-zero, scaffolding aborts and the partial directory is left in place for inspection.
+
+Pass values non-interactively:
+
+```bash
+warp new helm-mcp-project ./my-mcp \
+  --var project_name=my-mcp \
+  --var author="Ada Lovelace"
+```
+
+## template.toml shape
+
+```toml
+name = "helm-worker"
+description = "Cloudflare Worker with D1, AI Gateway, and Doppler-backed secrets."
+version = "0.1.0"
+author = "helm-team"
+
+[[variables]]
+name = "project_name"
+description = "Slug used for the Worker name and the directory."
+required = true
+
+[[variables]]
+name = "author"
+description = "Author name for package.json."
+default = ""
+required = false
+
+[[variables]]
+name = "d1_database_name"
+description = "D1 binding database_name."
+default = "{{project_name}}-db"
+required = false
+
+[hooks]
+post_init = [
+  "git init",
+  "npm install",
+  "doppler setup --scope . --project {{project_name}} --config dev --no-interactive",
+  "git add -A",
+  "git commit -m 'chore: scaffolded from helm-worker template'",
+]
+```
+
+Variable defaults can themselves contain `{{placeholders}}` — they are resolved in declaration order.
+
+## Using placeholders inside template files
+
+In any text file under the template tree:
+
+```jsonc
+// package.json
+{
+  "name": "{{project_name}}",
+  "author": "{{author}}",
+  "scripts": {
+    "dev": "doppler run --scope . -- wrangler dev",
+    "deploy": "doppler run --scope . -- wrangler deploy"
+  }
+}
+```
+
+Placeholders also work in **paths**:
+
+```
+templates/helm-worker/
+  src/
+    {{project_name}}.ts
+```
+
+After instantiation that becomes `src/my-mcp.ts`.
+
+Unknown placeholders are left intact — the engine does not fail on them. This lets a parent template embed a nested `{{placeholder}}` that a downstream tool resolves.
+
+## When a post-init hook fails
+
+`warp new` prints the failing command and its exit code, then leaves the partial directory. Common fixes:
+
+- `git init` failed because the user is already inside a git repo with `--no-such-init` policy → cd into the new dir and run hooks manually.
+- `npm install` failed → run it manually after fixing the underlying network / auth issue. The scaffolded files are correct.
+- `doppler setup` failed because `doppler login` was never run → run `doppler login --yes --scope .` and retry the hook.
+
+Hooks are intentionally **not** retried automatically — silent retries would mask broken templates.
+
+## Authoring a new template
+
+1. Create `templates/<your-template>/template.toml` with `name`, `description`, `version`, and any `[[variables]]`.
+2. Drop the source files into `templates/<your-template>/`. Use `{{placeholder}}` syntax wherever a value should be substituted.
+3. Add `[hooks].post_init` entries for anything that must run after copy (init git, install deps, set up Doppler).
+4. Test with `warp new <your-template> /tmp/test-out --var ...` and read the diff.
+5. Add the template name to the integration test in `crates/templates/src/lib_tests.rs` if there is a smoke-test list.
+
+## Anti-patterns
+
+- Hardcoding the project name in `package.json` or `wrangler.toml` instead of using `{{project_name}}`. Block the PR — it defeats the template.
+- Putting real secrets in template files. Use `doppler setup` in `post_init` instead.
+- Adding a `post_init` hook that requires interactive input (`npm init` without `-y`, `git config` prompts). Hooks must be non-interactive — pass `--yes`, `--no-interactive`, redirect stdin from `/dev/null`, etc.
+- Adding a hook that talks to the network without an offline fallback path. If `npm install` is in `post_init`, the README must say so — don't surprise users.
+- Forgetting to declare a `[[variables]]` entry for a `{{placeholder}}` used in the template — the engine will leave the literal `{{name}}` in the output. Block the PR.

--- a/templates/helm-starter-skills/wrangler-deploy/SKILL.md
+++ b/templates/helm-starter-skills/wrangler-deploy/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: wrangler-deploy
+description: Deploy a Cloudflare Worker with wrangler, including secret bindings sourced from Doppler. Never commit secrets and never set them with raw values from a developer laptop.
+roles: []
+tags: [cloudflare, wrangler, deploy, secrets, doppler, ci]
+---
+
+# wrangler-deploy
+
+This skill covers deploying a Worker with `wrangler deploy`, plus the boundary between **runtime bindings** (declared in `wrangler.toml`), **secret bindings** (set via `wrangler secret put`), and **Doppler-backed local env** (see the `doppler-secret-fetch` skill).
+
+## When to use
+
+- Shipping a new Worker for the first time.
+- Adding a new secret a Worker reads from `env`.
+- Wiring up the GitHub Actions deploy job.
+
+## wrangler.toml — declare bindings, not values
+
+```toml
+name = "helm-api"
+main = "src/index.ts"
+compatibility_date = "2026-04-01"
+compatibility_flags = ["nodejs_compat"]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "helm-prod"
+database_id = "<uuid>"
+migrations_dir = "db/migrations"
+
+[[r2_buckets]]
+binding = "ARTIFACTS"
+bucket_name = "helm-artifacts"
+
+[ai]
+binding = "AI"
+
+[observability]
+enabled = true
+```
+
+Secrets do **not** appear here — only their names appear in code as `env.MY_SECRET`. The values are uploaded out-of-band.
+
+## Setting a secret (one-time, then on rotation)
+
+Never type a secret value into your shell. Pipe it from Doppler:
+
+```bash
+doppler secrets get CF_AIG_TOKEN --plain --scope . | \
+  npx wrangler secret put CF_AIG_TOKEN
+```
+
+Verify:
+
+```bash
+npx wrangler secret list
+```
+
+Output should show `CF_AIG_TOKEN` (name only, never value).
+
+## Local dev (`wrangler dev`)
+
+For local dev, secrets come from Doppler — not from `.dev.vars`:
+
+```bash
+doppler run --scope . -- npx wrangler dev
+```
+
+Doppler injects `CF_AIG_TOKEN`, `CF_ACCOUNT_ID`, etc. into the process env, and wrangler exposes process env as bindings during `wrangler dev`.
+
+If you must use `.dev.vars`, generate it from Doppler at session start and add it to `.gitignore`:
+
+```bash
+doppler secrets download --no-file --format env --scope . > .dev.vars
+```
+
+`.dev.vars` is gitignored. Never commit it.
+
+## Deploying
+
+```bash
+npx wrangler deploy
+```
+
+For multi-environment:
+
+```bash
+npx wrangler deploy --env production
+npx wrangler deploy --env staging
+```
+
+With `[env.production]` and `[env.staging]` blocks in `wrangler.toml`, each gets its own bindings. Secrets must be set per environment:
+
+```bash
+npx wrangler secret put CF_AIG_TOKEN --env production
+```
+
+## CI deploy (GitHub Actions)
+
+```yaml
+# .github/workflows/deploy.yml
+name: deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: Apply D1 migrations
+        run: npx wrangler d1 migrations apply helm-prod --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Deploy
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```
+
+The `CLOUDFLARE_API_TOKEN` only needs `Workers Scripts:Edit` + `D1:Edit` for the target account — do not use a global token.
+
+## Anti-patterns
+
+- `wrangler secret put X` and pasting the value at the prompt. Always pipe from Doppler.
+- Committing `.dev.vars`, `.env`, or any file containing a real secret value. Block the PR.
+- Hardcoding `CLOUDFLARE_API_TOKEN` in `wrangler.toml` or any code. It belongs in CI secrets only.
+- Deploying from a developer laptop to production. Production deploys go through CI on merge to `main`. Staging is fine to deploy locally for quick iteration.
+- Block any PR that adds a new `env.X` read in Worker code without (a) a `wrangler secret put X` step in the deploy runbook or (b) a binding in `wrangler.toml`.


### PR DESCRIPTION
## Summary

Closes the last open Phase A long-tail issue: **PDX-73 [A7.5] Five hand-written starter skills exercising real patterns**.

Adds `templates/helm-starter-skills/` with five hand-authored `SKILL.md` files, each in its own subdirectory:

| Skill ID                  | Pattern                                                                            |
| ------------------------- | ---------------------------------------------------------------------------------- |
| `ai-gateway-routing`      | Route every model call through Cloudflare AI Gateway `dynamic/*` routes.           |
| `drizzle-migration`       | Drizzle schema -> generate SQL -> `wrangler d1 migrations apply` (local + remote). |
| `wrangler-deploy`         | `wrangler deploy` + `wrangler secret put` piped from `doppler secrets get`.        |
| `doppler-secret-fetch`    | `doppler run --scope .` cwd-scoping, service tokens for CI, anti-patterns.         |
| `warp-new-scaffolding`    | `warp new <template>` variables, `{{placeholder}}` substitution, post-init hooks.  |

Each ends with a concrete **Anti-patterns** section listing specific behaviors to block in review, per the audit's guidance ("Block any PR that adds a feature flag without specifying who removes it." > "Be respectful.").

## Schema decisions

- Front matter uses the `SkillFrontMatter` shape from `crates/skills/src/lib.rs`: `name`, `description`, `roles`, `tags`. Runtime stats (`SkillMetadata` — `last_used`, `success_rate`, etc.) intentionally do **not** appear in front matter; they live in the separate `MetadataStore` JSON sidecar.
- `roles: []` for all five skills — empty means "applies to every role" per the loader's filter logic (`crates/skills/src/lib.rs:192`), which is correct for starter skills.
- Filename is `SKILL.md` (matches the `.agents/skills/` convention already used in this repo). The loader picks up any `*.md` so the name is just convention.
- Bundle ships with `template.toml` so it can also be instantiated via `warp new helm-starter-skills .agents/skills/`.

## Out of scope

- No changes to `crates/skills/` source — the schema is consumed, not modified.
- No new Rust modules, no new Cargo deps. Skills are content.

## Test plan

- [ ] Skills load: `SkillRegistry::load` with `repo_root = templates/helm-starter-skills` returns 5 entries.
- [ ] Front matter parses without YAML errors (verified by inspection — `roles: []` and inline `tags: [...]` are both valid YAML).
- [ ] Each `SKILL.md` is human-reviewable for accuracy: gateway endpoints, drizzle commands, wrangler flags, doppler scope flags, `warp new` flow.
- [ ] Bundle copy-installs cleanly: `cp -R templates/helm-starter-skills/*/ .agents/skills/` produces five new skill directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)