### PR TITLE
PDX-35 [A1.5] Compile-clean minimal client capstone

### DIFF
--- a/crates/doppler_mcp/src/metadata.rs
+++ b/crates/doppler_mcp/src/metadata.rs
@@ -87,7 +87,10 @@ impl MetadataClient {
 
     /// List all Doppler projects.  Runs `doppler projects list --json`.
     pub async fn list_projects(&self) -> Result<Vec<Project>, DopplerError> {
-        let output = self.runner.run(&["projects", "list", "--json"]).await?;
+        let output = self
+            .runner
+            .run(&["projects", "list", "--json"], None)
+            .await?;
         parse_projects(output)
     }
 
@@ -95,7 +98,7 @@ impl MetadataClient {
     pub async fn list_configs(&self, project: &str) -> Result<Vec<Config>, DopplerError> {
         let output = self
             .runner
-            .run(&["configs", "--project", project, "--json"])
+            .run(&["configs", "--project", project, "--json"], None)
             .await?;
         parse_configs(project, output)
     }
@@ -111,7 +114,10 @@ impl MetadataClient {
     ) -> Result<Vec<String>, DopplerError> {
         let output = self
             .runner
-            .run(&["secrets", "names", "--project", project, "--config", config])
+            .run(
+                &["secrets", "names", "--project", project, "--config", config],
+                None,
+            )
             .await?;
         parse_secret_names(project, output)
     }

--- a/crates/doppler_mcp/src/server.rs
+++ b/crates/doppler_mcp/src/server.rs
@@ -12,7 +12,7 @@ use rmcp::{
     model::{
         CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
     },
-    schemars, tool, tool_router,
+    schemars, tool, tool_handler, tool_router,
 };
 use serde::Deserialize;
 
@@ -128,6 +128,9 @@ impl ServerHandler for DopplerMcpServer {
             server_info: Implementation {
                 name: "doppler-mcp".to_string(),
                 version: env!("CARGO_PKG_VERSION").to_string(),
+                title: None,
+                icons: None,
+                website_url: None,
             },
             instructions: Some(
                 "Doppler metadata MCP server. \

--- a/crates/symphony/src/main.rs
+++ b/crates/symphony/src/main.rs
@@ -141,13 +141,13 @@ async fn resolve_api_key(spec: &str) -> Result<SecretValue, Box<dyn std::error::
             value: spec.to_string(),
         });
         let client = DopplerClient::with_runner(DEFAULT_TTL, runner);
-        return Ok(client.get("LINEAR_API_KEY").await?);
+        return Ok(client.get("LINEAR_API_KEY", None).await?);
     }
 
     match doppler::detect() {
         Ok(_) => {
             let client = DopplerClient::new(DEFAULT_TTL);
-            let v = client.get("LINEAR_API_KEY").await?;
+            let v = client.get("LINEAR_API_KEY", None).await?;
             Ok(v)
         }
         Err(DopplerError::NotInstalled { install_hint }) => Err(format!(
@@ -165,7 +165,11 @@ struct LiteralRunner {
 
 #[async_trait::async_trait]
 impl CommandRunner for LiteralRunner {
-    async fn run(&self, _args: &[&str]) -> std::io::Result<Output> {
+    async fn run(
+        &self,
+        _args: &[&str],
+        _cwd: Option<&std::path::Path>,
+    ) -> std::io::Result<Output> {
         use std::os::unix::process::ExitStatusExt;
         Ok(Output {
             status: std::process::ExitStatus::from_raw(0),

--- a/docs/build/minimal-client.md
+++ b/docs/build/minimal-client.md
@@ -1,0 +1,97 @@
+# Helm minimal-client build (PDX-35 / A1.5)
+
+The Helm fork ships a "minimal" build of `warp` that strips Warp's hosted
+backend surface (Firebase auth, warp-server GraphQL, oz.warp.dev hosted
+agents, RudderStack telemetry, hardcoded `*.warp.dev` URLs) and keeps only
+the local-first surface: terminal, blocks, settings, and the BYO-CLI
+agent track (`claude` / `codex` / `ollama` via the orchestrator crate).
+
+The cutover is gated by the `warp_hosted` Cargo feature on the `warp`
+binary. It is **on by default** (so an unmodified `cargo build` continues
+to produce upstream-equivalent Warp), and the Helm minimal build opts out
+via `--no-default-features`.
+
+## Build invocations
+
+Minimal Helm client (default Helm target):
+
+```sh
+cargo build -p warp --no-default-features
+```
+
+Upstream-compatible Warp build (rebaseable onto `warpdotdev/warp`):
+
+```sh
+cargo build -p warp                          # default features = warp_hosted ON
+# or, equivalent and explicit:
+cargo build -p warp --no-default-features --features warp_hosted
+```
+
+`cargo check` works identically for fast iteration:
+
+```sh
+cargo check -p warp --no-default-features    # minimal
+cargo check -p warp                          # upstream-equivalent
+cargo check --workspace                      # everything (default features)
+```
+
+## What `--no-default-features` strips
+
+Driven by sibling issues that landed before this capstone:
+
+- **PDX-31 [A1.1] Auth.** Firebase OAuth device flow, anonymous user
+  creation, `identitytoolkit.googleapis.com` calls, and the
+  `AuthClient` trait surface are gated behind `warp_hosted` in
+  `app/src/auth/**` and `crates/warp_core::warp_hosted`.
+- **PDX-32 [A1.2] Drive.** Cloud-side Drive surfaces (folder/object
+  metadata sync, ACLs, shared notebooks/workflows hydration through
+  warp-server) are gated. Local notebook/workflow hydration still
+  works via the local-only path covered by PDX-82.
+- **PDX-33 [A1.3] Telemetry.** RudderStack product analytics calls
+  removed from the `warp_hosted`-OFF path.
+- **PDX-34 [A1.4] Hosted Oz.** `oz.warp.dev` cloud-agents code paths
+  removed from the `warp_hosted`-OFF path. The Helm minimal build
+  uses the BYO-CLI agent surface from PDX-103 / PDX-104 / PDX-105
+  instead (Claude Code / Codex / Ollama through `crates/orchestrator`).
+- **PDX-78 [A1.7] Sentry replacement.** Soft dependency. Crash reporting
+  is governed by the separate `crash_reporting` Cargo feature, not by
+  `warp_hosted`. PDX-78 may land later without re-gating this build.
+
+## Verifying a build
+
+After a `--no-default-features` build, confirm:
+
+1. The binary launches and opens a terminal.
+2. The BYO-CLI flow works — typing `claude` / `codex` / `ollama` in the
+   terminal routes through `crates/orchestrator` to the local CLI.
+3. No outbound network calls to:
+   - `*.warp.dev`
+   - `oz.warp.dev`
+   - `identitytoolkit.googleapis.com`
+   - RudderStack endpoints
+   - Firebase endpoints
+
+   On macOS this can be checked with a 30-second `lsof -i -nP` or
+   `tcpdump` capture during normal interactive use.
+
+## Known caveats (not in scope for PDX-35)
+
+- The `wasm32-unknown-unknown` target currently fails to compile because
+  `arborium-sysroot` 2.13's `build.rs` invokes Apple `clang`, which on
+  stock Xcode does not have a wasm backend. This is an upstream-toolchain
+  issue tracked separately and is not on the minimal-client critical
+  path (the Helm minimal client targets native macOS first).
+- A small number of pre-existing dead-code warnings in
+  `app/src/auth/**` and `app/src/server/server_api/**` are emitted by
+  the `warp_hosted`-OFF path. They are expected — the gated trait
+  surface intentionally keeps the types alive so upstream merges stay
+  clean — and are not errors.
+
+## Tagging the verified build
+
+After the binary has been verified end-to-end, tag the commit:
+
+```sh
+git tag helm-v0.1-compile-clean
+git push origin helm-v0.1-compile-clean
+```


### PR DESCRIPTION
## Summary

PDX-35 verification gate — confirms the Helm minimal client compiles cleanly after the A1.x strips (PDX-31 auth, PDX-32 drive, PDX-33 telemetry, PDX-34 hosted-Oz) and the BYO-CLI agent track (PDX-103/104/105) all landed.

The `warp_hosted` Cargo feature was already in place (`app/Cargo.toml`, `crates/warp_core`, `crates/warp_server_client`) and `cargo check -p warp` was already clean for both `--no-default-features` and the default `warp_hosted`-ON build. This PR's actual work is fixing two unrelated workspace breakages exposed by `cargo check --workspace` and documenting the build invocation.

## What was actually broken

- `crates/symphony/src/main.rs` and `crates/doppler_mcp/src/metadata.rs` still called the pre-PDX-56 doppler API (`get(name)` / `run(args)`), missing the new `cwd: Option<&Path>` parameter. The symphony `LiteralRunner` impl was missing the same param on the trait.
- `crates/doppler_mcp/src/server.rs` did not import `tool_handler` from `rmcp` and was constructing `rmcp::model::Implementation` without the now-required `title` / `icons` / `website_url` fields.

## Files touched

- `crates/symphony/src/main.rs` — pass `None` for cwd; fix `CommandRunner::run` impl signature.
- `crates/doppler_mcp/src/metadata.rs` — pass `None` for cwd at three call sites.
- `crates/doppler_mcp/src/server.rs` — import `tool_handler`; populate the three new `Implementation` fields.
- `docs/build/minimal-client.md` (new) — documents the `--no-default-features` Helm build, the `warp_hosted`-ON upstream-equivalent build, what each strip removes, the network-audit acceptance criteria, and the tag step.

## What was already clean

- `warp_hosted` feature definitions in `app/Cargo.toml`, `crates/warp_core/Cargo.toml`, `crates/warp_server_client/Cargo.toml`.
- `default = [\"warp_hosted\", ...]` so upstream rebases are unaffected.
- All BYO-CLI orchestrator wiring (PDX-103/104/105) compiles cleanly under both feature combinations.
- All other workspace members (orchestrator, agents, doppler core, warpui, etc.) were already clean.

## Verified

- `cargo check -p warp --no-default-features` — clean (warnings only)
- `cargo check -p warp` — clean (warnings only)
- `cargo check --workspace` — clean (warnings only)

## Deferred (per PDX-35 hard constraints)

- `wasm32-unknown-unknown` build still fails on the pre-existing `arborium-sysroot` 2.13 toolchain issue (Apple clang has no wasm backend). The minimal client targets native macOS first; tracked separately.
- Dead-code warnings on the `warp_hosted`-OFF path in `app/src/auth/**` and `app/src/server/server_api/**` — intentional to keep the upstream merge surface alive.
- Sentry replacement (PDX-78) is a soft dependency and can land later.
- Tag `helm-v0.1-compile-clean` will be applied after a manual binary launch + 30-second `lsof` network audit per the issue's acceptance criteria.

## Test plan

- [ ] CI: `cargo check -p warp --no-default-features` green
- [ ] CI: `cargo check -p warp` green
- [ ] CI: `cargo check --workspace` green
- [ ] Manual: launch the `--no-default-features` binary on macOS, type `claude` / `codex` in the terminal, confirm the orchestrator routes correctly
- [ ] Manual: `lsof -i -nP` for ~30s of normal use shows zero connections to `*.warp.dev`, `oz.warp.dev`, `identitytoolkit.googleapis.com`, RudderStack, or Firebase
- [ ] After verification, tag `helm-v0.1-compile-clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)