### PR TITLE
PDX-26 [D3] Triggers and integrations: cron + GitHub webhook receiver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,6 +3458,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron_scheduler"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5487,6 +5499,25 @@ dependencies = [
  "libgit2-sys",
  "log",
  "url",
+]
+
+[[package]]
+name = "github_webhook_receiver"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "hex",
+ "hyper 1.8.1",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
 ]
 
 [[package]]
@@ -12682,8 +12713,10 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "cron_scheduler",
  "doppler",
  "futures-util",
+ "github_webhook_receiver",
  "liquid",
  "mockall",
  "orchestrator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ default-members = [
   "crates/skills",
   "crates/template_hooks",
   "crates/templates",
+  "crates/cron_scheduler",
+  "crates/github_webhook_receiver",
   "crates/sum_tree",
   "crates/symphony",
   "crates/warpui",
@@ -49,6 +51,8 @@ cloud_protocol = { path = "crates/cloud_protocol" }
 command = { path = "crates/command" }
 command-signatures-v2 = { path = "crates/command-signatures-v2" }
 computer_use = { path = "crates/computer_use" }
+cron_scheduler = { path = "crates/cron_scheduler" }
+github_webhook_receiver = { path = "crates/github_webhook_receiver" }
 doppler = { path = "crates/doppler" }
 doppler_mcp = { path = "crates/doppler_mcp" }
 field_mask = { path = "crates/field_mask" }

--- a/crates/cron_scheduler/Cargo.toml
+++ b/crates/cron_scheduler/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "cron_scheduler"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+chrono = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync", "time", "macros"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "test-util"] }

--- a/crates/cron_scheduler/src/lib.rs
+++ b/crates/cron_scheduler/src/lib.rs
@@ -1,0 +1,479 @@
+//! Local cron-like scheduler for the Symphony daemon (PDX-26 D3).
+//!
+//! Pure-Rust 5-field cron expression parser (`min hour dom mon dow`) plus a
+//! tokio-based driver that fires [`ScheduledTaskTriggered`] events on a
+//! [`tokio::sync::mpsc`] channel whenever a configured schedule matures.
+//!
+//! Designed to slot in next to Symphony's reconciliation tick — the driver
+//! runs as a separate tokio task and the receiver side emits structured
+//! events that the rest of Symphony (or downstream consumers in tests) can
+//! react to without coupling to the scheduler internals.
+//!
+//! ## Cron expression syntax
+//!
+//! Standard 5-field UTC expressions:
+//!
+//! ```text
+//! ┌───────────── minute        (0-59)
+//! │ ┌─────────── hour          (0-23)
+//! │ │ ┌───────── day of month  (1-31)
+//! │ │ │ ┌─────── month         (1-12)
+//! │ │ │ │ ┌───── day of week   (0-6, 0 = Sunday)
+//! │ │ │ │ │
+//! * * * * *
+//! ```
+//!
+//! Each field accepts: `*`, `N`, `A-B` ranges, `A,B,C` lists, `*/N` step
+//! values, and `A-B/N` step-over-range. Names (e.g. `MON`) are not
+//! supported — keep the syntax tight to keep the parser small. Per POSIX
+//! cron, when both day-of-month and day-of-week are restricted (neither is
+//! `*`), the schedule fires when EITHER matches — this matches the behavior
+//! of Vixie cron and `cron` crate.
+//!
+//! ## Why not pull in the `cron` crate?
+//!
+//! The workspace already has a long compile budget and we only need a tiny
+//! subset of cron semantics. A self-contained ~250-LOC parser keeps the
+//! Symphony binary lean and dependency-clean; if we ever need 6-field
+//! (with seconds) or named months we can swap in `cron` behind the same
+//! [`Schedule`] trait.
+
+#![deny(missing_docs)]
+
+use std::collections::BTreeSet;
+
+use chrono::{DateTime, Datelike, Duration as ChronoDuration, TimeZone, Timelike, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::mpsc;
+
+/// One event emitted whenever a cron schedule matures.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScheduledTaskTriggered {
+    /// Configured task name (e.g. `"nightly-dependency-bump"`).
+    pub name: String,
+    /// Original cron expression.
+    pub cron: String,
+    /// Opaque payload supplied by the operator at config time. Symphony's
+    /// trigger handler decides what this means (e.g. a Linear issue
+    /// template name or a webhook to fan out).
+    pub payload: serde_json::Value,
+    /// UTC timestamp at which the schedule fired.
+    pub fired_at: DateTime<Utc>,
+}
+
+/// Single configured cron job.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CronJob {
+    /// Human-readable name (unique within the scheduler).
+    pub name: String,
+    /// 5-field cron expression in UTC.
+    pub cron: String,
+    /// Opaque payload echoed back in the emitted event.
+    #[serde(default)]
+    pub payload: serde_json::Value,
+}
+
+/// Top-level cron scheduler configuration. Suitable for embedding in
+/// `WORKFLOW.md` front matter under `cron.jobs`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CronSchedulerConfig {
+    /// Configured jobs. Empty means the scheduler is a no-op.
+    #[serde(default)]
+    pub jobs: Vec<CronJob>,
+}
+
+/// Errors produced while parsing or running cron expressions.
+#[derive(Debug, Error)]
+pub enum CronError {
+    /// The expression doesn't have exactly five whitespace-separated fields.
+    #[error("invalid cron: expected 5 fields, got {0}")]
+    WrongFieldCount(usize),
+    /// A field contained a value outside its valid range.
+    #[error("invalid cron field `{field}`: {reason}")]
+    InvalidField {
+        /// Source of the offending field, e.g. `minute`.
+        field: &'static str,
+        /// Human-readable explanation.
+        reason: String,
+    },
+}
+
+/// A parsed 5-field cron expression. Fields hold the explicit set of valid
+/// integers for that position (so `*/15` in minutes becomes `{0,15,30,45}`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CronExpression {
+    minutes: BTreeSet<u32>,
+    hours: BTreeSet<u32>,
+    days_of_month: BTreeSet<u32>,
+    months: BTreeSet<u32>,
+    days_of_week: BTreeSet<u32>,
+    /// True iff both day-of-month and day-of-week fields are not `*`. In that
+    /// case Vixie cron semantics OR the two together; otherwise we AND.
+    dom_dow_or: bool,
+    /// Original input, kept for echo-back into events.
+    raw: String,
+}
+
+impl CronExpression {
+    /// Parse a 5-field cron expression.
+    pub fn parse(raw: &str) -> Result<Self, CronError> {
+        let fields: Vec<&str> = raw.split_whitespace().collect();
+        if fields.len() != 5 {
+            return Err(CronError::WrongFieldCount(fields.len()));
+        }
+        let minutes = parse_field(fields[0], 0, 59, "minute")?;
+        let hours = parse_field(fields[1], 0, 23, "hour")?;
+        let days_of_month = parse_field(fields[2], 1, 31, "day_of_month")?;
+        let months = parse_field(fields[3], 1, 12, "month")?;
+        let days_of_week = parse_field(fields[4], 0, 6, "day_of_week")?;
+        let dom_dow_or = fields[2] != "*" && fields[4] != "*";
+        Ok(Self {
+            minutes,
+            hours,
+            days_of_month,
+            months,
+            days_of_week,
+            dom_dow_or,
+            raw: raw.to_string(),
+        })
+    }
+
+    /// Compute the next UTC time after `after` (exclusive) at which this
+    /// schedule fires. Resolution is one minute. Returns `None` only if no
+    /// match exists within ~4 years (which can only happen for impossibly
+    /// constrained expressions — well-formed ones always match within a
+    /// year).
+    pub fn next_after(&self, after: DateTime<Utc>) -> Option<DateTime<Utc>> {
+        // Round up to the next whole minute (cron resolution is 1 min).
+        let mut t = after
+            .with_second(0)
+            .and_then(|x| x.with_nanosecond(0))
+            .unwrap_or(after);
+        t += ChronoDuration::minutes(1);
+
+        // Bounded scan: max ~4 years of minutes.
+        let max_iters: u64 = 60 * 24 * 366 * 4;
+        for _ in 0..max_iters {
+            if !self.months.contains(&t.month()) {
+                // Skip to the 1st of next month.
+                t = advance_to_next_month(t);
+                continue;
+            }
+            let dow = t.weekday().num_days_from_sunday();
+            let dom_match = self.days_of_month.contains(&t.day());
+            let dow_match = self.days_of_week.contains(&dow);
+            let day_match = if self.dom_dow_or {
+                dom_match || dow_match
+            } else {
+                dom_match && dow_match
+            };
+            if !day_match {
+                // Skip to start of next day.
+                t = advance_to_next_day(t);
+                continue;
+            }
+            if !self.hours.contains(&t.hour()) {
+                t = advance_to_next_hour(t);
+                continue;
+            }
+            if !self.minutes.contains(&t.minute()) {
+                t += ChronoDuration::minutes(1);
+                continue;
+            }
+            return Some(t);
+        }
+        None
+    }
+
+    /// Original raw expression text.
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+}
+
+fn advance_to_next_month(t: DateTime<Utc>) -> DateTime<Utc> {
+    let (y, m) = if t.month() == 12 {
+        (t.year() + 1, 1)
+    } else {
+        (t.year(), t.month() + 1)
+    };
+    Utc.with_ymd_and_hms(y, m, 1, 0, 0, 0).unwrap()
+}
+
+fn advance_to_next_day(t: DateTime<Utc>) -> DateTime<Utc> {
+    (t.date_naive() + ChronoDuration::days(1))
+        .and_hms_opt(0, 0, 0)
+        .map(|d| Utc.from_utc_datetime(&d))
+        .unwrap_or(t)
+}
+
+fn advance_to_next_hour(t: DateTime<Utc>) -> DateTime<Utc> {
+    t.with_minute(0).and_then(|x| x.with_second(0)).unwrap_or(t) + ChronoDuration::hours(1)
+}
+
+fn parse_field(
+    spec: &str,
+    min: u32,
+    max: u32,
+    field: &'static str,
+) -> Result<BTreeSet<u32>, CronError> {
+    let mut out = BTreeSet::new();
+    for part in spec.split(',') {
+        let (range_part, step) = match part.split_once('/') {
+            Some((r, s)) => {
+                let s_n: u32 = s.parse().map_err(|_| CronError::InvalidField {
+                    field,
+                    reason: format!("bad step `{s}`"),
+                })?;
+                if s_n == 0 {
+                    return Err(CronError::InvalidField {
+                        field,
+                        reason: "step must be > 0".into(),
+                    });
+                }
+                (r, s_n)
+            }
+            None => (part, 1),
+        };
+        let (lo, hi) = if range_part == "*" {
+            (min, max)
+        } else if let Some((a, b)) = range_part.split_once('-') {
+            let a_n: u32 = a.parse().map_err(|_| CronError::InvalidField {
+                field,
+                reason: format!("bad range start `{a}`"),
+            })?;
+            let b_n: u32 = b.parse().map_err(|_| CronError::InvalidField {
+                field,
+                reason: format!("bad range end `{b}`"),
+            })?;
+            (a_n, b_n)
+        } else {
+            let n: u32 = range_part.parse().map_err(|_| CronError::InvalidField {
+                field,
+                reason: format!("bad value `{range_part}`"),
+            })?;
+            (n, n)
+        };
+        if lo < min || hi > max || lo > hi {
+            return Err(CronError::InvalidField {
+                field,
+                reason: format!("range {lo}-{hi} outside [{min},{max}]"),
+            });
+        }
+        let mut v = lo;
+        while v <= hi {
+            out.insert(v);
+            // Saturating step add to avoid overflow on the last iteration.
+            v = match v.checked_add(step) {
+                Some(n) => n,
+                None => break,
+            };
+        }
+    }
+    if out.is_empty() {
+        return Err(CronError::InvalidField {
+            field,
+            reason: "no values matched".into(),
+        });
+    }
+    Ok(out)
+}
+
+/// Driver wrapping a set of [`CronJob`]s with a tokio task that fires
+/// [`ScheduledTaskTriggered`] events on the channel returned by [`Self::run`].
+pub struct CronScheduler {
+    jobs: Vec<(CronJob, CronExpression)>,
+}
+
+impl CronScheduler {
+    /// Construct a scheduler from config, eagerly validating every cron
+    /// expression so misconfigurations fail at startup.
+    pub fn from_config(config: &CronSchedulerConfig) -> Result<Self, CronError> {
+        let mut jobs = Vec::with_capacity(config.jobs.len());
+        for job in &config.jobs {
+            let expr = CronExpression::parse(&job.cron)?;
+            jobs.push((job.clone(), expr));
+        }
+        Ok(Self { jobs })
+    }
+
+    /// Number of configured jobs.
+    pub fn len(&self) -> usize {
+        self.jobs.len()
+    }
+
+    /// True if no jobs are configured.
+    pub fn is_empty(&self) -> bool {
+        self.jobs.is_empty()
+    }
+
+    /// Spawn the scheduler. Returns an mpsc receiver of trigger events plus
+    /// a oneshot sender that cancels the loop (drop the sender to also stop
+    /// the scheduler). The task exits on cancel and on receiver-dropped.
+    pub fn run(
+        self,
+    ) -> (
+        mpsc::Receiver<ScheduledTaskTriggered>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (tx, rx) = mpsc::channel(64);
+        let handle = tokio::spawn(async move {
+            self.run_loop(tx).await;
+        });
+        (rx, handle)
+    }
+
+    async fn run_loop(self, tx: mpsc::Sender<ScheduledTaskTriggered>) {
+        if self.jobs.is_empty() {
+            tracing::debug!("cron_scheduler: no jobs configured; exiting");
+            return;
+        }
+        // Track each job's next fire time independently so we always sleep
+        // until the earliest one matures.
+        let mut next: Vec<DateTime<Utc>> = self
+            .jobs
+            .iter()
+            .map(|(_, expr)| expr.next_after(Utc::now()).unwrap_or_else(far_future))
+            .collect();
+
+        loop {
+            // Find earliest next.
+            let (idx, &when) = match next.iter().enumerate().min_by_key(|(_, t)| **t) {
+                Some(p) => p,
+                None => return,
+            };
+            let now = Utc::now();
+            let delay = (when - now).max(ChronoDuration::zero());
+            let std_delay =
+                std::time::Duration::from_millis(delay.num_milliseconds().max(0) as u64);
+            tokio::time::sleep(std_delay).await;
+
+            let (job, expr) = &self.jobs[idx];
+            let event = ScheduledTaskTriggered {
+                name: job.name.clone(),
+                cron: job.cron.clone(),
+                payload: job.payload.clone(),
+                fired_at: Utc::now(),
+            };
+            if tx.send(event).await.is_err() {
+                tracing::debug!("cron_scheduler: receiver dropped; exiting");
+                return;
+            }
+            // Schedule next occurrence strictly after the one we just fired
+            // to avoid re-firing the same minute.
+            next[idx] = expr.next_after(when).unwrap_or_else(far_future);
+        }
+    }
+}
+
+fn far_future() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(9999, 1, 1, 0, 0, 0).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_star_minute() {
+        let e = CronExpression::parse("* * * * *").unwrap();
+        assert_eq!(e.minutes.len(), 60);
+        assert_eq!(e.hours.len(), 24);
+    }
+
+    #[test]
+    fn parse_step() {
+        let e = CronExpression::parse("*/15 * * * *").unwrap();
+        assert_eq!(
+            e.minutes.iter().copied().collect::<Vec<_>>(),
+            vec![0, 15, 30, 45]
+        );
+    }
+
+    #[test]
+    fn parse_range_and_list() {
+        let e = CronExpression::parse("0 9-17 * * 1,3,5").unwrap();
+        assert_eq!(e.minutes.iter().copied().collect::<Vec<_>>(), vec![0]);
+        assert_eq!(
+            e.hours.iter().copied().collect::<Vec<_>>(),
+            (9..=17).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            e.days_of_week.iter().copied().collect::<Vec<_>>(),
+            vec![1, 3, 5]
+        );
+    }
+
+    #[test]
+    fn parse_bad_field() {
+        assert!(CronExpression::parse("60 * * * *").is_err());
+        assert!(CronExpression::parse("* 24 * * *").is_err());
+        assert!(CronExpression::parse("* * 0 * *").is_err());
+        assert!(CronExpression::parse("* * * 13 *").is_err());
+        assert!(CronExpression::parse("* * * * 7").is_err());
+    }
+
+    #[test]
+    fn parse_wrong_field_count() {
+        assert!(matches!(
+            CronExpression::parse("* * * *"),
+            Err(CronError::WrongFieldCount(4))
+        ));
+    }
+
+    #[test]
+    fn next_after_every_minute() {
+        let e = CronExpression::parse("* * * * *").unwrap();
+        let t = Utc.with_ymd_and_hms(2026, 5, 1, 12, 0, 0).unwrap();
+        let n = e.next_after(t).unwrap();
+        assert_eq!(n, Utc.with_ymd_and_hms(2026, 5, 1, 12, 1, 0).unwrap());
+    }
+
+    #[test]
+    fn next_after_nightly() {
+        // 0 3 * * * → next 03:00 UTC.
+        let e = CronExpression::parse("0 3 * * *").unwrap();
+        let t = Utc.with_ymd_and_hms(2026, 5, 1, 12, 0, 0).unwrap();
+        let n = e.next_after(t).unwrap();
+        assert_eq!(n, Utc.with_ymd_and_hms(2026, 5, 2, 3, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn next_after_weekly_monday() {
+        // 0 9 * * 1 → next Monday 09:00 UTC. 2026-05-01 is a Friday.
+        let e = CronExpression::parse("0 9 * * 1").unwrap();
+        let t = Utc.with_ymd_and_hms(2026, 5, 1, 12, 0, 0).unwrap();
+        let n = e.next_after(t).unwrap();
+        assert_eq!(n, Utc.with_ymd_and_hms(2026, 5, 4, 9, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn next_after_dom_dow_or() {
+        // Vixie semantics: when both DoM and DoW are set, fires on EITHER.
+        // 0 0 1 * 0 → midnight on the 1st OR on Sundays.
+        let e = CronExpression::parse("0 0 1 * 0").unwrap();
+        // 2026-05-02 is Saturday 12:00. Next match is Sun 2026-05-03 00:00.
+        let t = Utc.with_ymd_and_hms(2026, 5, 2, 12, 0, 0).unwrap();
+        let n = e.next_after(t).unwrap();
+        assert_eq!(n, Utc.with_ymd_and_hms(2026, 5, 3, 0, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn scheduler_validates_jobs_at_construction() {
+        let cfg = CronSchedulerConfig {
+            jobs: vec![CronJob {
+                name: "bad".into(),
+                cron: "not-a-cron".into(),
+                payload: serde_json::Value::Null,
+            }],
+        };
+        assert!(CronScheduler::from_config(&cfg).is_err());
+    }
+
+    #[test]
+    fn scheduler_empty_is_ok() {
+        let s = CronScheduler::from_config(&CronSchedulerConfig::default()).unwrap();
+        assert!(s.is_empty());
+    }
+}

--- a/crates/github_webhook_receiver/Cargo.toml
+++ b/crates/github_webhook_receiver/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "github_webhook_receiver"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+axum = { workspace = true }
+chrono = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync", "time", "macros", "net"] }
+tower = { workspace = true }
+tower-http = { workspace = true, features = ["trace"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+hyper = { workspace = true, features = ["client", "http1"] }
+reqwest = { workspace = true }
+tokio = { workspace = true, features = [
+    "rt-multi-thread",
+    "macros",
+    "sync",
+    "time",
+    "net",
+    "test-util",
+] }

--- a/crates/github_webhook_receiver/src/lib.rs
+++ b/crates/github_webhook_receiver/src/lib.rs
@@ -1,0 +1,708 @@
+//! GitHub webhook receiver for the Symphony daemon (PDX-26 D3).
+//!
+//! Implements the `server` extension referenced by Symphony's spec §13.7:
+//! a small Axum HTTP server with HMAC-SHA256 signature validation that
+//! accepts GitHub webhook deliveries (`pull_request`,
+//! `pull_request_review`, `issues`, `push`) and forwards them as structured
+//! [`WebhookEvent`]s on a tokio mpsc channel.
+//!
+//! In addition to GitHub, two adjacent endpoints are exposed for symmetry
+//! with the Linear ticket scope:
+//!
+//! * `POST /webhook/slack`   — Slack-style HMAC (`v0=...`) verification.
+//! * `POST /webhook/generic` — generic signed POST → enqueue an arbitrary
+//!   payload, useful for in-house automation that shouldn't pretend to be
+//!   GitHub or Slack.
+//!
+//! The receiver intentionally does NOT touch Symphony state directly; it
+//! emits events on an mpsc channel and the daemon decides how to fan them
+//! out (typically: create-or-update a Linear issue, which Symphony picks up
+//! on the next poll tick — no new orchestrator state needed).
+//!
+//! ## Security
+//!
+//! * GitHub: validates `X-Hub-Signature-256` using the configured
+//!   `webhook_secret`. Constant-time comparison.
+//! * Slack: validates `X-Slack-Signature` against the v0 string scheme.
+//! * Generic: validates `X-Webhook-Signature` (hex-encoded HMAC-SHA256).
+//! * All signatures are verified BEFORE the JSON body is deserialized so
+//!   that malformed payloads can never reach event consumers without
+//!   passing crypto.
+//!
+//! ## Non-portable surface
+//!
+//! Tokio + Axum, so this crate is gated to non-WASM targets via the build
+//! graph (it's only a member of the host workspace, not the WASM bundle).
+
+#![deny(missing_docs)]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::Router;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio::sync::mpsc;
+
+/// Canonical event shape emitted by the receiver. The `kind` discriminant
+/// drives Symphony's translation into Linear issues / agent dispatches.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WebhookEvent {
+    /// `pull_request` event from GitHub. Action is one of `opened`,
+    /// `closed`, `reopened`, `synchronize`, etc.
+    GithubPullRequest {
+        /// PR action.
+        action: String,
+        /// Repository full name (`owner/repo`).
+        repo: String,
+        /// PR number.
+        number: u64,
+        /// PR title.
+        title: String,
+        /// PR HTML URL.
+        url: String,
+        /// `true` if the PR is now in `merged` state.
+        merged: bool,
+    },
+    /// `pull_request_review` event.
+    GithubPullRequestReview {
+        /// Review action (`submitted`, `edited`, `dismissed`).
+        action: String,
+        /// `approved`, `changes_requested`, or `commented`.
+        state: String,
+        /// Repository full name.
+        repo: String,
+        /// PR number.
+        number: u64,
+        /// Review HTML URL.
+        url: String,
+    },
+    /// `issues` event.
+    GithubIssue {
+        /// Issue action (`opened`, `closed`, `reopened`, etc).
+        action: String,
+        /// Repository full name.
+        repo: String,
+        /// Issue number.
+        number: u64,
+        /// Issue title.
+        title: String,
+        /// Issue HTML URL.
+        url: String,
+    },
+    /// `push` event.
+    GithubPush {
+        /// Repository full name.
+        repo: String,
+        /// Git ref pushed to (e.g. `refs/heads/main`).
+        ref_: String,
+        /// Number of commits in this push.
+        commits: u64,
+        /// Pushed-by user login.
+        pusher: String,
+    },
+    /// Slack slash command or event.
+    Slack {
+        /// `/foo` command name or event subtype.
+        command: String,
+        /// Channel ID.
+        channel: String,
+        /// User ID.
+        user: String,
+        /// Free-form text payload.
+        text: String,
+    },
+    /// Generic HMAC-signed payload — Symphony decides the schema.
+    Generic {
+        /// Raw JSON body, kept as a value so callers can pull what they want.
+        payload: serde_json::Value,
+    },
+}
+
+/// Wrapper carrying a [`WebhookEvent`] and a UTC timestamp marking when the
+/// receiver enqueued it. Useful for audit logging.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReceivedEvent {
+    /// Decoded event.
+    pub event: WebhookEvent,
+    /// When the event was received (server-side clock).
+    pub received_at: DateTime<Utc>,
+}
+
+/// Receiver configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReceiverConfig {
+    /// Address to bind. Defaults to `127.0.0.1:9278` (next port up from
+    /// the existing in-app HttpServer at 9277).
+    #[serde(default = "default_bind")]
+    pub bind: SocketAddr,
+    /// HMAC secret for `/webhook/github`. Empty disables the route.
+    #[serde(default)]
+    pub github_secret: String,
+    /// HMAC secret for `/webhook/slack`. Empty disables the route.
+    #[serde(default)]
+    pub slack_secret: String,
+    /// HMAC secret for `/webhook/generic`. Empty disables the route.
+    #[serde(default)]
+    pub generic_secret: String,
+}
+
+impl Default for ReceiverConfig {
+    fn default() -> Self {
+        Self {
+            bind: default_bind(),
+            github_secret: String::new(),
+            slack_secret: String::new(),
+            generic_secret: String::new(),
+        }
+    }
+}
+
+fn default_bind() -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], 9278))
+}
+
+/// Receiver errors.
+#[derive(Debug, Error)]
+pub enum ReceiverError {
+    /// Failure to bind the TCP listener.
+    #[error("bind {addr}: {source}")]
+    Bind {
+        /// Bound address that failed.
+        addr: SocketAddr,
+        /// Underlying io error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Axum serve loop exited unexpectedly.
+    #[error("serve error: {0}")]
+    Serve(#[from] std::io::Error),
+}
+
+/// Build an [`axum::Router`] for the configured receiver. Useful when a
+/// caller wants to compose this with their own router or with the existing
+/// `crates/http_server` entry point.
+pub fn router(config: ReceiverConfig, sender: mpsc::Sender<ReceivedEvent>) -> Router {
+    let state = Arc::new(AppState { config, sender });
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/webhook/github", post(github_handler))
+        .route("/webhook/slack", post(slack_handler))
+        .route("/webhook/generic", post(generic_handler))
+        .with_state(state)
+}
+
+/// Spawn the receiver on its configured bind address. Returns the bound
+/// address (useful when the caller passed `:0` to pick a port at random)
+/// plus a join handle.
+pub async fn serve(
+    config: ReceiverConfig,
+    sender: mpsc::Sender<ReceivedEvent>,
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), ReceiverError> {
+    let bind = config.bind;
+    let app = router(config, sender);
+    let listener = tokio::net::TcpListener::bind(bind)
+        .await
+        .map_err(|source| ReceiverError::Bind { addr: bind, source })?;
+    let local = listener
+        .local_addr()
+        .map_err(|source| ReceiverError::Bind { addr: bind, source })?;
+    let handle = tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, app).await {
+            tracing::warn!(error = %e, "github_webhook_receiver: serve loop exited");
+        }
+    });
+    Ok((local, handle))
+}
+
+#[derive(Clone)]
+struct AppState {
+    config: ReceiverConfig,
+    sender: mpsc::Sender<ReceivedEvent>,
+}
+
+async fn healthz() -> &'static str {
+    "ok"
+}
+
+async fn github_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    if state.config.github_secret.is_empty() {
+        return (StatusCode::FORBIDDEN, "github webhook disabled").into_response();
+    }
+    let sig = match headers
+        .get("x-hub-signature-256")
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(s) => s,
+        None => return (StatusCode::UNAUTHORIZED, "missing signature").into_response(),
+    };
+    let expected = format!(
+        "sha256={}",
+        hmac_sha256_hex(state.config.github_secret.as_bytes(), &body)
+    );
+    if !constant_time_eq(sig.as_bytes(), expected.as_bytes()) {
+        return (StatusCode::UNAUTHORIZED, "bad signature").into_response();
+    }
+    let event_type = headers
+        .get("x-github-event")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let parsed: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(_) => return (StatusCode::BAD_REQUEST, "invalid json").into_response(),
+    };
+    let event = match parse_github_event(event_type, &parsed) {
+        Some(e) => e,
+        None => {
+            // Unsupported but valid event type — ack with 202 so GitHub
+            // doesn't keep retrying, but don't enqueue.
+            return (StatusCode::ACCEPTED, "ignored").into_response();
+        }
+    };
+    enqueue(&state.sender, event).await
+}
+
+async fn slack_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    if state.config.slack_secret.is_empty() {
+        return (StatusCode::FORBIDDEN, "slack webhook disabled").into_response();
+    }
+    let sig = match headers
+        .get("x-slack-signature")
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(s) => s,
+        None => return (StatusCode::UNAUTHORIZED, "missing signature").into_response(),
+    };
+    let ts = match headers
+        .get("x-slack-request-timestamp")
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(s) => s,
+        None => return (StatusCode::UNAUTHORIZED, "missing timestamp").into_response(),
+    };
+    // Slack v0: HMAC-SHA256 over "v0:{timestamp}:{body}" with hex digest,
+    // then prefixed with "v0=".
+    let mut signing = Vec::with_capacity(4 + ts.len() + 1 + body.len());
+    signing.extend_from_slice(b"v0:");
+    signing.extend_from_slice(ts.as_bytes());
+    signing.push(b':');
+    signing.extend_from_slice(&body);
+    let expected = format!(
+        "v0={}",
+        hmac_sha256_hex(state.config.slack_secret.as_bytes(), &signing)
+    );
+    if !constant_time_eq(sig.as_bytes(), expected.as_bytes()) {
+        return (StatusCode::UNAUTHORIZED, "bad signature").into_response();
+    }
+    let parsed: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(_) => return (StatusCode::BAD_REQUEST, "invalid json").into_response(),
+    };
+    let command = parsed
+        .get("command")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let channel = parsed
+        .get("channel_id")
+        .or_else(|| parsed.get("channel"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let user = parsed
+        .get("user_id")
+        .or_else(|| parsed.get("user"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let text = parsed
+        .get("text")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    enqueue(
+        &state.sender,
+        WebhookEvent::Slack {
+            command,
+            channel,
+            user,
+            text,
+        },
+    )
+    .await
+}
+
+async fn generic_handler(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    if state.config.generic_secret.is_empty() {
+        return (StatusCode::FORBIDDEN, "generic webhook disabled").into_response();
+    }
+    let sig = match headers
+        .get("x-webhook-signature")
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(s) => s,
+        None => return (StatusCode::UNAUTHORIZED, "missing signature").into_response(),
+    };
+    let expected = hmac_sha256_hex(state.config.generic_secret.as_bytes(), &body);
+    if !constant_time_eq(sig.as_bytes(), expected.as_bytes()) {
+        return (StatusCode::UNAUTHORIZED, "bad signature").into_response();
+    }
+    let parsed: serde_json::Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(_) => return (StatusCode::BAD_REQUEST, "invalid json").into_response(),
+    };
+    enqueue(&state.sender, WebhookEvent::Generic { payload: parsed }).await
+}
+
+async fn enqueue(
+    sender: &mpsc::Sender<ReceivedEvent>,
+    event: WebhookEvent,
+) -> axum::response::Response {
+    let envelope = ReceivedEvent {
+        event,
+        received_at: Utc::now(),
+    };
+    match sender.send(envelope).await {
+        Ok(()) => (StatusCode::ACCEPTED, "queued").into_response(),
+        Err(_) => (StatusCode::SERVICE_UNAVAILABLE, "consumer disconnected").into_response(),
+    }
+}
+
+fn parse_github_event(event_type: &str, body: &serde_json::Value) -> Option<WebhookEvent> {
+    let repo = body
+        .pointer("/repository/full_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let action = body
+        .get("action")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    match event_type {
+        "pull_request" => {
+            let pr = body.get("pull_request")?;
+            Some(WebhookEvent::GithubPullRequest {
+                action,
+                repo,
+                number: pr.get("number").and_then(|v| v.as_u64()).unwrap_or(0),
+                title: pr
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                url: pr
+                    .get("html_url")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                merged: pr.get("merged").and_then(|v| v.as_bool()).unwrap_or(false),
+            })
+        }
+        "pull_request_review" => {
+            let pr = body.get("pull_request")?;
+            let review = body.get("review")?;
+            Some(WebhookEvent::GithubPullRequestReview {
+                action,
+                state: review
+                    .get("state")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                repo,
+                number: pr.get("number").and_then(|v| v.as_u64()).unwrap_or(0),
+                url: review
+                    .get("html_url")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            })
+        }
+        "issues" => {
+            let issue = body.get("issue")?;
+            Some(WebhookEvent::GithubIssue {
+                action,
+                repo,
+                number: issue.get("number").and_then(|v| v.as_u64()).unwrap_or(0),
+                title: issue
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                url: issue
+                    .get("html_url")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            })
+        }
+        "push" => Some(WebhookEvent::GithubPush {
+            repo,
+            ref_: body
+                .get("ref")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            commits: body
+                .get("commits")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len() as u64)
+                .unwrap_or(0),
+            pusher: body
+                .pointer("/pusher/name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        }),
+        _ => None,
+    }
+}
+
+/// Plain HMAC-SHA256 implemented over `sha2`. We avoid pulling in the
+/// `hmac` crate to keep the Symphony dep tree narrow — the construction is
+/// well-defined (RFC 2104) and tested against a known vector below.
+fn hmac_sha256_hex(key: &[u8], msg: &[u8]) -> String {
+    const BLOCK: usize = 64;
+    let mut k = [0u8; BLOCK];
+    if key.len() > BLOCK {
+        let h = Sha256::digest(key);
+        k[..h.len()].copy_from_slice(&h);
+    } else {
+        k[..key.len()].copy_from_slice(key);
+    }
+    let mut ipad = [0x36u8; BLOCK];
+    let mut opad = [0x5cu8; BLOCK];
+    for i in 0..BLOCK {
+        ipad[i] ^= k[i];
+        opad[i] ^= k[i];
+    }
+    let mut inner = Sha256::new();
+    inner.update(ipad);
+    inner.update(msg);
+    let inner_digest = inner.finalize();
+    let mut outer = Sha256::new();
+    outer.update(opad);
+    outer.update(inner_digest);
+    let out = outer.finalize();
+    hex::encode(out)
+}
+
+/// Constant-time byte slice equality. Returns `false` if lengths differ.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// HMAC-SHA256 known-answer test from RFC 4231 test case 1.
+    #[test]
+    fn hmac_sha256_rfc4231_case1() {
+        let key = [0x0bu8; 20];
+        let msg = b"Hi There";
+        let got = hmac_sha256_hex(&key, msg);
+        let want = "b0344c61d8db38535ca8afceaf0bf12b\
+                    881dc200c9833da726e9376c2e32cff7";
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn constant_time_eq_basic() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+    }
+
+    #[test]
+    fn parse_pull_request_event() {
+        let body = serde_json::json!({
+            "action": "opened",
+            "repository": { "full_name": "octo/repo" },
+            "pull_request": {
+                "number": 42,
+                "title": "Add cool feature",
+                "html_url": "https://github.com/octo/repo/pull/42",
+                "merged": false,
+            }
+        });
+        let ev = parse_github_event("pull_request", &body).unwrap();
+        match ev {
+            WebhookEvent::GithubPullRequest {
+                action,
+                repo,
+                number,
+                title,
+                merged,
+                ..
+            } => {
+                assert_eq!(action, "opened");
+                assert_eq!(repo, "octo/repo");
+                assert_eq!(number, 42);
+                assert_eq!(title, "Add cool feature");
+                assert!(!merged);
+            }
+            _ => panic!("expected GithubPullRequest"),
+        }
+    }
+
+    #[test]
+    fn parse_unknown_event_returns_none() {
+        let body = serde_json::json!({});
+        assert!(parse_github_event("ping", &body).is_none());
+    }
+
+    #[tokio::test]
+    async fn github_route_rejects_bad_signature() {
+        let (tx, _rx) = mpsc::channel(8);
+        let cfg = ReceiverConfig {
+            bind: SocketAddr::from(([127, 0, 0, 1], 0)),
+            github_secret: "topsecret".into(),
+            slack_secret: String::new(),
+            generic_secret: String::new(),
+        };
+        let app = router(cfg, tx);
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/webhook/github")
+            .header("x-hub-signature-256", "sha256=deadbeef")
+            .header("x-github-event", "ping")
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from("{}".to_string()))
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn github_route_disabled_when_secret_empty() {
+        let (tx, _rx) = mpsc::channel(8);
+        let cfg = ReceiverConfig::default();
+        let app = router(cfg, tx);
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/webhook/github")
+            .body(axum::body::Body::from("{}".to_string()))
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn generic_route_accepts_valid_signature() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let secret = "shh";
+        let body = b"{\"hello\":\"world\"}";
+        let sig = hmac_sha256_hex(secret.as_bytes(), body);
+        let cfg = ReceiverConfig {
+            bind: SocketAddr::from(([127, 0, 0, 1], 0)),
+            github_secret: String::new(),
+            slack_secret: String::new(),
+            generic_secret: secret.into(),
+        };
+        let app = router(cfg, tx);
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/webhook/generic")
+            .header("x-webhook-signature", sig)
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body.to_vec()))
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+        let received = rx.recv().await.expect("event enqueued");
+        match received.event {
+            WebhookEvent::Generic { payload } => {
+                assert_eq!(payload["hello"], "world");
+            }
+            _ => panic!("expected Generic"),
+        }
+    }
+
+    #[tokio::test]
+    async fn slack_route_validates_v0_signature() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let secret = "slackshh";
+        let body =
+            b"{\"command\":\"/deploy\",\"channel_id\":\"C1\",\"user_id\":\"U1\",\"text\":\"now\"}";
+        let ts = "1700000000";
+        let mut signing = Vec::new();
+        signing.extend_from_slice(b"v0:");
+        signing.extend_from_slice(ts.as_bytes());
+        signing.push(b':');
+        signing.extend_from_slice(body);
+        let sig = format!("v0={}", hmac_sha256_hex(secret.as_bytes(), &signing));
+        let cfg = ReceiverConfig {
+            bind: SocketAddr::from(([127, 0, 0, 1], 0)),
+            github_secret: String::new(),
+            slack_secret: secret.into(),
+            generic_secret: String::new(),
+        };
+        let app = router(cfg, tx);
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/webhook/slack")
+            .header("x-slack-signature", sig)
+            .header("x-slack-request-timestamp", ts)
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(body.to_vec()))
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+        let received = rx.recv().await.expect("event enqueued");
+        match received.event {
+            WebhookEvent::Slack {
+                command,
+                channel,
+                user,
+                text,
+            } => {
+                assert_eq!(command, "/deploy");
+                assert_eq!(channel, "C1");
+                assert_eq!(user, "U1");
+                assert_eq!(text, "now");
+            }
+            _ => panic!("expected Slack"),
+        }
+    }
+
+    #[tokio::test]
+    async fn healthz_works() {
+        let (tx, _rx) = mpsc::channel(8);
+        let app = router(ReceiverConfig::default(), tx);
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/healthz")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/crates/symphony/Cargo.toml
+++ b/crates/symphony/Cargo.toml
@@ -14,6 +14,8 @@ path = "src/main.rs"
 orchestrator = { workspace = true }
 agents = { workspace = true }
 doppler = { workspace = true }
+cron_scheduler = { workspace = true }
+github_webhook_receiver = { workspace = true }
 tokio = { workspace = true, features = [
     "rt-multi-thread",
     "macros",

--- a/crates/symphony/src/lib.rs
+++ b/crates/symphony/src/lib.rs
@@ -16,6 +16,7 @@ pub mod audit;
 pub mod diff_guard;
 pub mod orchestrator;
 pub mod tracker;
+pub mod triggers;
 pub mod workflow;
 pub mod workspace;
 
@@ -23,8 +24,9 @@ pub use audit::{AuditEvent, AuditLog};
 pub use diff_guard::{DiffGuard, DiffGuardError, DiffStat};
 pub use orchestrator::{Orchestrator, OrchestratorError};
 pub use tracker::{BlockerRef, Issue, LinearClient, TrackerError};
+pub use triggers::{spawn_triggers, TriggerError, TriggerSurfaces};
 pub use workflow::{
-    AgentConfig, HooksConfig, PollingConfig, TrackerConfig, WorkflowConfig, WorkflowDefinition,
-    WorkflowError, WorkspaceConfig,
+    AgentConfig, CronJobConfig, HooksConfig, PollingConfig, ServerConfig, TrackerConfig,
+    WebhookConfig, WorkflowConfig, WorkflowDefinition, WorkflowError, WorkspaceConfig,
 };
 pub use workspace::{Workspace, WorkspaceError, WorkspaceManager};

--- a/crates/symphony/src/main.rs
+++ b/crates/symphony/src/main.rs
@@ -90,6 +90,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let audit_path = home_dir().join(".warp/symphony/audit.log");
     let audit = Arc::new(AuditLog::open(audit_path));
 
+    // Spin up the optional `server` extension surfaces (cron triggers +
+    // GitHub/Slack/generic webhook receiver) before the orchestrator
+    // takes over the main task. These run in their own tokio tasks and
+    // never block the orchestrator. PDX-26 D3.
+    let trigger_surfaces = symphony::spawn_triggers(&workflow.config.server, audit.clone()).await;
+    if let Err(e) = &trigger_surfaces {
+        tracing::warn!(error = %e, "trigger surfaces failed to start; continuing without them");
+    }
+    if let Ok(s) = &trigger_surfaces {
+        if let Some(addr) = s.webhook_bind {
+            tracing::info!(%addr, "symphony: webhook receiver bound");
+        }
+        if s.cron_handle.is_some() {
+            tracing::info!("symphony: cron scheduler running");
+        }
+    }
+    // Move the surfaces into a guard so they aren't dropped (which would
+    // abort the JoinHandles). Even when shutdown happens via Ctrl-C, the
+    // tokio runtime tear-down handles cleanup.
+    let _trigger_guard = trigger_surfaces.ok();
+
     let orch = Arc::new(Orchestrator::new(
         workflow,
         Arc::new(tracker) as Arc<dyn IssueSource>,

--- a/crates/symphony/src/triggers.rs
+++ b/crates/symphony/src/triggers.rs
@@ -1,0 +1,294 @@
+//! Symphony trigger surfaces (PDX-26 D3).
+//!
+//! Two side-channels into the orchestrator that don't require new
+//! reconciliation state:
+//!
+//! 1. **Cron triggers** — local cron-like scheduler driven by
+//!    [`cron_scheduler`]. Fires [`cron_scheduler::ScheduledTaskTriggered`]
+//!    events on a tokio mpsc channel.
+//! 2. **GitHub / Slack / generic webhook receiver** — HMAC-validated
+//!    Axum HTTP server from [`github_webhook_receiver`] that emits
+//!    [`github_webhook_receiver::WebhookEvent`]s on a separate channel.
+//!
+//! Both event streams are funneled into the audit log so operators can
+//! confirm fan-out without standing up a real Linear ticket. The
+//! create-or-update-Linear-issue translation lives in a follow-up wire-up
+//! that lands once the receiver is exercised end-to-end (see PDX-25
+//! Workflows for the consumer side).
+
+use std::sync::Arc;
+
+use crate::audit::{AuditEvent, AuditEventKind, AuditLog};
+use crate::workflow::ServerConfig;
+use cron_scheduler::{
+    CronError, CronJob, CronScheduler, CronSchedulerConfig, ScheduledTaskTriggered,
+};
+use github_webhook_receiver::{ReceivedEvent, ReceiverConfig, ReceiverError, WebhookEvent};
+use tokio::sync::mpsc;
+
+/// Aggregate of trigger-related background tasks Symphony spawned at boot.
+/// Kept around so callers can join them on shutdown if desired.
+#[allow(dead_code)]
+pub struct TriggerSurfaces {
+    /// JoinHandle of the cron driver loop, if jobs were configured.
+    pub cron_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Address the webhook server bound to (only set if `server` config
+    /// supplied a non-empty bind).
+    pub webhook_bind: Option<std::net::SocketAddr>,
+    /// JoinHandle of the webhook server.
+    pub webhook_handle: Option<tokio::task::JoinHandle<()>>,
+    /// JoinHandle of the audit fan-out loop forwarding both streams into
+    /// the audit log.
+    pub fanout_handle: tokio::task::JoinHandle<()>,
+}
+
+/// Errors raised while spinning up the trigger surfaces.
+#[derive(Debug, thiserror::Error)]
+pub enum TriggerError {
+    /// Bad cron expression in the `cron.jobs` config.
+    #[error("cron config: {0}")]
+    Cron(#[from] CronError),
+    /// Webhook receiver bind failed.
+    #[error("webhook receiver: {0}")]
+    Webhook(#[from] ReceiverError),
+}
+
+/// Spawn the cron scheduler + webhook receiver based on the
+/// [`ServerConfig`] in the workflow front matter. Returns a
+/// [`TriggerSurfaces`] handle plus channel receivers if callers want to
+/// pre-empt the audit-log fan-out (tests).
+///
+/// `audit` is cloned into a small fan-out task so cron and webhook events
+/// land in the same audit log as orchestrator ticks.
+pub async fn spawn_triggers(
+    config: &ServerConfig,
+    audit: Arc<AuditLog>,
+) -> Result<TriggerSurfaces, TriggerError> {
+    // Cron.
+    let cron_config = CronSchedulerConfig {
+        jobs: config
+            .cron_jobs
+            .iter()
+            .map(|j| CronJob {
+                name: j.name.clone(),
+                cron: j.cron.clone(),
+                payload: j.payload.clone(),
+            })
+            .collect(),
+    };
+    let scheduler = CronScheduler::from_config(&cron_config)?;
+    let (cron_rx, cron_handle) = if scheduler.is_empty() {
+        (None, None)
+    } else {
+        let (rx, h) = scheduler.run();
+        (Some(rx), Some(h))
+    };
+
+    // Webhook receiver.
+    let (webhook_rx, webhook_bind, webhook_handle) =
+        if config.webhook.is_some() && webhook_enabled(config) {
+            let receiver_config = build_receiver_config(config);
+            let (tx, rx) = mpsc::channel::<ReceivedEvent>(64);
+            let (bound, handle) = github_webhook_receiver::serve(receiver_config, tx).await?;
+            tracing::info!(addr = %bound, "symphony: webhook receiver listening");
+            (Some(rx), Some(bound), Some(handle))
+        } else {
+            (None, None, None)
+        };
+
+    // Fan-out task: forward cron + webhook events into the audit log.
+    let fanout_handle = tokio::spawn(audit_fanout(cron_rx, webhook_rx, audit));
+
+    Ok(TriggerSurfaces {
+        cron_handle,
+        webhook_bind,
+        webhook_handle,
+        fanout_handle,
+    })
+}
+
+fn webhook_enabled(c: &ServerConfig) -> bool {
+    c.webhook
+        .as_ref()
+        .map(|w| {
+            !w.github_secret.is_empty()
+                || !w.slack_secret.is_empty()
+                || !w.generic_secret.is_empty()
+        })
+        .unwrap_or(false)
+}
+
+fn build_receiver_config(c: &ServerConfig) -> ReceiverConfig {
+    let w = c.webhook.as_ref().expect("webhook block presence checked");
+    ReceiverConfig {
+        bind: w.bind,
+        github_secret: w.github_secret.clone(),
+        slack_secret: w.slack_secret.clone(),
+        generic_secret: w.generic_secret.clone(),
+    }
+}
+
+async fn audit_fanout(
+    mut cron_rx: Option<mpsc::Receiver<ScheduledTaskTriggered>>,
+    mut webhook_rx: Option<mpsc::Receiver<ReceivedEvent>>,
+    audit: Arc<AuditLog>,
+) {
+    loop {
+        if cron_rx.is_none() && webhook_rx.is_none() {
+            return;
+        }
+        tokio::select! {
+            biased;
+            // Cron events.
+            ev = next_opt(cron_rx.as_mut()) => match ev {
+                Some(ev) => {
+                    let summary = format!(
+                        "cron `{}` fired ({} UTC)",
+                        ev.name,
+                        ev.fired_at.format("%Y-%m-%dT%H:%M:%SZ"),
+                    );
+                    tracing::info!(target: "symphony::cron", "{}", summary);
+                    audit.record(
+                        AuditEvent::new(AuditEventKind::Tick).with_message(summary),
+                    );
+                }
+                None => {
+                    cron_rx = None;
+                }
+            },
+            // Webhook events.
+            ev = next_opt(webhook_rx.as_mut()) => match ev {
+                Some(env) => {
+                    let summary = describe_webhook(&env.event);
+                    tracing::info!(target: "symphony::webhook", "{}", summary);
+                    audit.record(
+                        AuditEvent::new(AuditEventKind::Tick).with_message(summary),
+                    );
+                }
+                None => {
+                    webhook_rx = None;
+                }
+            },
+        }
+        if cron_rx.is_none() && webhook_rx.is_none() {
+            return;
+        }
+    }
+}
+
+/// Helper that turns `&mut Option<Receiver<T>>` into a future that yields
+/// `Option<T>` (and `None` when the channel is closed). Returns a future
+/// that never resolves when the option is `None`, so the `tokio::select!`
+/// branch is effectively disabled.
+async fn next_opt<T>(rx: Option<&mut mpsc::Receiver<T>>) -> Option<T> {
+    match rx {
+        Some(r) => r.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
+fn describe_webhook(ev: &WebhookEvent) -> String {
+    match ev {
+        WebhookEvent::GithubPullRequest {
+            action,
+            repo,
+            number,
+            title,
+            ..
+        } => format!("github PR {repo}#{number} {action}: {title}"),
+        WebhookEvent::GithubPullRequestReview {
+            action,
+            state,
+            repo,
+            number,
+            ..
+        } => format!("github PR review {repo}#{number} {action}/{state}"),
+        WebhookEvent::GithubIssue {
+            action,
+            repo,
+            number,
+            title,
+            ..
+        } => format!("github issue {repo}#{number} {action}: {title}"),
+        WebhookEvent::GithubPush {
+            repo,
+            ref_,
+            commits,
+            pusher,
+        } => format!("github push {repo} {ref_} ({commits} commit(s) by {pusher})"),
+        WebhookEvent::Slack {
+            command,
+            channel,
+            user,
+            ..
+        } => {
+            format!("slack {command} from {user} in {channel}")
+        }
+        WebhookEvent::Generic { .. } => "generic webhook".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow::{CronJobConfig, ServerConfig, WebhookConfig};
+    use std::net::SocketAddr;
+
+    #[tokio::test]
+    async fn empty_server_config_spawns_no_listeners() {
+        let cfg = ServerConfig::default();
+        let audit = Arc::new(AuditLog::open(
+            std::env::temp_dir().join(format!("symphony-test-{}.log", uuid::Uuid::new_v4())),
+        ));
+        let surfaces = spawn_triggers(&cfg, audit).await.unwrap();
+        assert!(surfaces.cron_handle.is_none());
+        assert!(surfaces.webhook_bind.is_none());
+        assert!(surfaces.webhook_handle.is_none());
+        // Fan-out should exit cleanly because both channels are absent.
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            surfaces.fanout_handle,
+        )
+        .await
+        .expect("fanout should exit promptly")
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn webhook_receiver_binds_when_secret_set() {
+        let cfg = ServerConfig {
+            cron_jobs: vec![],
+            webhook: Some(WebhookConfig {
+                bind: SocketAddr::from(([127, 0, 0, 1], 0)),
+                github_secret: "topsecret".into(),
+                slack_secret: String::new(),
+                generic_secret: String::new(),
+            }),
+        };
+        let audit = Arc::new(AuditLog::open(
+            std::env::temp_dir().join(format!("symphony-test-{}.log", uuid::Uuid::new_v4())),
+        ));
+        let surfaces = spawn_triggers(&cfg, audit).await.unwrap();
+        assert!(surfaces.webhook_bind.is_some(), "should bind a port");
+        // Tear down.
+        if let Some(h) = surfaces.webhook_handle {
+            h.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn cron_config_validation_fails_loudly() {
+        let cfg = ServerConfig {
+            cron_jobs: vec![CronJobConfig {
+                name: "bad".into(),
+                cron: "not-cron".into(),
+                payload: serde_json::Value::Null,
+            }],
+            webhook: None,
+        };
+        let audit = Arc::new(AuditLog::open(
+            std::env::temp_dir().join(format!("symphony-test-{}.log", uuid::Uuid::new_v4())),
+        ));
+        assert!(spawn_triggers(&cfg, audit).await.is_err());
+    }
+}

--- a/crates/symphony/src/workflow.rs
+++ b/crates/symphony/src/workflow.rs
@@ -39,6 +39,11 @@ pub struct WorkflowConfig {
     /// Agent dispatch knobs.
     #[serde(default)]
     pub agent: AgentConfig,
+    /// Optional `server` extension (PDX-26 D3): cron triggers and the
+    /// HMAC-validated webhook receiver. When omitted, neither surface
+    /// is started.
+    #[serde(default)]
+    pub server: ServerConfig,
 }
 
 /// Tracker block.
@@ -237,6 +242,56 @@ fn default_max_turns() -> usize {
 }
 fn default_agent_label_required() -> String {
     "agent:claude".to_string()
+}
+
+// ---------------------------------------------------------------------------
+// `server` extension — PDX-26 D3 (cron triggers + webhook receiver).
+// ---------------------------------------------------------------------------
+
+/// Optional `server` block for cron triggers and the GitHub/Slack/generic
+/// webhook receiver. Both sub-blocks are optional and independent.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ServerConfig {
+    /// Configured cron jobs (5-field UTC expressions). Empty disables.
+    #[serde(default)]
+    pub cron_jobs: Vec<CronJobConfig>,
+    /// Webhook receiver block. `None` disables the receiver entirely.
+    #[serde(default)]
+    pub webhook: Option<WebhookConfig>,
+}
+
+/// One cron-driven trigger.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CronJobConfig {
+    /// Job name, unique within the daemon.
+    pub name: String,
+    /// 5-field cron expression in UTC: `min hour dom mon dow`.
+    pub cron: String,
+    /// Opaque payload echoed back when the schedule fires; consumed by
+    /// downstream handlers (e.g. Linear-issue templates, agent kickoffs).
+    #[serde(default)]
+    pub payload: serde_json::Value,
+}
+
+/// Webhook receiver block.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookConfig {
+    /// Bind address. Defaults to `127.0.0.1:9278`.
+    #[serde(default = "default_webhook_bind")]
+    pub bind: std::net::SocketAddr,
+    /// HMAC secret for `/webhook/github`. Empty disables the route.
+    #[serde(default)]
+    pub github_secret: String,
+    /// HMAC secret for `/webhook/slack`. Empty disables the route.
+    #[serde(default)]
+    pub slack_secret: String,
+    /// HMAC secret for `/webhook/generic`. Empty disables the route.
+    #[serde(default)]
+    pub generic_secret: String,
+}
+
+fn default_webhook_bind() -> std::net::SocketAddr {
+    std::net::SocketAddr::from(([127, 0, 0, 1], 9278))
 }
 
 /// Errors raised by the workflow loader.


### PR DESCRIPTION
## Summary

Closes PDX-26 [D3] for the Helm M4 milestone. Adds two new trigger surfaces to the Symphony daemon that complement the existing Linear-poll loop without touching orchestrator state.

### Path chosen: A (local Symphony Rust)

Path A picked over Path B (Cloudflare Workers) because:

1. Symphony already owns the reconciliation tick and the audit log, so cron and webhook events land in the same observability stream as orchestrator events for free.
2. PDX-25 still owns Cloudflare Workflows — staying out of `cloudflare-control-plane/src/workers/workflows/` keeps the merge clean.
3. The webhook receiver emits structured `WebhookEvent`s on a tokio mpsc channel, which is exactly what PDX-25 Workflows can consume once they merge (the Cloudflare port is then a thin Worker that forwards the same event shape).
4. Helm phase D explicitly says local cron is sufficient and the Cloudflare port is deferred.

### Files added

- `crates/cron_scheduler/` — pure-Rust 5-field cron parser (`min hour dom mon dow`) with full Vixie semantics (DoM/DoW OR-vs-AND), tokio-driven loop emitting `ScheduledTaskTriggered` events on an mpsc channel. **11 unit tests.**
- `crates/github_webhook_receiver/` — Axum HTTP server with HMAC-SHA256 validation for `/webhook/github` (X-Hub-Signature-256), `/webhook/slack` (v0 scheme), and `/webhook/generic` (X-Webhook-Signature). Handles GitHub `pull_request`, `pull_request_review`, `issues`, and `push` events. Constant-time signature comparison. **9 unit tests** including an RFC 4231 HMAC known-answer test.
- `crates/symphony/src/triggers.rs` + workflow `ServerConfig` — wires both surfaces via Symphony's `main.rs`. Cron + webhook events fan out into the existing audit log so operators can confirm without a real Linear ticket.

### Files modified

- `Cargo.toml` — workspace members + dep entries for the two new crates.
- `crates/symphony/Cargo.toml` — adds `cron_scheduler` and `github_webhook_receiver` deps.
- `crates/symphony/src/{lib.rs,main.rs,workflow.rs}` — `ServerConfig`/`CronJobConfig`/`WebhookConfig` extension on `WORKFLOW.md` front matter; `spawn_triggers` invocation in `main` before the orchestrator loop starts.

### Out of scope (intentional)

- The Linear-issue create/update translation is left as a follow-up so this PR doesn't take a tracker dependency in test paths. The audit log fan-out gives end-to-end visibility today.
- Cloudflare port of either surface — file separately under M3 if needed (PDX-26 description out-of-scope).
- `crates/orchestrator/`, `crates/agents/`, `crates/cloud_protocol/` — untouched per process notes.
- `cloudflare-control-plane/src/workers/workflows/` — untouched (PDX-25 territory).

## Test plan

- [x] `cargo check -p cron_scheduler -p github_webhook_receiver -p symphony` — passes.
- [x] `cargo test -p cron_scheduler` — 11/11 pass (cron parser, scheduler).
- [x] `cargo test -p github_webhook_receiver` — 9/9 pass (HMAC RFC vector, signature rejection, all three routes).
- [x] `cargo test -p symphony` — 19/19 lib + 6/6 + 5/5 + 4/4 integration suites pass; pre-existing 1 ignored.
- [x] `cargo clippy -p cron_scheduler -p github_webhook_receiver --all-targets -- -D warnings` — clean. (Symphony clippy fails on a pre-existing `agents` crate lint, unrelated.)
- [x] `rustfmt --check` clean on the three new files.
- [ ] Manual: drive a real GitHub webhook through `/webhook/github` with a known signature once a PDX-26 deploy slot opens.

## Decisions for downstream tickets

**PDX-25 (Cloudflare Workflows)** — the receiver's `WebhookEvent` enum is the canonical envelope. If/when Workflows needs to react to PR open/merge events, it can either:
1. Subscribe directly to a future cloudflare-side Worker that re-emits the same enum, or
2. Read the audit log (Symphony already writes structured JSONL there).

I recommend option 1 long-term — it keeps the Worker side stateless. For now, no contract changes needed.

**PDX-29 (24/7 weekend soak)** — the cron scheduler is the natural driver. Drop a `WORKFLOW.md` front-matter block like:

```yaml
server:
  cron_jobs:
    - name: weekend-soak-pulse
      cron: "*/15 * * * *"
      payload: { kind: "soak_health_check" }
```

and the soak harness can listen on the audit log (or, once the Linear-issue translation lands, on a synthetic ticket Symphony creates per pulse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)