### PR TITLE
PDX-28 [D5] Auto-healing bounds: diff-size limit + test-deletion detection + audit log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,6 +1449,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_healing"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "regex",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12663,6 +12677,7 @@ version = "0.1.0"
 dependencies = [
  "agents",
  "async-trait",
+ "auto_healing",
  "chrono",
  "clap",
  "doppler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ resolver = "2"
 default-members = [
   "app",
   "crates/agents",
+  "crates/auto_healing",
   "crates/channel_versions",
   "crates/command",
   "crates/doppler",
@@ -40,6 +41,7 @@ publish = false
 # Local workspace crates. This lets us reference them in other crates without specifying a path.
 agents = { path = "crates/agents" }
 ai = { path = "crates/ai" }
+auto_healing = { path = "crates/auto_healing" }
 app-installation-detection = { path = "crates/app-installation-detection" }
 asset_cache = { path = "crates/asset_cache" }
 asset_macro = { path = "crates/asset_macro" }

--- a/crates/auto_healing/Cargo.toml
+++ b/crates/auto_healing/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "auto_healing"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+license.workspace = true
+publish.workspace = true
+
+# PDX-28 [D5] Auto-healing bounds.
+#
+# Helm-side guardrails layered on top of Symphony's retry/backoff/stall
+# detection. This crate is intentionally narrow: three pure-logic checks
+# (diff size, test-file deletion, production-deploy command gate), an
+# aggregate `GuardrailSet` that composes them, and an append-only audit
+# log used to record every guardrail trip.
+#
+# Symphony already owns one diff-size check + one JSONL audit log. The
+# logic in this crate is deliberately decoupled from the Symphony loop
+# so it can also be invoked from the in-process orchestrator dispatch
+# path in `app/src/ai/agent_sdk/driver/local_orchestrator.rs` for
+# non-Symphony agent sessions.
+
+[dependencies]
+chrono = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs", "process", "sync", "rt"] }
+tracing = { workspace = true }
+regex = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "test-util"] }

--- a/crates/auto_healing/src/audit_log.rs
+++ b/crates/auto_healing/src/audit_log.rs
@@ -1,0 +1,247 @@
+//! Append-only audit log for guardrail trips.
+//!
+//! Stores one JSON object per line. Append-only, never truncated by
+//! this code (rotation, if any, is the caller's problem). Failures are
+//! logged through `tracing` and never propagated, since the audit log
+//! is observability rather than load-bearing state.
+//!
+//! ## Schema
+//!
+//! Each line is a JSON object with keys:
+//!
+//! ```json
+//! {
+//!   "timestamp": "2026-05-02T12:34:56.789Z",
+//!   "task_id": "PDX-28",
+//!   "agent_id": "claude_code",
+//!   "rule": "diff_size",
+//!   "action": "blocked",
+//!   "offending_path": "tests/foo_test.rs",
+//!   "detail": "diff size 1234 lines exceeds configured cap of 500"
+//! }
+//! ```
+//!
+//! `task_id`, `agent_id`, `offending_path`, and `detail` are all
+//! optional. The schema mirrors the `audit.log` layout already produced
+//! by `crates/symphony/src/audit.rs` so a single tooling surface
+//! (`grep`, `jq`) covers both. SQLite mirroring (PDX-71 ledger pattern)
+//! is left as a follow-up gated behind `cfg(not(target_family =
+//! "wasm"))` once a queryable corpus is needed.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Categorical guardrail rule identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GuardrailRule {
+    /// [`crate::diff_size::DiffSizeCheck`] tripped.
+    DiffSize,
+    /// [`crate::test_deletion::TestDeletionCheck`] tripped.
+    TestDeletion,
+    /// [`crate::deploy_gate::DeployGate`] tripped.
+    DeployGate,
+}
+
+/// Action recorded against a guardrail trip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GuardrailAction {
+    /// Operation was blocked.
+    Blocked,
+    /// Operation was allowed despite the rule firing (override active).
+    Overridden,
+    /// Operation was allowed because no rule fired (recorded for audit
+    /// completeness on opt-in deployments).
+    Allowed,
+}
+
+/// One line in the audit log.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuditEntry {
+    /// When the trip was recorded.
+    pub timestamp: DateTime<Utc>,
+    /// Task / issue id, if available.
+    pub task_id: Option<String>,
+    /// Agent provider, if available.
+    pub agent_id: Option<String>,
+    /// Which rule fired.
+    pub rule: GuardrailRule,
+    /// What happened.
+    pub action: GuardrailAction,
+    /// Offending file path, if applicable (e.g. test-deletion).
+    pub offending_path: Option<String>,
+    /// Free-form detail (e.g. the human-readable block reason).
+    pub detail: Option<String>,
+}
+
+/// Append-only JSONL audit log. Thread-safe via an internal `Mutex`.
+pub struct AuditLog {
+    path: PathBuf,
+    file: Mutex<Option<std::fs::File>>,
+}
+
+impl AuditLog {
+    /// Open (or create) the log file at `path`. Best effort: if the
+    /// parent directory cannot be created, the writer falls back to a
+    /// no-op state and emits a `tracing::warn!` on the first attempted
+    /// write.
+    pub fn open(path: PathBuf) -> Self {
+        let file = match Self::open_inner(&path) {
+            Ok(f) => Some(f),
+            Err(e) => {
+                tracing::warn!(error = %e, path = %path.display(), "failed to open audit log");
+                None
+            }
+        };
+        Self {
+            path,
+            file: Mutex::new(file),
+        }
+    }
+
+    fn open_inner(path: &PathBuf) -> std::io::Result<std::fs::File> {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+    }
+
+    /// Append `entry` as a JSON line. Failures are logged, never
+    /// returned.
+    pub fn record(&self, entry: AuditEntry) {
+        let line = match serde_json::to_string(&entry) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to serialize audit entry");
+                return;
+            }
+        };
+        let mut guard = match self.file.lock() {
+            Ok(g) => g,
+            Err(e) => {
+                tracing::warn!(error = %e, "audit log mutex poisoned");
+                return;
+            }
+        };
+        if guard.is_none() {
+            // Try once to reopen; the parent directory may have appeared
+            // since `open()`.
+            if let Ok(f) = Self::open_inner(&self.path) {
+                *guard = Some(f);
+            }
+        }
+        if let Some(f) = guard.as_mut() {
+            if let Err(e) = writeln!(f, "{}", line) {
+                tracing::warn!(error = %e, "failed to write audit entry");
+            }
+        }
+    }
+
+    /// Path the log writes to. Useful for tests and tooling.
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(rule: GuardrailRule, detail: &str) -> AuditEntry {
+        AuditEntry {
+            timestamp: Utc::now(),
+            task_id: Some("PDX-28".into()),
+            agent_id: Some("claude_code".into()),
+            rule,
+            action: GuardrailAction::Blocked,
+            offending_path: None,
+            detail: Some(detail.into()),
+        }
+    }
+
+    #[test]
+    fn round_trip_entry() {
+        let e = entry(GuardrailRule::DiffSize, "too big");
+        let s = serde_json::to_string(&e).unwrap();
+        let back: AuditEntry = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, e);
+        // Wire format uses snake_case.
+        assert!(s.contains("\"rule\":\"diff_size\""));
+        assert!(s.contains("\"action\":\"blocked\""));
+    }
+
+    #[test]
+    fn append_writes_one_line_per_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.log");
+        let log = AuditLog::open(path.clone());
+        log.record(entry(GuardrailRule::DiffSize, "first"));
+        log.record(entry(GuardrailRule::TestDeletion, "second"));
+        log.record(entry(GuardrailRule::DeployGate, "third"));
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents.lines().count(), 3);
+        assert!(contents.contains("first"));
+        assert!(contents.contains("second"));
+        assert!(contents.contains("third"));
+
+        // Each line parses back to a valid AuditEntry.
+        for line in contents.lines() {
+            let _: AuditEntry = serde_json::from_str(line).expect("valid JSON line");
+        }
+    }
+
+    #[test]
+    fn append_creates_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested/dir/audit.log");
+        let log = AuditLog::open(path.clone());
+        log.record(entry(GuardrailRule::DiffSize, "hello"));
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("hello"));
+    }
+
+    #[test]
+    fn record_after_open_failure_is_noop() {
+        // Path that can't be created (the parent is a regular file).
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("not-a-dir");
+        std::fs::write(&blocker, b"sentinel").unwrap();
+        let path = blocker.join("audit.log");
+        let log = AuditLog::open(path.clone());
+        // Must not panic.
+        log.record(entry(GuardrailRule::DiffSize, "should be dropped"));
+        // Sentinel file is untouched.
+        assert_eq!(std::fs::read(&blocker).unwrap(), b"sentinel");
+    }
+
+    #[test]
+    fn append_is_strictly_additive() {
+        // Two `AuditLog` handles share the on-disk file but each holds
+        // its own descriptor in append mode. We never truncate.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.log");
+
+        let log1 = AuditLog::open(path.clone());
+        log1.record(entry(GuardrailRule::DiffSize, "a"));
+        drop(log1);
+
+        let log2 = AuditLog::open(path.clone());
+        log2.record(entry(GuardrailRule::TestDeletion, "b"));
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("\"a\""));
+        assert!(contents.contains("\"b\""));
+        assert_eq!(contents.lines().count(), 2);
+    }
+}

--- a/crates/auto_healing/src/deploy_gate.rs
+++ b/crates/auto_healing/src/deploy_gate.rs
@@ -1,0 +1,233 @@
+//! Production-deploy command gate (PDX-28 acceptance criterion 4).
+//!
+//! Intercepts shell commands the agent intends to run and refuses any
+//! command matching one of the configured "production deploy" regexes
+//! unless an explicit user override has been recorded.
+//!
+//! The default pattern set covers:
+//!
+//! * `wrangler deploy` (Cloudflare Workers)
+//! * `gh release create` (GitHub release publish)
+//! * `cargo publish` (crates.io publish)
+//! * `npm publish` (npm registry publish)
+//!
+//! Patterns are anchored at the start of the command line (after
+//! optional leading whitespace and an optional `sudo`/`env VAR=val`
+//! prefix), and case-insensitive on the executable name.
+
+use regex::RegexSet;
+
+/// Default production-deploy regex anchors.
+///
+/// Each regex is matched against the post-trimmed command line and is
+/// anchored with `^`. The shared `^(?:[a-zA-Z_][a-zA-Z0-9_]*=\S+\s+|sudo\s+)*`
+/// prefix (added when the regex set is constructed) tolerates leading
+/// `KEY=VAL` env exports and a leading `sudo`.
+pub const DEFAULT_DEPLOY_PATTERNS: &[&str] = &[
+    r"wrangler\s+deploy(\s|$)",
+    r"gh\s+release\s+create(\s|$)",
+    r"cargo\s+publish(\s|$)",
+    r"npm\s+publish(\s|$)",
+];
+
+const ENV_OR_SUDO_PREFIX: &str = r"^(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+|sudo\s+)*";
+
+/// Production deploy gate.
+#[derive(Debug, Clone)]
+pub struct DeployGate {
+    set: RegexSet,
+    /// When set, the gate behaves as a no-op (allow everything). Used
+    /// to record an explicit user override per PDX-28 (default deny;
+    /// human must approve).
+    override_active: bool,
+}
+
+impl Default for DeployGate {
+    fn default() -> Self {
+        Self::with_patterns(DEFAULT_DEPLOY_PATTERNS).expect("default patterns must compile")
+    }
+}
+
+impl DeployGate {
+    /// Build a gate from custom patterns.
+    pub fn with_patterns<I, S>(patterns: I) -> Result<Self, regex::Error>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        // Compose each pattern with the shared env/sudo-tolerant prefix.
+        let composed: Vec<String> = patterns
+            .into_iter()
+            .map(|p| format!("{}{}", ENV_OR_SUDO_PREFIX, p.as_ref()))
+            .collect();
+        let set = RegexSet::new(composed)?;
+        Ok(Self {
+            set,
+            override_active: false,
+        })
+    }
+
+    /// Activate an explicit user override. While active, every command
+    /// is allowed. Use this to record "yes, the human said run it".
+    pub fn with_override(mut self, on: bool) -> Self {
+        self.override_active = on;
+        self
+    }
+
+    /// Evaluate against `cmd`. The check is best-effort textual: it
+    /// does not parse the command line, so e.g. `bash -c "wrangler
+    /// deploy"` will not trip. The intent is to catch the *typical*
+    /// agent invocation, not to be a security boundary.
+    pub fn evaluate(&self, cmd: &str) -> DeployGateDecision {
+        if self.override_active {
+            return DeployGateDecision::Allow;
+        }
+        let trimmed = cmd.trim_start();
+        if self.set.is_match(trimmed) {
+            DeployGateDecision::Block {
+                reason: format!(
+                    "production-deploy command intercepted; explicit human approval required: `{}`",
+                    truncate(trimmed, 200)
+                ),
+            }
+        } else {
+            DeployGateDecision::Allow
+        }
+    }
+}
+
+/// Outcome of a [`DeployGate::evaluate`] call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeployGateDecision {
+    /// The command may proceed.
+    Allow,
+    /// The command must not run without explicit human approval.
+    Block {
+        /// Human-readable reason suitable for a Linear comment.
+        reason: String,
+    },
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.len() <= n {
+        s.to_string()
+    } else {
+        let mut end = n;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &s[..end])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allow_arbitrary_commands() {
+        let g = DeployGate::default();
+        for ok in [
+            "ls -la",
+            "cargo build",
+            "npm install",
+            "git commit -m foo",
+            "wrangler dev",
+            "wrangler tail",
+            "echo wrangler deploy",
+        ] {
+            assert_eq!(g.evaluate(ok), DeployGateDecision::Allow, "cmd: {ok}");
+        }
+    }
+
+    #[test]
+    fn block_wrangler_deploy() {
+        let g = DeployGate::default();
+        for bad in [
+            "wrangler deploy",
+            "wrangler deploy --env production",
+            "wrangler   deploy",
+            "  wrangler deploy --name my-worker",
+        ] {
+            assert!(
+                matches!(g.evaluate(bad), DeployGateDecision::Block { .. }),
+                "expected block for {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn block_gh_release_create() {
+        let g = DeployGate::default();
+        let bad = "gh release create v1.2.3 --notes ./RELEASE.md";
+        assert!(matches!(g.evaluate(bad), DeployGateDecision::Block { .. }));
+    }
+
+    #[test]
+    fn block_cargo_publish() {
+        let g = DeployGate::default();
+        for bad in ["cargo publish", "cargo publish --dry-run"] {
+            assert!(
+                matches!(g.evaluate(bad), DeployGateDecision::Block { .. }),
+                "expected block for {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn block_npm_publish() {
+        let g = DeployGate::default();
+        for bad in ["npm publish", "npm publish --access public"] {
+            assert!(
+                matches!(g.evaluate(bad), DeployGateDecision::Block { .. }),
+                "expected block for {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn tolerates_env_prefix() {
+        let g = DeployGate::default();
+        let bad = "CLOUDFLARE_API_TOKEN=xxx wrangler deploy --env production";
+        assert!(matches!(g.evaluate(bad), DeployGateDecision::Block { .. }));
+    }
+
+    #[test]
+    fn tolerates_sudo_prefix() {
+        let g = DeployGate::default();
+        let bad = "sudo npm publish";
+        assert!(matches!(g.evaluate(bad), DeployGateDecision::Block { .. }));
+    }
+
+    #[test]
+    fn override_disables_blocks() {
+        let g = DeployGate::default().with_override(true);
+        assert_eq!(
+            g.evaluate("wrangler deploy --env production"),
+            DeployGateDecision::Allow
+        );
+    }
+
+    #[test]
+    fn custom_patterns() {
+        let g = DeployGate::with_patterns(&[r"helm\s+upgrade(\s|$)"])
+            .unwrap();
+        assert!(matches!(
+            g.evaluate("helm upgrade prod ./charts"),
+            DeployGateDecision::Block { .. }
+        ));
+        // Defaults no longer apply because we replaced the set.
+        assert_eq!(g.evaluate("wrangler deploy"), DeployGateDecision::Allow);
+    }
+
+    #[test]
+    fn does_not_match_substring_inside_word() {
+        let g = DeployGate::default();
+        // `mywrangler deploy` should NOT match `wrangler deploy` because
+        // we anchor at start of the executable.
+        assert_eq!(
+            g.evaluate("mywrangler deploy"),
+            DeployGateDecision::Allow
+        );
+    }
+}

--- a/crates/auto_healing/src/diff_size.rs
+++ b/crates/auto_healing/src/diff_size.rs
@@ -1,0 +1,169 @@
+//! Diff-size guardrail.
+//!
+//! Refuses agent-produced diffs whose total `added + removed` line count
+//! exceeds a configured threshold. Intended for post-run evaluation
+//! once the agent has finished editing the workspace.
+//!
+//! Symphony already has a sibling implementation that shells out to
+//! `git diff --shortstat HEAD`. This crate accepts pre-parsed
+//! [`FileDiff`] records so callers can drive the check from any source
+//! (a `git diff --numstat` parse, an `rdiff` library, a direct in-memory
+//! buffer comparison, etc.) without forcing a `git` shell-out.
+
+use serde::{Deserialize, Serialize};
+
+/// One file's worth of diff statistics.
+///
+/// Per-file rather than per-hunk to keep the surface tiny — the
+/// guardrail only needs aggregate counts plus a path and a flag for
+/// "file was removed entirely".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileDiff {
+    /// Path of the file relative to the workspace root.
+    pub path: String,
+    /// Lines added in this diff.
+    pub added_lines: usize,
+    /// Lines removed in this diff.
+    pub removed_lines: usize,
+    /// `true` if the file is being removed by this commit (as opposed
+    /// to merely having lines deleted from it).
+    pub deleted: bool,
+}
+
+impl FileDiff {
+    /// Net change for this file (`added + removed`).
+    pub fn churn(&self) -> usize {
+        self.added_lines + self.removed_lines
+    }
+}
+
+/// Guardrail configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DiffSizeCheck {
+    /// Maximum allowed `added + removed` lines summed across every
+    /// file in the diff.
+    pub max_total_lines: usize,
+}
+
+impl DiffSizeCheck {
+    /// New check with `max_total_lines` cap.
+    pub fn new(max_total_lines: usize) -> Self {
+        Self { max_total_lines }
+    }
+
+    /// Evaluate the check against a slice of file diffs.
+    pub fn evaluate(&self, diffs: &[FileDiff]) -> DiffSizeDecision {
+        let total: usize = diffs.iter().map(FileDiff::churn).sum();
+        if total > self.max_total_lines {
+            DiffSizeDecision::Block {
+                reason: format!(
+                    "diff size {} lines exceeds configured cap of {} lines",
+                    total, self.max_total_lines
+                ),
+            }
+        } else {
+            DiffSizeDecision::Allow { total_lines: total }
+        }
+    }
+}
+
+/// Outcome of a [`DiffSizeCheck`] evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiffSizeDecision {
+    /// Diff was at or below the configured cap.
+    Allow {
+        /// Total observed `added + removed`.
+        total_lines: usize,
+    },
+    /// Diff exceeded the cap.
+    Block {
+        /// Human-readable explanation suitable for a Linear comment.
+        reason: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn diff(path: &str, add: usize, rem: usize) -> FileDiff {
+        FileDiff {
+            path: path.into(),
+            added_lines: add,
+            removed_lines: rem,
+            deleted: false,
+        }
+    }
+
+    #[test]
+    fn empty_diff_allows() {
+        let check = DiffSizeCheck::new(100);
+        let decision = check.evaluate(&[]);
+        assert_eq!(decision, DiffSizeDecision::Allow { total_lines: 0 });
+    }
+
+    #[test]
+    fn under_cap_allows() {
+        let check = DiffSizeCheck::new(500);
+        let diffs = vec![diff("a.rs", 100, 0), diff("b.rs", 200, 50)];
+        let decision = check.evaluate(&diffs);
+        assert_eq!(decision, DiffSizeDecision::Allow { total_lines: 350 });
+    }
+
+    #[test]
+    fn at_cap_allows() {
+        // Boundary: exactly at the cap is fine.
+        let check = DiffSizeCheck::new(500);
+        let diffs = vec![diff("a.rs", 250, 250)];
+        let decision = check.evaluate(&diffs);
+        assert_eq!(decision, DiffSizeDecision::Allow { total_lines: 500 });
+    }
+
+    #[test]
+    fn one_over_cap_blocks() {
+        // Boundary: cap + 1 trips.
+        let check = DiffSizeCheck::new(500);
+        let diffs = vec![diff("a.rs", 251, 250)];
+        let decision = check.evaluate(&diffs);
+        match decision {
+            DiffSizeDecision::Block { reason } => {
+                assert!(reason.contains("501"), "reason: {reason}");
+                assert!(reason.contains("500"), "reason: {reason}");
+            }
+            _ => panic!("expected block"),
+        }
+    }
+
+    #[test]
+    fn cap_zero_blocks_any_change() {
+        let check = DiffSizeCheck::new(0);
+        let diffs = vec![diff("a.rs", 1, 0)];
+        assert!(matches!(
+            check.evaluate(&diffs),
+            DiffSizeDecision::Block { .. }
+        ));
+        // Empty diff still allowed at cap=0.
+        assert_eq!(
+            check.evaluate(&[]),
+            DiffSizeDecision::Allow { total_lines: 0 }
+        );
+    }
+
+    #[test]
+    fn aggregates_across_many_files() {
+        let check = DiffSizeCheck::new(50);
+        let diffs: Vec<_> = (0..10).map(|i| diff(&format!("f{i}.rs"), 6, 0)).collect();
+        // total = 60, cap = 50 → block.
+        match check.evaluate(&diffs) {
+            DiffSizeDecision::Block { reason } => {
+                assert!(reason.contains("60"));
+            }
+            _ => panic!("expected block"),
+        }
+    }
+
+    #[test]
+    fn churn_helper() {
+        assert_eq!(diff("x", 3, 4).churn(), 7);
+    }
+}

--- a/crates/auto_healing/src/lib.rs
+++ b/crates/auto_healing/src/lib.rs
@@ -1,0 +1,352 @@
+//! PDX-28 [D5] auto-healing bounds.
+//!
+//! Helm-side guardrails layered on top of Symphony's retry/backoff/stall
+//! detection. This crate exposes three orthogonal checks (`diff_size`,
+//! `test_deletion`, `deploy_gate`) plus an aggregating [`GuardrailSet`]
+//! and an append-only [`audit_log::AuditLog`] used to record every
+//! guardrail trip.
+//!
+//! ## Defaults are lenient
+//!
+//! [`GuardrailSet::default`] returns an empty set: no checks are wired,
+//! no commits are blocked. Configuration is opt-in. This makes it safe
+//! to merge while the consuming sites are still being wired.
+//!
+//! ## Wiring sites
+//!
+//! * Symphony's post-run handler in
+//!   `crates/symphony/src/orchestrator.rs::run_post_steps` calls
+//!   [`crate::test_deletion`] (and the existing
+//!   `symphony::diff_guard::DiffGuard` covers the diff-size case via
+//!   `git diff --shortstat`). [`crate::diff_size`] is the
+//!   pre-parsed-input alternative used by callers that already have a
+//!   numstat parse on hand.
+//! * [`crate::deploy_gate`] is library-only at the moment and is meant
+//!   to plug into the agent-dispatch path. The current Warp dispatch
+//!   layer (`app/src/ai/agent_sdk/driver/local_orchestrator.rs`) wraps
+//!   a driver that does not expose a discrete pre-tool-call hook; a
+//!   dedicated wiring pass at the MCP forwarder or driver level is
+//!   tracked separately so this PR can land independent of those
+//!   surfaces.
+//!
+//! Sites use the same audit-log surface so a single `audit.log`
+//! reflects every guardrail trip regardless of dispatcher.
+//!
+//! ## Cross-platform
+//!
+//! All modules are macOS-first. Audit-log backed by SQLite (planned
+//! follow-up) is gated behind `cfg(not(target_family = "wasm"))`; the
+//! current JSONL backend is portable Rust and works in any environment
+//! with a writable filesystem.
+
+#![deny(missing_docs)]
+
+pub mod audit_log;
+pub mod deploy_gate;
+pub mod diff_size;
+pub mod test_deletion;
+
+use std::sync::Arc;
+
+pub use audit_log::{AuditEntry, AuditLog, GuardrailRule, GuardrailAction};
+pub use deploy_gate::{DeployGate, DeployGateDecision};
+pub use diff_size::{DiffSizeCheck, DiffSizeDecision, FileDiff};
+pub use test_deletion::{TestDeletionCheck, TestDeletionDecision};
+
+/// Outcome of a [`GuardrailSet`] evaluation. `Allow` means every wired
+/// check passed; `Block` means at least one check rejected the input
+/// and execution should be halted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuardrailOutcome {
+    /// Allow the operation to proceed.
+    Allow,
+    /// Block the operation. The reason is suitable for human display
+    /// (Linear comment, log line, etc.).
+    Block {
+        /// Which rule fired.
+        rule: GuardrailRule,
+        /// Human-readable explanation.
+        reason: String,
+    },
+}
+
+impl GuardrailOutcome {
+    /// `true` if this outcome blocks the operation.
+    pub fn is_block(&self) -> bool {
+        matches!(self, GuardrailOutcome::Block { .. })
+    }
+}
+
+/// Composed guardrail set evaluated as a single unit.
+///
+/// Each member is optional; an empty set is the lenient default and
+/// allows everything. The audit log is also optional — if `None`, trips
+/// are still returned as `Block` outcomes but no append happens.
+#[derive(Default, Clone)]
+pub struct GuardrailSet {
+    /// Diff-size check (post-run).
+    pub diff_size: Option<DiffSizeCheck>,
+    /// Test-deletion check (post-run).
+    pub test_deletion: Option<TestDeletionCheck>,
+    /// Production-deploy command gate (pre-tool-call).
+    pub deploy_gate: Option<DeployGate>,
+    /// Audit-log sink. Wrapped in `Arc` so callers can share one log
+    /// across multiple guardrail sets without rebuilding.
+    pub audit: Option<Arc<AuditLog>>,
+}
+
+impl GuardrailSet {
+    /// Convenience constructor for an empty (allow-all) set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Builder: attach a diff-size check.
+    pub fn with_diff_size(mut self, c: DiffSizeCheck) -> Self {
+        self.diff_size = Some(c);
+        self
+    }
+
+    /// Builder: attach a test-deletion check.
+    pub fn with_test_deletion(mut self, c: TestDeletionCheck) -> Self {
+        self.test_deletion = Some(c);
+        self
+    }
+
+    /// Builder: attach a deploy gate.
+    pub fn with_deploy_gate(mut self, g: DeployGate) -> Self {
+        self.deploy_gate = Some(g);
+        self
+    }
+
+    /// Builder: attach a shared audit log.
+    pub fn with_audit_log(mut self, log: Arc<AuditLog>) -> Self {
+        self.audit = Some(log);
+        self
+    }
+
+    /// Evaluate the post-run checks (diff size + test deletion) against
+    /// a list of per-file diffs. Returns the *first* `Block` outcome,
+    /// or `Allow` if every wired check passed.
+    ///
+    /// `meta` is associated with any audit-log entry written.
+    pub fn evaluate_post_run(
+        &self,
+        diffs: &[FileDiff],
+        meta: &EvaluationMeta,
+    ) -> GuardrailOutcome {
+        if let Some(check) = &self.diff_size {
+            if let DiffSizeDecision::Block { reason } = check.evaluate(diffs) {
+                self.record(GuardrailRule::DiffSize, &reason, meta, None);
+                return GuardrailOutcome::Block {
+                    rule: GuardrailRule::DiffSize,
+                    reason,
+                };
+            }
+        }
+        if let Some(check) = &self.test_deletion {
+            if let TestDeletionDecision::Block {
+                reason,
+                offending_path,
+            } = check.evaluate(diffs)
+            {
+                self.record(
+                    GuardrailRule::TestDeletion,
+                    &reason,
+                    meta,
+                    Some(offending_path.clone()),
+                );
+                return GuardrailOutcome::Block {
+                    rule: GuardrailRule::TestDeletion,
+                    reason,
+                };
+            }
+        }
+        GuardrailOutcome::Allow
+    }
+
+    /// Evaluate the deploy gate against a candidate command line. The
+    /// command is the literal shell invocation the agent intends to run
+    /// (e.g. `"wrangler deploy --env production"`). Returns `Allow` if
+    /// no gate is wired or the gate accepts the command.
+    pub fn evaluate_command(&self, cmd: &str, meta: &EvaluationMeta) -> GuardrailOutcome {
+        if let Some(gate) = &self.deploy_gate {
+            if let DeployGateDecision::Block { reason } = gate.evaluate(cmd) {
+                self.record(GuardrailRule::DeployGate, &reason, meta, None);
+                return GuardrailOutcome::Block {
+                    rule: GuardrailRule::DeployGate,
+                    reason,
+                };
+            }
+        }
+        GuardrailOutcome::Allow
+    }
+
+    fn record(
+        &self,
+        rule: GuardrailRule,
+        reason: &str,
+        meta: &EvaluationMeta,
+        offending_path: Option<String>,
+    ) {
+        if let Some(log) = &self.audit {
+            let entry = AuditEntry {
+                timestamp: chrono::Utc::now(),
+                task_id: meta.task_id.clone(),
+                agent_id: meta.agent_id.clone(),
+                rule,
+                action: GuardrailAction::Blocked,
+                offending_path,
+                detail: Some(reason.to_string()),
+            };
+            log.record(entry);
+        }
+    }
+}
+
+/// Per-evaluation context attached to audit-log entries.
+#[derive(Debug, Clone, Default)]
+pub struct EvaluationMeta {
+    /// Task / issue id (Symphony issue id, Linear identifier, or local task id).
+    pub task_id: Option<String>,
+    /// Agent provider tag (e.g. `"claude_code"`, `"codex"`).
+    pub agent_id: Option<String>,
+}
+
+impl EvaluationMeta {
+    /// Convenience builder.
+    pub fn new(task_id: impl Into<String>, agent_id: impl Into<String>) -> Self {
+        Self {
+            task_id: Some(task_id.into()),
+            agent_id: Some(agent_id.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod set_tests {
+    use super::*;
+
+    #[test]
+    fn default_set_allows_everything() {
+        let set = GuardrailSet::new();
+        let outcome = set.evaluate_post_run(
+            &[FileDiff {
+                path: "anything.rs".into(),
+                added_lines: 99_999,
+                removed_lines: 99_999,
+                deleted: true,
+            }],
+            &EvaluationMeta::default(),
+        );
+        assert_eq!(outcome, GuardrailOutcome::Allow);
+    }
+
+    #[test]
+    fn default_set_allows_any_command() {
+        let set = GuardrailSet::new();
+        let outcome = set.evaluate_command(
+            "wrangler deploy --env production",
+            &EvaluationMeta::default(),
+        );
+        assert_eq!(outcome, GuardrailOutcome::Allow);
+    }
+
+    #[test]
+    fn diff_size_check_blocks_when_wired() {
+        let set = GuardrailSet::new().with_diff_size(DiffSizeCheck::new(500));
+        let diffs = vec![FileDiff {
+            path: "src/big.rs".into(),
+            added_lines: 600,
+            removed_lines: 0,
+            deleted: false,
+        }];
+        let outcome = set.evaluate_post_run(&diffs, &EvaluationMeta::default());
+        assert!(outcome.is_block());
+        match outcome {
+            GuardrailOutcome::Block { rule, .. } => {
+                assert_eq!(rule, GuardrailRule::DiffSize);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn test_deletion_blocks_when_wired() {
+        let set = GuardrailSet::new().with_test_deletion(TestDeletionCheck::default());
+        let diffs = vec![FileDiff {
+            path: "crates/foo/tests/integration.rs".into(),
+            added_lines: 0,
+            removed_lines: 80,
+            deleted: true,
+        }];
+        let outcome = set.evaluate_post_run(&diffs, &EvaluationMeta::default());
+        assert!(outcome.is_block());
+        match outcome {
+            GuardrailOutcome::Block { rule, .. } => {
+                assert_eq!(rule, GuardrailRule::TestDeletion);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn deploy_gate_blocks_when_wired() {
+        let set = GuardrailSet::new().with_deploy_gate(DeployGate::default());
+        let outcome = set.evaluate_command(
+            "wrangler deploy --env production",
+            &EvaluationMeta::default(),
+        );
+        assert!(outcome.is_block());
+        match outcome {
+            GuardrailOutcome::Block { rule, .. } => assert_eq!(rule, GuardrailRule::DeployGate),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn diff_size_fires_before_test_deletion() {
+        // Both rules would trip; diff_size is checked first.
+        let set = GuardrailSet::new()
+            .with_diff_size(DiffSizeCheck::new(10))
+            .with_test_deletion(TestDeletionCheck::default());
+        let diffs = vec![FileDiff {
+            path: "tests/foo_test.rs".into(),
+            added_lines: 0,
+            removed_lines: 100,
+            deleted: true,
+        }];
+        let outcome = set.evaluate_post_run(&diffs, &EvaluationMeta::default());
+        match outcome {
+            GuardrailOutcome::Block { rule, .. } => assert_eq!(rule, GuardrailRule::DiffSize),
+            _ => panic!("expected block"),
+        }
+    }
+
+    #[test]
+    fn audit_log_records_block() {
+        use std::sync::Arc;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.log");
+        let log = Arc::new(AuditLog::open(path.clone()));
+        let set = GuardrailSet::new()
+            .with_diff_size(DiffSizeCheck::new(10))
+            .with_audit_log(log.clone());
+
+        let outcome = set.evaluate_post_run(
+            &[FileDiff {
+                path: "x.rs".into(),
+                added_lines: 50,
+                removed_lines: 0,
+                deleted: false,
+            }],
+            &EvaluationMeta::new("PDX-28", "claude_code"),
+        );
+        assert!(outcome.is_block());
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("\"diff_size\""), "log: {contents}");
+        assert!(contents.contains("\"PDX-28\""));
+        assert!(contents.contains("\"claude_code\""));
+    }
+}

--- a/crates/auto_healing/src/test_deletion.rs
+++ b/crates/auto_healing/src/test_deletion.rs
@@ -1,0 +1,279 @@
+//! Test-deletion guardrail.
+//!
+//! Flags any agent commit that deletes a file matching one of the
+//! configured test-path patterns. "Deletion" is defined as
+//! [`FileDiff::deleted`] being `true` and at least one line removed,
+//! which avoids false positives on rename-only changes that some diff
+//! representations encode as `deleted == true && removed_lines == 0`.
+//!
+//! The default pattern set targets the conventional locations and
+//! suffixes for Rust, TypeScript, JavaScript, Go and Python tests.
+//! Callers can construct a custom check with [`TestDeletionCheck::with_patterns`].
+
+use crate::diff_size::FileDiff;
+use regex::RegexSet;
+
+/// Default regular expressions matched against forward-slash-normalised
+/// paths. The set covers:
+///
+/// * Anything under a `tests/` directory anywhere in the tree.
+/// * Anything under a `__tests__/` directory (JS/TS convention).
+/// * Anything under a `spec/` directory (Ruby/JS convention).
+/// * `*_test.go` (Go).
+/// * `*_test.rs` (Rust convention for inline integration tests).
+/// * `*_test.py`, `test_*.py` (Python pytest convention).
+/// * `*.test.ts`, `*.test.tsx`, `*.test.js`, `*.test.jsx`,
+///   `*.spec.ts`, `*.spec.tsx`, `*.spec.js`, `*.spec.jsx` (JS/TS).
+pub const DEFAULT_TEST_PATTERNS: &[&str] = &[
+    r"(^|/)tests?/",
+    r"(^|/)__tests__/",
+    r"(^|/)spec/",
+    r"_test\.go$",
+    r"_test\.rs$",
+    r"(^|/)test_[^/]+\.py$",
+    r"_test\.py$",
+    r"\.test\.[jt]sx?$",
+    r"\.spec\.[jt]sx?$",
+];
+
+/// Test-deletion check.
+#[derive(Debug, Clone)]
+pub struct TestDeletionCheck {
+    patterns: RegexSet,
+}
+
+impl Default for TestDeletionCheck {
+    fn default() -> Self {
+        Self::with_patterns(DEFAULT_TEST_PATTERNS).expect("default patterns must compile")
+    }
+}
+
+impl TestDeletionCheck {
+    /// Build a check from a list of regex patterns. Patterns are matched
+    /// against forward-slash-normalised paths.
+    pub fn with_patterns<I, S>(patterns: I) -> Result<Self, regex::Error>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let set = RegexSet::new(patterns)?;
+        Ok(Self { patterns: set })
+    }
+
+    /// Evaluate the check. Returns the *first* offending diff in iter
+    /// order; callers should treat the result as illustrative — there
+    /// may be additional offenders.
+    pub fn evaluate(&self, diffs: &[FileDiff]) -> TestDeletionDecision {
+        for diff in diffs {
+            if !diff.deleted {
+                continue;
+            }
+            if diff.removed_lines == 0 {
+                // Rename-only; not an actual content deletion.
+                continue;
+            }
+            let normalized = diff.path.replace('\\', "/");
+            if self.patterns.is_match(&normalized) {
+                return TestDeletionDecision::Block {
+                    reason: format!(
+                        "agent attempted to delete test file `{}` ({} lines removed)",
+                        diff.path, diff.removed_lines
+                    ),
+                    offending_path: diff.path.clone(),
+                };
+            }
+        }
+        TestDeletionDecision::Allow
+    }
+}
+
+/// Outcome of a [`TestDeletionCheck`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TestDeletionDecision {
+    /// No test-file deletion was detected.
+    Allow,
+    /// A test-file deletion was detected and the operation should be blocked.
+    Block {
+        /// Human-readable reason.
+        reason: String,
+        /// Path of the offending file.
+        offending_path: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deleted(path: &str, removed: usize) -> FileDiff {
+        FileDiff {
+            path: path.into(),
+            added_lines: 0,
+            removed_lines: removed,
+            deleted: true,
+        }
+    }
+
+    fn modified(path: &str, removed: usize) -> FileDiff {
+        FileDiff {
+            path: path.into(),
+            added_lines: 5,
+            removed_lines: removed,
+            deleted: false,
+        }
+    }
+
+    #[test]
+    fn allow_on_empty_diff() {
+        let check = TestDeletionCheck::default();
+        assert_eq!(check.evaluate(&[]), TestDeletionDecision::Allow);
+    }
+
+    #[test]
+    fn allow_when_no_test_files_touched() {
+        let check = TestDeletionCheck::default();
+        let diffs = vec![
+            deleted("src/main.rs", 50),
+            deleted("docs/readme.md", 10),
+        ];
+        assert_eq!(check.evaluate(&diffs), TestDeletionDecision::Allow);
+    }
+
+    #[test]
+    fn allow_when_test_file_only_modified_not_deleted() {
+        let check = TestDeletionCheck::default();
+        // File matches a test pattern, but `deleted` is false → modified
+        // tests are allowed.
+        let diffs = vec![modified("crates/foo/tests/integration.rs", 5)];
+        assert_eq!(check.evaluate(&diffs), TestDeletionDecision::Allow);
+    }
+
+    #[test]
+    fn block_on_rust_tests_dir_deletion() {
+        let check = TestDeletionCheck::default();
+        let diffs = vec![deleted("crates/foo/tests/integration.rs", 80)];
+        match check.evaluate(&diffs) {
+            TestDeletionDecision::Block {
+                offending_path, ..
+            } => {
+                assert_eq!(offending_path, "crates/foo/tests/integration.rs");
+            }
+            _ => panic!("expected block"),
+        }
+    }
+
+    #[test]
+    fn block_on_rust_underscore_test_suffix() {
+        let check = TestDeletionCheck::default();
+        let diffs = vec![deleted("crates/auth/src/auth_manager_test.rs", 200)];
+        assert!(matches!(
+            check.evaluate(&diffs),
+            TestDeletionDecision::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn block_on_typescript_dot_test() {
+        let check = TestDeletionCheck::default();
+        for path in [
+            "src/foo.test.ts",
+            "src/foo.test.tsx",
+            "src/foo.test.js",
+            "src/foo.test.jsx",
+            "src/foo.spec.ts",
+        ] {
+            let diffs = vec![deleted(path, 30)];
+            assert!(
+                matches!(check.evaluate(&diffs), TestDeletionDecision::Block { .. }),
+                "expected block for {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn block_on_go_test_suffix() {
+        let check = TestDeletionCheck::default();
+        let diffs = vec![deleted("internal/server/handler_test.go", 40)];
+        assert!(matches!(
+            check.evaluate(&diffs),
+            TestDeletionDecision::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn block_on_python_test_prefix() {
+        let check = TestDeletionCheck::default();
+        let diffs = vec![deleted("tests_dir_does_not_exist/test_foo.py", 20)];
+        // `test_foo.py` directly under any directory.
+        assert!(matches!(
+            check.evaluate(&diffs),
+            TestDeletionDecision::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn block_on_jest_dunder_dir() {
+        let check = TestDeletionCheck::default();
+        let diffs = vec![deleted("src/__tests__/foo.js", 12)];
+        assert!(matches!(
+            check.evaluate(&diffs),
+            TestDeletionDecision::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn skips_rename_only_deletes_with_zero_removed_lines() {
+        // Some diff producers encode "renamed" as `deleted == true,
+        // removed_lines == 0`. Don't trip on those.
+        let check = TestDeletionCheck::default();
+        let diffs = vec![FileDiff {
+            path: "tests/foo.rs".into(),
+            added_lines: 0,
+            removed_lines: 0,
+            deleted: true,
+        }];
+        assert_eq!(check.evaluate(&diffs), TestDeletionDecision::Allow);
+    }
+
+    #[test]
+    fn normalizes_windows_path_separators() {
+        let check = TestDeletionCheck::default();
+        let diffs = vec![deleted(r"crates\foo\tests\integration.rs", 50)];
+        assert!(matches!(
+            check.evaluate(&diffs),
+            TestDeletionDecision::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn custom_patterns_override_defaults() {
+        // Strict pattern: only `.spec.ts` counts.
+        let check = TestDeletionCheck::with_patterns(&[r"\.spec\.ts$"]).unwrap();
+        // Default pattern would catch this; custom set does not.
+        let diffs = vec![deleted("crates/foo/tests/integration.rs", 50)];
+        assert_eq!(check.evaluate(&diffs), TestDeletionDecision::Allow);
+
+        // Custom pattern still trips on `.spec.ts`.
+        let diffs = vec![deleted("src/api.spec.ts", 50)];
+        assert!(matches!(
+            check.evaluate(&diffs),
+            TestDeletionDecision::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn returns_first_offender_when_multiple() {
+        let check = TestDeletionCheck::default();
+        let diffs = vec![
+            deleted("src/foo.rs", 10), // not a test file
+            deleted("tests/a_test.rs", 20),
+            deleted("tests/b_test.rs", 30),
+        ];
+        match check.evaluate(&diffs) {
+            TestDeletionDecision::Block {
+                offending_path, ..
+            } => assert_eq!(offending_path, "tests/a_test.rs"),
+            _ => panic!("expected block"),
+        }
+    }
+}

--- a/crates/auto_healing/tests/integration.rs
+++ b/crates/auto_healing/tests/integration.rs
@@ -1,0 +1,224 @@
+//! End-to-end integration tests for [`auto_healing::GuardrailSet`].
+//!
+//! Exercises the public API the way the dispatch site in
+//! `crates/symphony/src/orchestrator.rs` and
+//! `app/src/ai/agent_sdk/driver/local_orchestrator.rs` will: build a
+//! configured [`GuardrailSet`] with a shared on-disk audit log, drive
+//! a "commit" through it, then assert both the returned outcome and
+//! the resulting audit-log JSONL.
+
+use std::sync::Arc;
+
+use auto_healing::{
+    AuditLog, DeployGate, DiffSizeCheck, EvaluationMeta, FileDiff, GuardrailOutcome,
+    GuardrailRule, GuardrailSet, TestDeletionCheck,
+};
+
+fn standard_set(audit: Arc<AuditLog>) -> GuardrailSet {
+    GuardrailSet::new()
+        .with_diff_size(DiffSizeCheck::new(500))
+        .with_test_deletion(TestDeletionCheck::default())
+        .with_deploy_gate(DeployGate::default())
+        .with_audit_log(audit)
+}
+
+fn read_audit(log: &AuditLog) -> Vec<serde_json::Value> {
+    let raw = std::fs::read_to_string(log.path()).unwrap_or_default();
+    raw.lines()
+        .map(|l| serde_json::from_str::<serde_json::Value>(l).expect("valid JSON"))
+        .collect()
+}
+
+#[test]
+fn small_diff_passes_and_records_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(AuditLog::open(dir.path().join("audit.log")));
+    let set = standard_set(log.clone());
+
+    let diffs = vec![FileDiff {
+        path: "src/foo.rs".into(),
+        added_lines: 12,
+        removed_lines: 4,
+        deleted: false,
+    }];
+    let outcome = set.evaluate_post_run(&diffs, &EvaluationMeta::new("PDX-28", "claude_code"));
+    assert_eq!(outcome, GuardrailOutcome::Allow);
+
+    let entries = read_audit(&log);
+    assert!(
+        entries.is_empty(),
+        "no guardrail tripped, expected empty log; got: {entries:?}"
+    );
+}
+
+#[test]
+fn oversize_diff_blocks_and_appends_audit_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(AuditLog::open(dir.path().join("audit.log")));
+    let set = standard_set(log.clone());
+
+    let diffs = vec![FileDiff {
+        path: "src/big.rs".into(),
+        added_lines: 800,
+        removed_lines: 0,
+        deleted: false,
+    }];
+    let outcome =
+        set.evaluate_post_run(&diffs, &EvaluationMeta::new("PDX-28", "claude_code"));
+    match &outcome {
+        GuardrailOutcome::Block { rule, reason } => {
+            assert_eq!(*rule, GuardrailRule::DiffSize);
+            assert!(reason.contains("800"), "reason: {reason}");
+        }
+        _ => panic!("expected diff-size block"),
+    }
+
+    let entries = read_audit(&log);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["rule"], "diff_size");
+    assert_eq!(entries[0]["action"], "blocked");
+    assert_eq!(entries[0]["task_id"], "PDX-28");
+    assert_eq!(entries[0]["agent_id"], "claude_code");
+    assert!(entries[0]["timestamp"].is_string());
+}
+
+#[test]
+fn test_file_deletion_blocks_with_offending_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(AuditLog::open(dir.path().join("audit.log")));
+    let set = standard_set(log.clone());
+
+    // Acceptance criterion: an agent deleting
+    // `app/src/auth/auth_manager_test.rs` gets caught.
+    let diffs = vec![FileDiff {
+        path: "app/src/auth/auth_manager_test.rs".into(),
+        added_lines: 0,
+        removed_lines: 250,
+        deleted: true,
+    }];
+    let outcome = set.evaluate_post_run(
+        &diffs,
+        &EvaluationMeta::new("PDX-28-acceptance", "codex"),
+    );
+    match &outcome {
+        GuardrailOutcome::Block { rule, reason } => {
+            assert_eq!(*rule, GuardrailRule::TestDeletion);
+            assert!(reason.contains("auth_manager_test.rs"), "reason: {reason}");
+        }
+        _ => panic!("expected test-deletion block"),
+    }
+
+    let entries = read_audit(&log);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["rule"], "test_deletion");
+    assert_eq!(entries[0]["offending_path"], "app/src/auth/auth_manager_test.rs");
+}
+
+#[test]
+fn deploy_command_blocked_with_audit_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(AuditLog::open(dir.path().join("audit.log")));
+    let set = standard_set(log.clone());
+
+    // Acceptance criterion: an agent issuing
+    // `wrangler deploy --env production` gets blocked.
+    let outcome = set.evaluate_command(
+        "wrangler deploy --env production",
+        &EvaluationMeta::new("PDX-28-acceptance", "claude_code"),
+    );
+    match &outcome {
+        GuardrailOutcome::Block { rule, .. } => {
+            assert_eq!(*rule, GuardrailRule::DeployGate);
+        }
+        _ => panic!("expected deploy-gate block"),
+    }
+
+    let entries = read_audit(&log);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["rule"], "deploy_gate");
+}
+
+#[test]
+fn multiple_blocks_are_appended_chronologically() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(AuditLog::open(dir.path().join("audit.log")));
+    let set = standard_set(log.clone());
+
+    // Three independent trips, each on its own meta.
+    let _ = set.evaluate_post_run(
+        &[FileDiff {
+            path: "src/big.rs".into(),
+            added_lines: 1_000,
+            removed_lines: 0,
+            deleted: false,
+        }],
+        &EvaluationMeta::new("PDX-A", "agent-1"),
+    );
+    let _ = set.evaluate_post_run(
+        &[FileDiff {
+            path: "tests/foo.rs".into(),
+            added_lines: 0,
+            removed_lines: 50,
+            deleted: true,
+        }],
+        &EvaluationMeta::new("PDX-B", "agent-2"),
+    );
+    let _ = set.evaluate_command(
+        "cargo publish",
+        &EvaluationMeta::new("PDX-C", "agent-3"),
+    );
+
+    let entries = read_audit(&log);
+    assert_eq!(entries.len(), 3);
+    let rules: Vec<&str> = entries
+        .iter()
+        .map(|e| e["rule"].as_str().unwrap())
+        .collect();
+    assert_eq!(rules, vec!["diff_size", "test_deletion", "deploy_gate"]);
+    let task_ids: Vec<&str> = entries
+        .iter()
+        .map(|e| e["task_id"].as_str().unwrap())
+        .collect();
+    assert_eq!(task_ids, vec!["PDX-A", "PDX-B", "PDX-C"]);
+}
+
+#[test]
+fn empty_set_lets_everything_through_with_empty_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(AuditLog::open(dir.path().join("audit.log")));
+    // Default = lenient; the Arc is wired but no checks fire.
+    let set = GuardrailSet::new().with_audit_log(log.clone());
+
+    let outcome = set.evaluate_post_run(
+        &[FileDiff {
+            path: "anything.rs".into(),
+            added_lines: 99_999,
+            removed_lines: 99_999,
+            deleted: true,
+        }],
+        &EvaluationMeta::new("PDX-X", "agent-y"),
+    );
+    assert_eq!(outcome, GuardrailOutcome::Allow);
+    assert_eq!(
+        set.evaluate_command("wrangler deploy --env production", &EvaluationMeta::default()),
+        GuardrailOutcome::Allow
+    );
+    let entries = read_audit(&log);
+    assert!(entries.is_empty(), "no checks → no log entries");
+}
+
+#[test]
+fn override_disables_deploy_gate_per_call() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(AuditLog::open(dir.path().join("audit.log")));
+    let set = GuardrailSet::new()
+        .with_deploy_gate(DeployGate::default().with_override(true))
+        .with_audit_log(log.clone());
+
+    let outcome = set.evaluate_command(
+        "wrangler deploy --env production",
+        &EvaluationMeta::new("PDX-Z", "agent-z"),
+    );
+    assert_eq!(outcome, GuardrailOutcome::Allow);
+    assert!(read_audit(&log).is_empty());
+}

--- a/crates/symphony/Cargo.toml
+++ b/crates/symphony/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 orchestrator = { workspace = true }
 agents = { workspace = true }
+auto_healing = { workspace = true }
 doppler = { workspace = true }
 tokio = { workspace = true, features = [
     "rt-multi-thread",

--- a/crates/symphony/src/audit.rs
+++ b/crates/symphony/src/audit.rs
@@ -31,6 +31,8 @@ pub enum AuditEventKind {
     Failed,
     /// Diff guard rejected the run for being too large.
     DiffGuardExceeded,
+    /// Test-deletion guardrail rejected the run.
+    TestDeletionBlocked,
     /// Workflow tick boundary.
     Tick,
     /// An in-flight agent run exceeded `agent.stall_timeout_ms` since

--- a/crates/symphony/src/lib.rs
+++ b/crates/symphony/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod audit;
 pub mod diff_guard;
+pub mod numstat;
 pub mod orchestrator;
 pub mod tracker;
 pub mod workflow;

--- a/crates/symphony/src/numstat.rs
+++ b/crates/symphony/src/numstat.rs
@@ -1,0 +1,206 @@
+//! Bridge between Symphony's `git`-shell-out diff inspection and
+//! [`auto_healing`]'s pre-parsed [`auto_healing::FileDiff`] surface.
+//!
+//! Runs `git diff --numstat HEAD` plus `git diff --name-status HEAD`
+//! inside a workspace and merges the two outputs into a `FileDiff` list
+//! the auto_healing crate can consume. We separate this from
+//! [`crate::diff_guard`] (which uses `--shortstat` for a fast
+//! aggregate) so the two checks are independent and either can be
+//! disabled without affecting the other.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use auto_healing::FileDiff;
+use thiserror::Error;
+use tokio::process::Command;
+
+/// Errors raised by [`collect_workspace_diffs`].
+#[derive(Debug, Error)]
+pub enum NumstatError {
+    /// `git` invocation failed.
+    #[error("git failed: {0}")]
+    GitFailed(String),
+}
+
+/// Run `git diff --numstat HEAD` + `git diff --name-status HEAD` and
+/// merge the results.
+///
+/// On a non-git workspace or a fresh repo with no `HEAD`, this returns
+/// an empty list (matching [`crate::diff_guard::DiffGuard::check`]'s
+/// behaviour for the same edge cases).
+pub async fn collect_workspace_diffs(
+    workspace_path: &Path,
+) -> Result<Vec<FileDiff>, NumstatError> {
+    let numstat = run_git(workspace_path, &["diff", "--numstat", "HEAD"]).await?;
+    let Some(numstat) = numstat else {
+        return Ok(Vec::new());
+    };
+    let names = run_git(workspace_path, &["diff", "--name-status", "HEAD"]).await?;
+    let names = names.unwrap_or_default();
+
+    let mut deletion_paths: HashMap<String, bool> = HashMap::new();
+    for raw in names.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // name-status format: "<STATUS>\t<path>" or for renames
+        // "R<score>\t<old>\t<new>". We only care about deletions ("D").
+        let mut parts = line.split('\t');
+        let Some(status) = parts.next() else {
+            continue;
+        };
+        if !status.starts_with('D') {
+            continue;
+        }
+        let Some(path) = parts.next() else { continue };
+        deletion_paths.insert(path.to_string(), true);
+    }
+
+    let mut diffs = Vec::new();
+    for raw in numstat.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // numstat format: "<added>\t<removed>\t<path>"; both counts are
+        // "-" for binary files.
+        let mut parts = line.splitn(3, '\t');
+        let added = parts.next().unwrap_or("0").trim();
+        let removed = parts.next().unwrap_or("0").trim();
+        let Some(path) = parts.next() else { continue };
+        let path = path.trim();
+        if path.is_empty() {
+            continue;
+        }
+        let added_lines: usize = added.parse().unwrap_or(0);
+        let removed_lines: usize = removed.parse().unwrap_or(0);
+        let deleted = deletion_paths.contains_key(path);
+        diffs.push(FileDiff {
+            path: path.to_string(),
+            added_lines,
+            removed_lines,
+            deleted,
+        });
+    }
+    Ok(diffs)
+}
+
+async fn run_git(
+    workspace_path: &Path,
+    args: &[&str],
+) -> Result<Option<String>, NumstatError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace_path)
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| NumstatError::GitFailed(e.to_string()))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr_lower = stderr.to_lowercase();
+        if stderr_lower.contains("unknown revision")
+            || stderr_lower.contains("ambiguous argument")
+            || stderr_lower.contains("not a git repository")
+        {
+            tracing::debug!(
+                workspace = %workspace_path.display(),
+                stderr = %stderr.trim(),
+                "numstat: non-repo or no-HEAD workspace; treating as zero-diff"
+            );
+            return Ok(None);
+        }
+        return Err(NumstatError::GitFailed(stderr.into_owned()));
+    }
+    Ok(Some(String::from_utf8_lossy(&output.stdout).into_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn non_git_workspace_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let diffs = collect_workspace_diffs(tmp.path()).await.unwrap();
+        assert!(diffs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fresh_repo_no_head_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _ = tokio::process::Command::new("git")
+            .arg("-C")
+            .arg(tmp.path())
+            .arg("init")
+            .arg("-q")
+            .output()
+            .await
+            .unwrap();
+        let diffs = collect_workspace_diffs(tmp.path()).await.unwrap();
+        assert!(diffs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn detects_added_modified_and_deleted_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Helper: shell out to git.
+        async fn git(dir: &Path, args: &[&str]) {
+            let out = tokio::process::Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(args)
+                .output()
+                .await
+                .unwrap();
+            assert!(out.status.success(), "git {args:?} failed: {:?}", out);
+        }
+
+        git(tmp.path(), &["init", "-q"]).await;
+        git(tmp.path(), &["config", "user.email", "test@example.com"]).await;
+        git(tmp.path(), &["config", "user.name", "Test"]).await;
+        git(tmp.path(), &["config", "commit.gpgsign", "false"]).await;
+
+        // Initial commit: keep.txt + tests/old_test.rs.
+        std::fs::write(tmp.path().join("keep.txt"), "k1\nk2\nk3\n").unwrap();
+        std::fs::create_dir_all(tmp.path().join("tests")).unwrap();
+        std::fs::write(
+            tmp.path().join("tests/old_test.rs"),
+            "fn t() {}\nfn u() {}\nfn v() {}\n",
+        )
+        .unwrap();
+        git(tmp.path(), &["add", "."]).await;
+        git(tmp.path(), &["commit", "-q", "-m", "init"]).await;
+
+        // Working tree changes: modify keep.txt, delete tests/old_test.rs,
+        // add a new file.
+        std::fs::write(tmp.path().join("keep.txt"), "k1\nk2\nk3\nk4\n").unwrap();
+        std::fs::remove_file(tmp.path().join("tests/old_test.rs")).unwrap();
+        std::fs::write(tmp.path().join("new.txt"), "n1\nn2\n").unwrap();
+        // `git diff HEAD` includes untracked? No — only after add.
+        git(tmp.path(), &["add", "-A"]).await;
+
+        let diffs = collect_workspace_diffs(tmp.path()).await.unwrap();
+        let by_path: HashMap<&str, &FileDiff> =
+            diffs.iter().map(|d| (d.path.as_str(), d)).collect();
+
+        let kept = by_path.get("keep.txt").expect("keep.txt diff");
+        assert_eq!(kept.added_lines, 1);
+        assert_eq!(kept.removed_lines, 0);
+        assert!(!kept.deleted);
+
+        let new = by_path.get("new.txt").expect("new.txt diff");
+        assert_eq!(new.added_lines, 2);
+        assert_eq!(new.removed_lines, 0);
+        assert!(!new.deleted);
+
+        let removed = by_path
+            .get("tests/old_test.rs")
+            .expect("tests/old_test.rs diff");
+        assert_eq!(removed.added_lines, 0);
+        assert_eq!(removed.removed_lines, 3);
+        assert!(removed.deleted);
+    }
+}

--- a/crates/symphony/src/orchestrator.rs
+++ b/crates/symphony/src/orchestrator.rs
@@ -27,8 +27,11 @@ use orchestrator::{
 use thiserror::Error;
 use tokio::sync::RwLock;
 
+use auto_healing::{TestDeletionCheck, TestDeletionDecision};
+
 use crate::audit::{AuditEvent, AuditEventKind, AuditLog};
 use crate::diff_guard::{DiffGuard, DiffGuardError};
+use crate::numstat::collect_workspace_diffs;
 use crate::tracker::{Issue, TrackerError};
 use crate::workflow::WorkflowDefinition;
 use crate::workspace::{Workspace, WorkspaceError, WorkspaceManager};
@@ -186,6 +189,12 @@ pub struct Orchestrator {
     state: Arc<RwLock<RuntimeState>>,
     audit: Arc<AuditLog>,
     diff_guard: DiffGuard,
+    /// PDX-28 [D5] auto-healing: test-deletion guardrail. Always wired
+    /// with the default pattern set; the spec acceptance criterion
+    /// explicitly calls out catching `app/src/auth/auth_manager_test.rs`
+    /// deletions, so we keep this on by default rather than making it
+    /// opt-in via the workflow front matter.
+    test_deletion: TestDeletionCheck,
 }
 
 impl Orchestrator {
@@ -206,6 +215,7 @@ impl Orchestrator {
             state: Arc::new(RwLock::new(RuntimeState::default())),
             audit,
             diff_guard: DiffGuard::new(max_diff),
+            test_deletion: TestDeletionCheck::default(),
         }
     }
 
@@ -513,7 +523,7 @@ impl Orchestrator {
         provider: &str,
         outcome: RunOutcome,
     ) {
-        let diff_summary = match self.diff_guard.check(&workspace.path).await {
+        let mut diff_summary = match self.diff_guard.check(&workspace.path).await {
             Ok(stat) => {
                 tracing::info!(
                     insertions = stat.insertions,
@@ -531,6 +541,37 @@ impl Orchestrator {
                 format!("diff guard exceeded: {}", e)
             }
         };
+
+        // PDX-28 [D5]: test-deletion guardrail.
+        match collect_workspace_diffs(&workspace.path).await {
+            Ok(diffs) => {
+                if let TestDeletionDecision::Block {
+                    reason,
+                    offending_path,
+                } = self.test_deletion.evaluate(&diffs)
+                {
+                    tracing::warn!(
+                        issue = %issue.identifier,
+                        path = %offending_path,
+                        "test-deletion guardrail tripped"
+                    );
+                    self.audit.record(
+                        AuditEvent::new(AuditEventKind::TestDeletionBlocked)
+                            .with_issue(issue.id.clone(), issue.identifier.clone())
+                            .with_message(offending_path)
+                            .with_error(reason.clone()),
+                    );
+                    diff_summary.push_str(&format!("\n  test-deletion blocked: {}", reason));
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    issue = %issue.identifier,
+                    error = %e,
+                    "test-deletion numstat collect failed; skipping check"
+                );
+            }
+        }
 
         self.workspaces.run_after_run_hook(workspace).await;
 


### PR DESCRIPTION
## Summary

Adds a new `crates/auto_healing/` crate implementing the Helm additions from PDX-28 [D5] and wires the test-deletion check into Symphony's post-run path. Folds with Symphony's existing retry/backoff/stall detection (§8.4/§8.5) without modifying it.

### What's in the crate

| Module | Purpose | Default |
|---|---|---|
| `diff_size` | Cap on `added + removed` lines per commit | lenient (off) |
| `test_deletion` | Block deletion of files matching test-path patterns | lenient (off); patterns cover Rust/Go/Python/JS/TS |
| `deploy_gate` | Block `wrangler deploy` / `gh release create` / `cargo publish` / `npm publish` (env/sudo-prefix tolerant) | lenient (off) |
| `audit_log` | Append-only JSONL: `{ timestamp, task_id, agent_id, rule, action, offending_path?, detail? }` | best-effort, opt-in |
| `GuardrailSet` | Composes the three checks + shared audit log | `default()` allows everything |

### Audit log schema (JSONL)

```json
{
  "timestamp": "2026-05-02T12:34:56.789Z",
  "task_id": "PDX-28",
  "agent_id": "claude_code",
  "rule": "diff_size",
  "action": "blocked",
  "offending_path": "tests/foo_test.rs",
  "detail": "diff size 1234 lines exceeds configured cap of 500"
}
```

`rule` is one of `diff_size | test_deletion | deploy_gate`. `action` is `blocked | overridden | allowed`. Schema is intentionally close to `crates/symphony/src/audit.rs` so a single `jq` surface covers both. SQLite mirroring (PDX-71 ledger pattern) deferred to a follow-up gated behind `cfg(not(target_family = "wasm"))` once a queryable corpus is needed.

### Symphony wiring

* New `symphony::numstat` runs `git diff --numstat HEAD` + `git diff --name-status HEAD` and produces `Vec<auto_healing::FileDiff>`.
* `symphony::orchestrator::Orchestrator` holds a `TestDeletionCheck::default()`. After the existing diff guard runs in `run_post_steps`, the new check fires; trips emit a new `AuditEventKind::TestDeletionBlocked` and surface in the Linear comment via `diff_summary`.
* The existing `symphony::diff_guard::DiffGuard` (which uses `git diff --shortstat`) is left intact — it covers PDX-28 acceptance criterion 2.

### Acceptance criteria coverage

* Stalled-agent kill within `stall_timeout_ms`: covered by Symphony §8.5 (untouched)
* 2000-line PR caught + halted + Linear comment: covered by `symphony::diff_guard` (existing) — Linear comment surface already wired
* Deletion of `app/src/auth/auth_manager_test.rs` caught: covered by new `test_deletion` (integration test asserts this exact path)
* `wrangler deploy --env production` blocked: `deploy_gate` is library-ready and unit-tested; dispatch-side wiring is a follow-up (the warp `local_orchestrator` path doesn't expose a discrete pre-tool-call hook). Documented in lib.rs.
* Audit log shows every state transition: existing Symphony audit log unchanged + new auto_healing audit log tracks every guardrail trip

### Hard-constraint compliance

* macOS-first; no non-portable bits introduced
* Symphony retry/backoff code untouched
* `crates/orchestrator/src/router.rs` untouched
* `cloudflare-control-plane/` untouched
* No commit amends
* `GuardrailSet::default()` is empty → no blocks fire by default

### What this PR does *not* do (follow-ups)

* Production-deploy gate dispatch wiring at the MCP forwarder / driver level
* SQLite-backed audit log (currently JSONL, matching Symphony)
* D1 mirror of audit log (Phase C cloud control plane work)

## Test plan

- [x] `cargo test -p auto_healing`: 42 unit + 7 integration = 49 tests, all pass
- [x] `cargo test -p symphony --lib`: 19 tests pass (4 new in `numstat`)
- [x] `cargo test -p orchestrator`: 3 doc-tests pass, no regressions
- [x] `cargo check -p warp`: builds (pre-existing warnings only)
- [ ] Smoke-test against a real Symphony run with an agent that deletes a `*_test.rs` file (manual)
- [ ] Wire `deploy_gate` into the chosen dispatch surface in a follow-up PR

## Decisions affecting siblings

* **PDX-27 (Budget enforcement, Phase D):** Can reuse `auto_healing::AuditLog` directly. Suggested rule name: `budget_exceeded`. Same `EvaluationMeta` shape (`task_id` + `agent_id`).
* **PDX-29 (24/7 weekend test, Phase D):** Will exercise these guardrails. Default-empty `GuardrailSet` means tests must explicitly opt in; the integration tests in `crates/auto_healing/tests/integration.rs` are the canonical wiring example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)