### PR TITLE
PDX-21 [C5] Cloudflare Containers: agent-runtime Dockerfile + binding

### DIFF
--- a/cloudflare-control-plane/Dockerfile.agent-runtime
+++ b/cloudflare-control-plane/Dockerfile.agent-runtime
@@ -1,0 +1,106 @@
+# syntax=docker/dockerfile:1.7
+#
+# Helm agent-runtime container image
+#
+# This image is launched by the SessionDO (PDX-20) on Cloudflare Containers
+# whenever a new agent runtime session is created. It carries the CLIs that
+# Warp/Helm agents shell into (`claude`, `codex`), plus `git` and `gh` so the
+# container can clone a workspace repo and push commits back. The agent's
+# /workspace directory is intended to be mounted from R2 (see
+# docs/agent-runtime-container.md) by the lifecycle code in PDX-20.
+#
+# Build:
+#   ./scripts/build-agent-runtime.sh
+# Or directly:
+#   docker build -t helm/agent-runtime -f Dockerfile.agent-runtime .
+
+FROM ubuntu:24.04
+
+# ---- build args / labels ----------------------------------------------------
+ARG GIT_SHA=unknown
+ARG BUILD_DATE=unknown
+ARG CLAUDE_CODE_VERSION=latest
+ARG CODEX_VERSION=latest
+
+LABEL org.opencontainers.image.title="helm-agent-runtime" \
+      org.opencontainers.image.description="Helm agent runtime: claude + codex + git + gh on ubuntu 24.04" \
+      org.opencontainers.image.source="https://github.com/aloewright/warp" \
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      helm.component="agent-runtime" \
+      helm.git-sha="${GIT_SHA}"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PYTHONUNBUFFERED=1 \
+    NODE_ENV=production \
+    NPM_CONFIG_UPDATE_NOTIFIER=false \
+    NPM_CONFIG_FUND=false \
+    HELM_WORKSPACE=/workspace \
+    HELM_AGENT_USER=agent
+
+# ---- base packages ----------------------------------------------------------
+# Node.js 22.x via NodeSource (claude/codex CLIs are distributed via npm).
+# `gh` via the official GitHub CLI apt repo.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        jq \
+        locales \
+        openssh-client \
+        tini \
+        unzip \
+        xz-utils; \
+    locale-gen C.UTF-8; \
+    # Node.js 22.x
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash -; \
+    apt-get install -y --no-install-recommends nodejs; \
+    # GitHub CLI
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg; \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends gh; \
+    # Cleanup
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# ---- agent CLIs (claude code + codex) --------------------------------------
+# Both CLIs ship via npm. Pinning is parameterized via build args so the
+# control plane can rev them independently of the base image.
+RUN set -eux; \
+    npm install -g \
+        "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+        "@openai/codex@${CODEX_VERSION}"; \
+    # Smoke-check the binaries exist on PATH (versions may print to stderr).
+    command -v claude >/dev/null; \
+    command -v codex >/dev/null; \
+    npm cache clean --force
+
+# ---- non-root user ----------------------------------------------------------
+RUN set -eux; \
+    groupadd --system --gid 1001 "${HELM_AGENT_USER}"; \
+    useradd  --system --uid 1001 --gid 1001 \
+        --home-dir /home/"${HELM_AGENT_USER}" --create-home \
+        --shell /bin/bash "${HELM_AGENT_USER}"; \
+    mkdir -p "${HELM_WORKSPACE}"; \
+    chown -R "${HELM_AGENT_USER}:${HELM_AGENT_USER}" "${HELM_WORKSPACE}"
+
+# ---- entrypoint -------------------------------------------------------------
+COPY --chown=root:root scripts/agent-entrypoint.sh /usr/local/bin/agent-entrypoint
+RUN chmod 0755 /usr/local/bin/agent-entrypoint
+
+USER agent
+WORKDIR /workspace
+
+# tini reaps zombies and forwards signals; the entrypoint script handles
+# graceful shutdown on SIGTERM with a 30s grace window.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/agent-entrypoint"]
+CMD ["claude", "--help"]

--- a/cloudflare-control-plane/docs/agent-runtime-container.md
+++ b/cloudflare-control-plane/docs/agent-runtime-container.md
@@ -1,0 +1,95 @@
+# Helm agent-runtime container
+
+The agent-runtime container is the per-session execution environment that the
+`helm-agent-runtime` Worker spins up via Cloudflare Containers when a new
+agent session is created. It carries the agent CLIs (`claude`, `codex`),
+along with `git`, `gh`, and the workspace tooling needed for the agent to
+clone a repo, run, and push back changes.
+
+## Image
+
+- File: [`Dockerfile.agent-runtime`](../Dockerfile.agent-runtime)
+- Base: `ubuntu:24.04` (glibc, recent enough for both Node 22 and modern Git)
+- Installed:
+  - Node.js 22 (NodeSource)
+  - `@anthropic-ai/claude-code` (`claude`)
+  - `@openai/codex` (`codex`)
+  - `git`, `gh`, `curl`, `ca-certificates`, `jq`, `openssh-client`, `tini`
+- User: non-root `agent` (uid/gid 1001), workspace at `/workspace`
+- Entrypoint: [`scripts/agent-entrypoint.sh`](../scripts/agent-entrypoint.sh)
+  - Sources `/workspace/.env` if present
+  - Runs the requested CLI with unbuffered stdio for line-streaming
+  - On `SIGTERM`, forwards to the child and waits up to 30s before `SIGKILL`
+- Image is labelled with `helm.git-sha` for traceability.
+
+Build locally:
+
+```bash
+cd cloudflare-control-plane
+npm run build:container
+# or directly:
+./scripts/build-agent-runtime.sh
+```
+
+## Wrangler binding
+
+The image is wired into `wrangler.agent-runtime.toml` via a top-level
+`[[containers]]` block (see `cloudflare-control-plane/wrangler.agent-runtime.toml`):
+
+```toml
+[[containers]]
+name = "agent-runtime"
+image = "./Dockerfile.agent-runtime"
+max_instances = 50
+instance_type = "standard"
+```
+
+The `RuntimeSessionCoordinator` Durable Object (in
+`src/workers/agent-runtime.ts`) is the lifecycle owner — it owns the mapping
+from `sessionId` → container instance, starts/stops the container, and
+proxies requests in.
+
+## R2 workspace mount
+
+Each session's `/workspace` is logically backed by an R2 prefix scoped by
+`sessionId` so that work is durable across container restarts and so that
+checkpoints can be replayed.
+
+The intended flow (to be implemented as part of PDX-20 SessionDO lifecycle):
+
+1. **Session create** — DO allocates a session id and an R2 prefix
+   `sessions/<sessionId>/workspace/`.
+2. **Container start** — DO starts the container with environment variables
+   pointing at the R2 prefix:
+   - `HELM_R2_BUCKET=<bucket>`
+   - `HELM_R2_PREFIX=sessions/<sessionId>/workspace/`
+   - `HELM_R2_ACCESS_KEY_ID` / `HELM_R2_SECRET_ACCESS_KEY` (scoped, short-TTL)
+3. **Workspace hydrate** — entrypoint pulls the prefix into `/workspace`
+   on boot (rclone-style sync, TODO).
+4. **Checkpoint** — periodically (and on `SIGTERM` graceful shutdown) the
+   entrypoint flushes `/workspace` back to R2 as the next checkpoint.
+5. **Resume** — a follow-up session id can re-hydrate from the latest
+   checkpoint manifest.
+
+> Status: the Dockerfile and the binding ship in PDX-21. The R2 hydrate /
+> checkpoint loop and the DO-driven container lifecycle are TODO and will
+> land with PDX-20 (SessionDO) and the workspace-checkpoint task that
+> follows.
+
+## Lifecycle hooks (TODO — PDX-20)
+
+The DO will need to:
+
+- Call the Containers API to start a new instance keyed by `sessionId`.
+- Stream stdout/stderr from the container to the client (the Worker holds
+  the SSE/WebSocket; the DO is the source of truth for ordering).
+- Send `SIGTERM` on session end and rely on the entrypoint's 30s grace
+  window before forced shutdown.
+- Persist final checkpoint manifest to D1 (PDX-22) once the container exits.
+
+## Smoke test
+
+A vitest smoke test (`test/agent-runtime-container.test.ts`) builds the
+Dockerfile and verifies that both `claude --version` and `codex --version`
+resolve inside it. The test is automatically skipped when `docker` is not on
+the `PATH` (e.g. in CI runners that don't have Docker).

--- a/cloudflare-control-plane/package.json
+++ b/cloudflare-control-plane/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "helm": "tsx src/cli/helm.ts",
     "deploy:control-plane": "wrangler deploy -c wrangler.control-plane.toml",
-    "deploy:agent-runtime": "wrangler deploy -c wrangler.agent-runtime.toml"
+    "deploy:agent-runtime": "wrangler deploy -c wrangler.agent-runtime.toml",
+    "build:container": "bash scripts/build-agent-runtime.sh"
   },
   "dependencies": {
     "zod": "^3.23.8"

--- a/cloudflare-control-plane/scripts/agent-entrypoint.sh
+++ b/cloudflare-control-plane/scripts/agent-entrypoint.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Helm agent-runtime container entrypoint.
+#
+# Responsibilities:
+#   1. Source environment overrides from /workspace/.env if present
+#      (this is how the SessionDO/PDX-20 will inject per-session config).
+#   2. Exec the requested agent CLI command with stdout/stderr unbuffered
+#      so the Worker can stream events line-by-line back to the client.
+#   3. On SIGTERM, forward to the child and give it 30s to shut down
+#      gracefully before SIGKILL.
+#
+# Invocation:
+#   /usr/local/bin/agent-entrypoint <cmd> [args...]
+# Defaults to `claude --help` (set by Dockerfile CMD) so a bare `docker run`
+# is a quick smoke-test.
+
+set -euo pipefail
+
+WORKSPACE="${HELM_WORKSPACE:-/workspace}"
+GRACE_SECONDS="${HELM_SHUTDOWN_GRACE_SECONDS:-30}"
+
+# 1) Source per-session env if mounted from R2/DO.
+if [[ -f "${WORKSPACE}/.env" ]]; then
+  # shellcheck disable=SC1091
+  set -a
+  . "${WORKSPACE}/.env"
+  set +a
+fi
+
+# 2) Default to a no-op help command if nothing was passed.
+if [[ "$#" -eq 0 ]]; then
+  set -- claude --help
+fi
+
+# 3) Force unbuffered stdio for line-streaming.
+export PYTHONUNBUFFERED=1
+export NODE_NO_WARNINGS=1
+# stdbuf isn't available in distroless-style images; we rely on each CLI
+# auto-flushing when stdout is a pipe + Node's default line buffering.
+
+child_pid=0
+
+forward_signal() {
+  local sig="$1"
+  if [[ "${child_pid}" -gt 0 ]]; then
+    # Send the signal to the child; ignore failures if it already exited.
+    kill -s "${sig}" "${child_pid}" 2>/dev/null || true
+  fi
+}
+
+graceful_shutdown() {
+  echo "agent-entrypoint: received SIGTERM, forwarding and waiting up to ${GRACE_SECONDS}s" >&2
+  forward_signal TERM
+  # Give the child up to GRACE_SECONDS to exit cleanly.
+  local waited=0
+  while kill -0 "${child_pid}" 2>/dev/null; do
+    if (( waited >= GRACE_SECONDS )); then
+      echo "agent-entrypoint: grace period exceeded, sending SIGKILL" >&2
+      forward_signal KILL
+      break
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+}
+
+trap 'forward_signal INT' INT
+trap 'graceful_shutdown' TERM
+trap 'forward_signal HUP' HUP
+
+# Run the agent command in the background so the shell can keep handling
+# signals; then `wait` on it and propagate the exit code.
+"$@" &
+child_pid=$!
+
+# `wait` returns 128+signo if interrupted by a signal; loop until the
+# child actually exits so trap handlers can run to completion.
+set +e
+while true; do
+  wait "${child_pid}"
+  exit_code=$?
+  if ! kill -0 "${child_pid}" 2>/dev/null; then
+    break
+  fi
+done
+set -e
+
+exit "${exit_code}"

--- a/cloudflare-control-plane/scripts/build-agent-runtime.sh
+++ b/cloudflare-control-plane/scripts/build-agent-runtime.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Build the helm/agent-runtime container image and tag it with the current
+# git SHA. Intended to be run from the cloudflare-control-plane directory
+# (or via `npm run build:container`).
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+IMAGE_NAME="${HELM_AGENT_IMAGE:-helm/agent-runtime}"
+GIT_SHA="$(git rev-parse --short=12 HEAD 2>/dev/null || echo "unknown")"
+BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+CLAUDE_CODE_VERSION="${CLAUDE_CODE_VERSION:-latest}"
+CODEX_VERSION="${CODEX_VERSION:-latest}"
+
+echo "Building ${IMAGE_NAME} (sha=${GIT_SHA}, date=${BUILD_DATE})"
+
+docker build \
+  --file Dockerfile.agent-runtime \
+  --tag "${IMAGE_NAME}:${GIT_SHA}" \
+  --tag "${IMAGE_NAME}:latest" \
+  --build-arg "GIT_SHA=${GIT_SHA}" \
+  --build-arg "BUILD_DATE=${BUILD_DATE}" \
+  --build-arg "CLAUDE_CODE_VERSION=${CLAUDE_CODE_VERSION}" \
+  --build-arg "CODEX_VERSION=${CODEX_VERSION}" \
+  .
+
+echo
+echo "Built ${IMAGE_NAME}:${GIT_SHA}"
+echo "Tagged ${IMAGE_NAME}:latest"

--- a/cloudflare-control-plane/test/agent-runtime-container.test.ts
+++ b/cloudflare-control-plane/test/agent-runtime-container.test.ts
@@ -1,0 +1,69 @@
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, "..");
+const dockerfile = resolve(projectRoot, "Dockerfile.agent-runtime");
+
+function dockerAvailable(): boolean {
+  try {
+    execSync("docker version --format '{{.Server.Version}}'", {
+      stdio: "ignore"
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const describeIfDocker = dockerAvailable() ? describe : describe.skip;
+
+describe("agent-runtime Dockerfile", () => {
+  it("exists at the expected path", () => {
+    expect(existsSync(dockerfile)).toBe(true);
+  });
+});
+
+describeIfDocker("agent-runtime container build (docker required)", () => {
+  // Building Ubuntu + Node + npm globals takes a few minutes on a cold cache.
+  const tag = "helm/agent-runtime:vitest";
+
+  it(
+    "builds and exposes claude + codex on PATH",
+    () => {
+      const build = spawnSync(
+        "docker",
+        [
+          "build",
+          "--file",
+          dockerfile,
+          "--tag",
+          tag,
+          "--build-arg",
+          "GIT_SHA=vitest",
+          projectRoot
+        ],
+        { stdio: "inherit" }
+      );
+      expect(build.status).toBe(0);
+
+      const claude = spawnSync(
+        "docker",
+        ["run", "--rm", tag, "claude", "--version"],
+        { encoding: "utf8" }
+      );
+      expect(claude.status).toBe(0);
+
+      const codex = spawnSync(
+        "docker",
+        ["run", "--rm", tag, "codex", "--version"],
+        { encoding: "utf8" }
+      );
+      expect(codex.status).toBe(0);
+    },
+    10 * 60 * 1000
+  );
+});

--- a/cloudflare-control-plane/wrangler.agent-runtime.toml
+++ b/cloudflare-control-plane/wrangler.agent-runtime.toml
@@ -6,6 +6,16 @@ compatibility_flags = ["nodejs_compat"]
 [durable_objects]
 bindings = [{ name = "RUNTIME_SESSION_COORDINATOR", class_name = "RuntimeSessionCoordinator" }]
 
+# Agent runtime container — built from ./Dockerfile.agent-runtime.
+# Lifecycle is owned by the RuntimeSessionCoordinator DO (PDX-20):
+# the DO starts/stops one container instance per agent session and
+# streams stdout/stderr back through the Worker.
+[[containers]]
+name = "agent-runtime"
+image = "./Dockerfile.agent-runtime"
+max_instances = 50
+instance_type = "standard"
+
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["RuntimeSessionCoordinator"]


### PR DESCRIPTION
## Summary

PDX-21 [C5] — base **agent-runtime** container image + Cloudflare Containers wiring.

- `cloudflare-control-plane/Dockerfile.agent-runtime` — Ubuntu 24.04 (glibc) + Node 22 + `claude` (`@anthropic-ai/claude-code`) + `codex` (`@openai/codex`) + `git` + `gh` + `curl` + `ca-certificates`. Non-root `agent` user, `/workspace`, `tini`. Image labelled with `helm.git-sha` for traceability.
- `cloudflare-control-plane/scripts/agent-entrypoint.sh` — sources `/workspace/.env`, runs the agent CLI with unbuffered stdio for line-streaming, forwards `SIGTERM` to the child and waits up to 30s before `SIGKILL`.
- `cloudflare-control-plane/scripts/build-agent-runtime.sh` — `docker build` with the git SHA injected as a build arg, tags both `:<sha>` and `:latest`. Exposed as `npm run build:container`.
- `cloudflare-control-plane/wrangler.agent-runtime.toml` — adds the `[[containers]]` block (`name = "agent-runtime"`, `image = "./Dockerfile.agent-runtime"`, `max_instances = 50`, `instance_type = "standard"`).
- `cloudflare-control-plane/docs/agent-runtime-container.md` — documents the R2-backed `/workspace` mount + checkpoint flow as a TODO that the SessionDO (PDX-20) will own.
- `cloudflare-control-plane/test/agent-runtime-container.test.ts` — vitest smoke test that builds the Dockerfile and asserts `claude --version` + `codex --version` succeed inside it; auto-skips when `docker` is not on `PATH`.

The DO-driven container lifecycle (start/stop per session, stdout streaming, R2 hydrate/checkpoint) is intentionally **left as a TODO** and lands with PDX-20.

## Hard constraints respected

- Did not touch `wrangler.control-plane.toml` (PDX-22).
- Did not touch `src/workers/workflows/` (PDX-25).
- Did not touch `crates/` — TypeScript + Dockerfile only.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm test` — all 9 tests pass, including the live `docker build` of `helm/agent-runtime:vitest` and `claude --version` + `codex --version` smoke checks (~49s).
- [ ] Wrangler-side validation: `wrangler deploy -c wrangler.agent-runtime.toml --dry-run` once the Cloudflare Containers preview is enabled on the account.

## Decisions affecting downstream PRs

- **PDX-20 (SessionDO):** the `RuntimeSessionCoordinator` DO needs to (1) call the Containers API to start a container per `sessionId`, (2) inject `HELM_R2_*` env vars + write `/workspace/.env`, (3) stream stdout/stderr back through the Worker, and (4) send `SIGTERM` on session end and rely on the entrypoint's 30s grace.
- **PDX-19 (Workers route work into the container):** the agent-runtime Worker will resolve the DO by `sessionId` and proxy fetches into the container instance. The CLI surface inside the container is `claude` and `codex` on `PATH` — no shim needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)