### PR TITLE
PDX-19 [C3] Cloudflare Workers: Hono migration + WS Worker + Webhook stubs

### DIFF
--- a/cloudflare-control-plane/package-lock.json
+++ b/cloudflare-control-plane/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
+        "hono": "^4.12.16",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -3235,6 +3236,15 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/hono": {
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",

--- a/cloudflare-control-plane/package.json
+++ b/cloudflare-control-plane/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",
+    "hono": "^4.12.16",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/cloudflare-control-plane/src/shared/webhooks.ts
+++ b/cloudflare-control-plane/src/shared/webhooks.ts
@@ -1,0 +1,151 @@
+/**
+ * Webhook signature validators (PDX-19 stubs).
+ *
+ * The cloud control plane exposes three webhook intake endpoints:
+ *
+ *   - `POST /api/webhooks/github`   — GitHub HMAC SHA-256 (`X-Hub-Signature-256`)
+ *   - `POST /api/webhooks/slack`    — Slack v0 HMAC (`X-Slack-Signature` + `X-Slack-Request-Timestamp`)
+ *   - `POST /api/webhooks/generic`  — generic HMAC SHA-256 (`X-Webhook-Signature`)
+ *
+ * Phase C ships only the *stubs*: HMAC validate, log, return 202. Routing
+ * the validated payloads into the rest of the system is PDX-26 territory
+ * (the in-repo `crates/github_webhook_receiver/` Rust receiver — for the
+ * cloud port we'll wire up follow-on workflow invocations there).
+ *
+ * All three validators are constant-time: signatures are compared byte-by-byte
+ * via `timingSafeEqual` so we don't leak validity timing. Validation
+ * failures are logged but never echo signature bytes back into the response.
+ */
+
+const encoder = new TextEncoder();
+
+/** Constant-time byte comparison. Returns false for unequal lengths. */
+export function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  }
+  return diff === 0;
+}
+
+function hexToBytes(hex: string): Uint8Array | null {
+  if (hex.length % 2 !== 0) return null;
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    const byte = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(byte)) return null;
+    out[i] = byte;
+  }
+  return out;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    s += (bytes[i] ?? 0).toString(16).padStart(2, "0");
+  }
+  return s;
+}
+
+async function hmacSha256(secret: string, payload: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+  return new Uint8Array(sig);
+}
+
+// ── GitHub ──────────────────────────────────────────────────────────────────
+
+/**
+ * Verify a GitHub webhook signature. GitHub sends `X-Hub-Signature-256` as
+ * `sha256=<hex>` over the raw request body using the per-hook secret.
+ * https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+ */
+export async function verifyGitHubSignature(
+  secret: string,
+  rawBody: string,
+  signatureHeader: string | null
+): Promise<boolean> {
+  if (!signatureHeader || !signatureHeader.startsWith("sha256=")) return false;
+  const expected = hexToBytes(signatureHeader.slice("sha256=".length));
+  if (!expected) return false;
+  const actual = await hmacSha256(secret, rawBody);
+  return timingSafeEqual(actual, expected);
+}
+
+// ── Slack ───────────────────────────────────────────────────────────────────
+
+/** Reject Slack requests older than this many seconds (defends against replay). */
+export const SLACK_REPLAY_WINDOW_SECONDS = 60 * 5;
+
+/**
+ * Verify a Slack webhook signature. Slack signs
+ * `v0:{timestamp}:{rawBody}` with the signing secret and sends the result as
+ * `v0=<hex>` in `X-Slack-Signature`. The timestamp is in `X-Slack-Request-Timestamp`.
+ * https://api.slack.com/authentication/verifying-requests-from-slack
+ */
+export async function verifySlackSignature(
+  secret: string,
+  rawBody: string,
+  signatureHeader: string | null,
+  timestampHeader: string | null,
+  now: number = Math.floor(Date.now() / 1000)
+): Promise<boolean> {
+  if (!signatureHeader || !signatureHeader.startsWith("v0=")) return false;
+  if (!timestampHeader) return false;
+  const ts = Number.parseInt(timestampHeader, 10);
+  if (!Number.isFinite(ts)) return false;
+  if (Math.abs(now - ts) > SLACK_REPLAY_WINDOW_SECONDS) return false;
+  const expected = hexToBytes(signatureHeader.slice("v0=".length));
+  if (!expected) return false;
+  const actual = await hmacSha256(secret, `v0:${ts}:${rawBody}`);
+  return timingSafeEqual(actual, expected);
+}
+
+// ── Generic ─────────────────────────────────────────────────────────────────
+
+/**
+ * Verify a generic webhook signature. Takes the raw body and a hex-encoded
+ * SHA-256 HMAC in `X-Webhook-Signature` (with optional `sha256=` prefix).
+ * Per-source secrets can be plumbed in by the route handler — the validator
+ * itself just compares.
+ */
+export async function verifyGenericSignature(
+  secret: string,
+  rawBody: string,
+  signatureHeader: string | null
+): Promise<boolean> {
+  if (!signatureHeader) return false;
+  const cleaned = signatureHeader.startsWith("sha256=")
+    ? signatureHeader.slice("sha256=".length)
+    : signatureHeader;
+  const expected = hexToBytes(cleaned);
+  if (!expected) return false;
+  const actual = await hmacSha256(secret, rawBody);
+  return timingSafeEqual(actual, expected);
+}
+
+/** Helper used by tests to pre-compute a valid signature. */
+export async function signGitHubPayload(secret: string, body: string): Promise<string> {
+  return `sha256=${bytesToHex(await hmacSha256(secret, body))}`;
+}
+
+/** Helper used by tests to pre-compute a valid Slack signature. */
+export async function signSlackPayload(
+  secret: string,
+  timestamp: number,
+  body: string
+): Promise<string> {
+  return `v0=${bytesToHex(await hmacSha256(secret, `v0:${timestamp}:${body}`))}`;
+}
+
+/** Helper used by tests to pre-compute a valid generic signature. */
+export async function signGenericPayload(secret: string, body: string): Promise<string> {
+  return bytesToHex(await hmacSha256(secret, body));
+}

--- a/cloudflare-control-plane/src/workers/app.ts
+++ b/cloudflare-control-plane/src/workers/app.ts
@@ -1,0 +1,646 @@
+/**
+ * Hono application that powers the helm control-plane Worker (PDX-19).
+ *
+ * Routing tree
+ * ────────────
+ *   Public:
+ *     GET  /api/health
+ *     POST /api/auth/session   (Cf-Access-Jwt-Assertion or X-Doppler-Token)
+ *     POST /api/auth/logout
+ *     POST /api/webhooks/github
+ *     POST /api/webhooks/slack
+ *     POST /api/webhooks/generic
+ *
+ *   Authenticated (helm session JWT, every request audited via withAuditAttribution):
+ *     GET  /api/environments
+ *     POST /api/onboarding/check
+ *     GET  /api/resources
+ *     POST /api/workflows/:slug/instances
+ *     POST /api/workflows/deploy/instances/:id/approve
+ *     GET  /api/workflows/:slug/instances/:id
+ *     GET  /api/sessions/:sessionId/ws       (WebSocket upgrade → SessionDO)
+ *
+ * The Hono app is exported separately from the Worker entry so:
+ *   - Tests can mount it against a `Request` without a full Workers runtime.
+ *   - Future helm-cloud extraction can pick up `app.ts` verbatim and pair
+ *     it with a different Worker shell (durable-objects/workflows live in
+ *     this monorepo today; once they move, only `control-plane.ts` shifts).
+ */
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+
+import {
+  denyJwt,
+  extractHelmJwt,
+  issueHelmJwt,
+  recordAuthEvent,
+  validateDopplerToken,
+  verifyHelmJwt,
+  type AuthEnv,
+  type AuthenticatedRequestContext
+} from "../shared/auth.js";
+import {
+  json,
+  notFound,
+  requireAccess,
+  verifyAccessJwt
+} from "../shared/http.js";
+import {
+  assertEnvironment,
+  manifestForRuntime,
+  type HelmEnvironment
+} from "../shared/manifest.js";
+import {
+  auditInventory,
+  createCloudflareClient,
+  fetchInventory
+} from "../shared/cloudflare.js";
+import {
+  verifyGenericSignature,
+  verifyGitHubSignature,
+  verifySlackSignature
+} from "../shared/webhooks.js";
+import { auditLog, getDb, users } from "../db/index.js";
+import { resolveWorkflowBinding, type WorkflowBinding } from "./workflows/index.js";
+import type {
+  DeployWorkflowParams,
+  SwarmWorkflowParams
+} from "./workflows/types.js";
+
+// ── Env shape ───────────────────────────────────────────────────────────────
+
+/** Minimal Durable Object namespace we need from the SessionDO binding (PDX-20). */
+export interface SessionDoNamespace {
+  idFromName(name: string): DurableObjectId;
+  get(id: DurableObjectId): { fetch(request: Request): Promise<Response> };
+}
+
+export interface ControlPlaneEnv extends AuthEnv {
+  HELM_ENVIRONMENT: HelmEnvironment;
+  HELM_VERSION: string;
+  HELM_BUILD_ID: string;
+  HELM_MANIFEST_JSON: string;
+  CLOUDFLARE_API_TOKEN?: string;
+  CONTROL_PLANE_REGISTRY: DurableObjectNamespace;
+  DB: D1Database;
+
+  // Optional bindings — present once PDX-20 / PDX-25 land alongside this Worker.
+  SESSION_DO?: SessionDoNamespace;
+  SWARM_WORKFLOW?: WorkflowBinding;
+  DEPLOY_WORKFLOW?: WorkflowBinding;
+  SCHEDULED_TASK_WORKFLOW?: WorkflowBinding;
+  WATCHDOG_WORKFLOW?: WorkflowBinding;
+
+  // Webhook secrets (wrangler secret put …). Each is optional — the route
+  // returns 503 with `webhook_disabled` if its secret isn't configured, so
+  // hooks can be enabled per-environment without code changes.
+  GITHUB_WEBHOOK_SECRET?: string;
+  SLACK_WEBHOOK_SECRET?: string;
+  GENERIC_WEBHOOK_SECRET?: string;
+}
+
+// ── Hono app variables ──────────────────────────────────────────────────────
+
+interface AppVariables {
+  /** Authenticated principal context populated by `helmAuth` middleware. */
+  authCtx: AuthenticatedRequestContext;
+}
+
+// Hono is parameterised on a `Bindings` (env) and `Variables` (per-request) shape.
+type AppEnv = { Bindings: ControlPlaneEnv; Variables: AppVariables };
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Extract the helm session JWT from either the `Authorization: Bearer …`
+ * header (programmatic clients) or the `?token=…` query parameter
+ * (browser-initiated WebSocket upgrades, which can't set custom headers).
+ */
+function extractHelmJwtFromRequestOrQuery(req: Request): string | null {
+  const headerToken = extractHelmJwt(req);
+  if (headerToken) return headerToken;
+  const url = new URL(req.url);
+  const queryToken = url.searchParams.get("token");
+  return queryToken ?? null;
+}
+
+async function ensureUser(env: ControlPlaneEnv, sub: string, email?: string): Promise<string> {
+  const db = getDb(env);
+  const existing = await db.select().from(users).where(eq(users.id, sub)).all();
+  if (existing.length === 0) {
+    await db
+      .insert(users)
+      .values({ id: sub, email: email ?? `${sub}@unknown.local` })
+      .onConflictDoNothing();
+  }
+  return sub;
+}
+
+// ── Middleware: requireHelmAuth + withAuditAttribution composed for Hono ────
+
+/**
+ * Hono adapter for `requireHelmAuth` (PDX-23). Either populates `c.var.authCtx`
+ * and calls `next()`, or short-circuits with a 401. The helm JWT may come from
+ * the `Authorization` header *or* the `?token=` query parameter so browser
+ * WebSocket clients (which can't set custom headers) work.
+ */
+async function helmAuth(c: import("hono").Context<AppEnv>, next: () => Promise<void>): Promise<Response | void> {
+  const env = c.env;
+  const manifest = manifestForRuntime(env);
+
+  const helmToken = extractHelmJwtFromRequestOrQuery(c.req.raw);
+  if (helmToken) {
+    if (!env.HELM_JWT_SIGNING_KEY) {
+      return c.json(
+        { error: "misconfigured", message: "HELM_JWT_SIGNING_KEY is not set." },
+        500
+      );
+    }
+    const result = await verifyHelmJwt(helmToken, {
+      signingKey: env.HELM_JWT_SIGNING_KEY,
+      authKv: env.AUTH_KV
+    });
+    if (result.ok) {
+      c.set("authCtx", {
+        userId: result.payload.sub,
+        jti: result.payload.jti,
+        source: "helm",
+        scope: result.payload.scope
+      });
+      await next();
+      return;
+    }
+    return c.json({ error: "unauthorized", reason: result.reason }, 401);
+  }
+
+  // Doppler fallback only kicks in when Access is *not* required.
+  if (!manifest.access.required) {
+    const dopplerToken = c.req.header("X-Doppler-Token");
+    if (dopplerToken) {
+      const validation = await validateDopplerToken(dopplerToken);
+      if (validation.ok && validation.project) {
+        c.set("authCtx", {
+          userId: `doppler:${validation.project}`,
+          source: "doppler",
+          scope: `doppler:${validation.project}`
+        });
+        await next();
+        return;
+      }
+      return c.json(
+        { error: "unauthorized", reason: validation.reason ?? "doppler_invalid" },
+        401
+      );
+    }
+  }
+
+  return c.json(
+    { error: "unauthorized", message: "A helm session JWT is required." },
+    401
+  );
+}
+
+/**
+ * Hono adapter for `withAuditAttribution` (PDX-23). Runs the downstream
+ * handler chain (`next()`), then writes a row to `audit_log` keyed on the
+ * authenticated principal. Anonymous requests (e.g. the public webhook
+ * endpoints) get `user_id = null` and `source = "anonymous"`.
+ *
+ * We deliberately don't wrap with `withAuditAttribution` directly — that
+ * helper expects to *own* the inner handler call. Hono's middleware contract
+ * is `next()`-based, so we replicate the audit-row write here against the
+ * same `audit_log` shape `withAuditAttribution` writes. Failures swallowed.
+ */
+function audit(opts: { anonymous?: boolean } = {}) {
+  return async (c: import("hono").Context<AppEnv>, next: () => Promise<void>): Promise<void> => {
+    const ctx: AuthenticatedRequestContext = opts.anonymous
+      ? { userId: null, source: "anonymous" }
+      : c.var.authCtx;
+    const startedAt = Date.now();
+    const url = new URL(c.req.url);
+    let threw: unknown = null;
+    try {
+      await next();
+    } catch (err) {
+      threw = err;
+      c.res = json(
+        { error: "internal_error", message: (err as Error).message },
+        { status: 500 }
+      );
+    }
+    const status = c.res?.status ?? 200;
+    try {
+      await getDb(c.env).insert(auditLog).values({
+        id: crypto.randomUUID(),
+        userId: ctx.userId,
+        action: "http.request",
+        targetKind: "endpoint",
+        targetId: url.pathname,
+        details: {
+          method: c.req.method,
+          path: url.pathname,
+          status,
+          durationMs: Date.now() - startedAt,
+          source: ctx.source,
+          ...(ctx.scope ? { scope: ctx.scope } : {})
+        }
+      });
+    } catch {
+      // Audit failures must not break the request path.
+    }
+    if (threw && !c.res) throw threw;
+  };
+}
+
+// ── App factory ────────────────────────────────────────────────────────────
+
+export function createApp(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+
+  // ── Health ──────────────────────────────────────────────────────────────
+  app.get("/api/health", (c) => {
+    return c.json({
+      service: "helm-control-plane",
+      environment: c.env.HELM_ENVIRONMENT,
+      version: c.env.HELM_VERSION,
+      buildId: c.env.HELM_BUILD_ID
+    });
+  });
+
+  // ── Auth: session exchange ──────────────────────────────────────────────
+  // Public endpoint — gated by Cloudflare Access (when the manifest requires
+  // it) rather than helm JWT, since the whole point is to *issue* a helm JWT.
+  app.post("/api/auth/session", async (c) => {
+    const env = c.env;
+    if (!env.HELM_JWT_SIGNING_KEY) {
+      return c.json(
+        { error: "misconfigured", message: "HELM_JWT_SIGNING_KEY is not set." },
+        500
+      );
+    }
+
+    const manifest = manifestForRuntime(env);
+    const accessFailure = await requireAccess(
+      c.req.raw,
+      manifest.access,
+      env.HELM_ENVIRONMENT,
+      env.AUTH_KV
+    );
+    if (accessFailure && manifest.access.required) return accessFailure;
+
+    const ip = c.req.header("CF-Connecting-IP") ?? null;
+    const userAgent = c.req.header("User-Agent") ?? null;
+
+    // Path 1 — Cloudflare Access JWT.
+    const accessJwt = c.req.header("Cf-Access-Jwt-Assertion");
+    if (accessJwt && manifest.access.required) {
+      const result = await verifyAccessJwt(
+        accessJwt,
+        manifest.access.teamDomain,
+        manifest.access.audiences[env.HELM_ENVIRONMENT],
+        env.AUTH_KV
+      );
+      if (!result.ok || !result.payload?.sub) {
+        return c.json({ error: "unauthorized", reason: "access_invalid" }, 401);
+      }
+      const userId = await ensureUser(env, result.payload.sub, result.payload.email);
+      const issued = await issueHelmJwt({
+        userId,
+        signingKey: env.HELM_JWT_SIGNING_KEY
+      });
+      await recordAuthEvent(env, {
+        userId,
+        action: "auth.session.issued",
+        jti: issued.payload.jti,
+        details: { ip, user_agent: userAgent, source: "access" }
+      });
+      return c.json({
+        token: issued.token,
+        expiresAt: issued.payload.exp,
+        jti: issued.payload.jti
+      });
+    }
+
+    // Path 2 — Doppler fallback.
+    if (!manifest.access.required) {
+      const dopplerToken = c.req.header("X-Doppler-Token");
+      if (dopplerToken) {
+        const validation = await validateDopplerToken(dopplerToken);
+        if (!validation.ok || !validation.project) {
+          return c.json(
+            { error: "unauthorized", reason: validation.reason ?? "doppler_invalid" },
+            401
+          );
+        }
+        const userId = `doppler:${validation.project}`;
+        const issued = await issueHelmJwt({
+          userId,
+          signingKey: env.HELM_JWT_SIGNING_KEY,
+          scope: `doppler:${validation.project}`
+        });
+        await recordAuthEvent(env, {
+          userId: null,
+          action: "auth.session.issued.doppler_fallback",
+          jti: issued.payload.jti,
+          details: {
+            ip,
+            user_agent: userAgent,
+            project: validation.project,
+            source: "doppler"
+          }
+        });
+        return c.json({
+          token: issued.token,
+          expiresAt: issued.payload.exp,
+          jti: issued.payload.jti,
+          scope: `doppler:${validation.project}`
+        });
+      }
+    }
+
+    return c.json(
+      { error: "unauthorized", message: "An Access JWT or Doppler token is required." },
+      401
+    );
+  });
+
+  // ── Auth: logout ────────────────────────────────────────────────────────
+  app.post("/api/auth/logout", async (c) => {
+    const env = c.env;
+    const token = extractHelmJwt(c.req.raw);
+    if (!token) return c.json({ error: "no_token" }, 400);
+    if (!env.HELM_JWT_SIGNING_KEY) {
+      return c.json(
+        { error: "misconfigured", message: "HELM_JWT_SIGNING_KEY is not set." },
+        500
+      );
+    }
+    const result = await verifyHelmJwt(token, {
+      signingKey: env.HELM_JWT_SIGNING_KEY,
+      authKv: env.AUTH_KV
+    });
+    if (!result.ok) {
+      return c.json({ revoked: false, reason: result.reason });
+    }
+    if (env.AUTH_KV) {
+      await denyJwt(env.AUTH_KV, result.payload.jti, result.payload.exp);
+    }
+    await recordAuthEvent(env, {
+      userId: result.payload.sub.startsWith("doppler:") ? null : result.payload.sub,
+      action: "auth.session.revoked",
+      jti: result.payload.jti,
+      details: { source: result.payload.scope ? "doppler" : "helm" }
+    });
+    return c.json({ revoked: true, jti: result.payload.jti });
+  });
+
+  // ── Webhooks (PDX-19 stubs) ─────────────────────────────────────────────
+  // Public — auth is the HMAC, not a helm JWT. Each route validates the
+  // signature against the per-source secret, logs minimal metadata, and
+  // returns 202. Event handling is deliberately deferred (TODO PDX-26).
+  app.post("/api/webhooks/github", audit({ anonymous: true }), async (c) => {
+    const env = c.env;
+    if (!env.GITHUB_WEBHOOK_SECRET) {
+      return c.json({ error: "webhook_disabled", reason: "no_secret" }, 503);
+    }
+    const rawBody = await c.req.text();
+    const ok = await verifyGitHubSignature(
+      env.GITHUB_WEBHOOK_SECRET,
+      rawBody,
+      c.req.header("X-Hub-Signature-256") ?? null
+    );
+    if (!ok) return c.json({ error: "bad_signature" }, 401);
+    const event = c.req.header("X-GitHub-Event") ?? "unknown";
+    const delivery = c.req.header("X-GitHub-Delivery") ?? null;
+    // TODO(PDX-26): dispatch into the cloud port of crates/github_webhook_receiver.
+    console.log(`[webhook][github] event=${event} delivery=${delivery ?? "-"}`);
+    return c.json({ accepted: true, event, delivery }, 202);
+  });
+
+  app.post("/api/webhooks/slack", audit({ anonymous: true }), async (c) => {
+    const env = c.env;
+    if (!env.SLACK_WEBHOOK_SECRET) {
+      return c.json({ error: "webhook_disabled", reason: "no_secret" }, 503);
+    }
+    const rawBody = await c.req.text();
+    const ok = await verifySlackSignature(
+      env.SLACK_WEBHOOK_SECRET,
+      rawBody,
+      c.req.header("X-Slack-Signature") ?? null,
+      c.req.header("X-Slack-Request-Timestamp") ?? null
+    );
+    if (!ok) return c.json({ error: "bad_signature" }, 401);
+    // TODO(PDX-26): route Slack events into the symphony pipeline.
+    console.log(`[webhook][slack] payload_bytes=${rawBody.length}`);
+    return c.json({ accepted: true }, 202);
+  });
+
+  app.post("/api/webhooks/generic", audit({ anonymous: true }), async (c) => {
+    const env = c.env;
+    if (!env.GENERIC_WEBHOOK_SECRET) {
+      return c.json({ error: "webhook_disabled", reason: "no_secret" }, 503);
+    }
+    const rawBody = await c.req.text();
+    const ok = await verifyGenericSignature(
+      env.GENERIC_WEBHOOK_SECRET,
+      rawBody,
+      c.req.header("X-Webhook-Signature") ?? null
+    );
+    if (!ok) return c.json({ error: "bad_signature" }, 401);
+    const source = c.req.header("X-Webhook-Source") ?? "unknown";
+    // TODO(PDX-26): per-source dispatch.
+    console.log(`[webhook][generic] source=${source} payload_bytes=${rawBody.length}`);
+    return c.json({ accepted: true, source }, 202);
+  });
+
+  // ── Authenticated subtree ───────────────────────────────────────────────
+  // Every protected route gets:
+  //   1. helmAuth  — verify helm JWT (header or ?token=)
+  //   2. audit()   — write the request into audit_log keyed on userId
+  app.use("/api/environments", helmAuth, audit());
+  app.use("/api/onboarding/check", helmAuth, audit());
+  app.use("/api/resources", helmAuth, audit());
+  app.use("/api/workflows/*", helmAuth, audit());
+  app.use("/api/sessions/*", helmAuth, audit());
+
+  app.get("/api/environments", (c) => {
+    const manifest = manifestForRuntime(c.env);
+    return c.json({
+      environments: manifest.environments.map((environment) => ({
+        name: environment,
+        configured: Boolean(manifest.access.audiences[environment]),
+        containers: manifest.containers[environment]
+      }))
+    });
+  });
+
+  app.post("/api/onboarding/check", async (c) => {
+    const env = c.env;
+    const manifest = manifestForRuntime(env);
+    const body = (await c.req.json().catch(() => ({}))) as { environment?: string };
+    const targetEnvironment = body.environment ?? env.HELM_ENVIRONMENT;
+    assertEnvironment(manifest, targetEnvironment);
+    return c.json({
+      environment: targetEnvironment,
+      account: {
+        id: manifest.accountId,
+        configured: !manifest.accountId.startsWith("replace-with")
+      },
+      zone: {
+        id: manifest.zone.id,
+        domain: manifest.zone.domain,
+        configured: !manifest.zone.id.startsWith("replace-with")
+      },
+      access: {
+        required: manifest.access.required,
+        teamDomain: manifest.access.teamDomain,
+        audienceConfigured: Boolean(manifest.access.audiences[targetEnvironment])
+      },
+      resources: {
+        d1: Object.keys(manifest.resources.d1).filter(
+          (name) =>
+            manifest.resources.d1[name]?.environment === targetEnvironment ||
+            manifest.resources.d1[name]?.environment === "all"
+        ),
+        r2: Object.keys(manifest.resources.r2).filter(
+          (name) =>
+            manifest.resources.r2[name]?.environment === targetEnvironment ||
+            manifest.resources.r2[name]?.environment === "all"
+        ),
+        durableObjects: Object.keys(manifest.resources.durableObjects)
+      },
+      containers: manifest.containers[targetEnvironment]
+    });
+  });
+
+  app.get("/api/resources", async (c) => {
+    const env = c.env;
+    const manifest = manifestForRuntime(env);
+    assertEnvironment(manifest, env.HELM_ENVIRONMENT);
+    if (!env.CLOUDFLARE_API_TOKEN) {
+      return c.json({
+        manifest,
+        reconciliation: {
+          skipped: true,
+          reason: "CLOUDFLARE_API_TOKEN is not configured."
+        }
+      });
+    }
+    const client = createCloudflareClient(env.CLOUDFLARE_API_TOKEN);
+    const inventory = await fetchInventory(client, manifest.accountId);
+    return c.json({
+      manifest,
+      reconciliation: auditInventory(manifest, env.HELM_ENVIRONMENT, inventory)
+    });
+  });
+
+  // ── Workflows (PDX-25) ──────────────────────────────────────────────────
+  // The control-plane Worker proxies into the workflow bindings declared in
+  // wrangler.control-plane.toml. The workflows Worker still owns the cron
+  // handler — this is just the synchronous create / approve / status surface
+  // exposed under one origin.
+  app.post("/api/workflows/:slug/instances", async (c) => {
+    const env = c.env;
+    const slug = c.req.param("slug");
+    const binding = resolveWorkflowBinding(env as never, slug);
+    if (!binding) return c.notFound();
+    const body = (await c.req.json().catch(() => ({}))) as {
+      id?: string;
+      params?: unknown;
+    };
+    if (slug === "swarm") {
+      const p = body.params as Partial<SwarmWorkflowParams> | undefined;
+      if (!p?.swarmId || !p?.taskId || !Array.isArray(p?.agents)) {
+        return c.json({ error: "invalid swarm params" }, 400);
+      }
+    } else if (slug === "deploy") {
+      const p = body.params as Partial<DeployWorkflowParams> | undefined;
+      if (!p?.deployId || !p?.target || !p?.artifact || !Array.isArray(p?.approvers)) {
+        return c.json({ error: "invalid deploy params" }, 400);
+      }
+    }
+    const instance = await binding.create({ id: body.id, params: body.params });
+    return c.json({ id: instance.id, slug }, 201);
+  });
+
+  app.post("/api/workflows/deploy/instances/:id/approve", async (c) => {
+    const env = c.env;
+    if (!env.DEPLOY_WORKFLOW) return c.notFound();
+    const id = c.req.param("id");
+    const body = (await c.req.json().catch(() => ({}))) as {
+      approval?: { approver?: string; approvedAt?: string };
+    };
+    if (!body.approval?.approver || !body.approval?.approvedAt) {
+      return c.json({ error: "invalid approval payload" }, 400);
+    }
+    const instance = await env.DEPLOY_WORKFLOW.get(id);
+    await instance.sendEvent({ type: "approval", payload: body.approval });
+    return c.json({ id, accepted: true });
+  });
+
+  app.get("/api/workflows/:slug/instances/:id", async (c) => {
+    const env = c.env;
+    const slug = c.req.param("slug");
+    const id = c.req.param("id");
+    const binding = resolveWorkflowBinding(env as never, slug);
+    if (!binding) return c.notFound();
+    const instance = await binding.get(id);
+    const status = await instance.status();
+    return c.json({ id, slug, status: status.status });
+  });
+
+  // ── WebSocket → SessionDO (PDX-19 + PDX-20) ────────────────────────────
+  // GET /api/sessions/:sessionId/ws — forward the upgrade to the per-session
+  // Durable Object. The DO reads `x-helm-user-id` and `x-helm-session-id`
+  // from the rewritten request for D1 attribution. We intentionally do NOT
+  // strip the original `Upgrade` / `Sec-WebSocket-*` headers — the DO is
+  // expected to call `acceptWebSocket` against the inbound connection.
+  app.get("/api/sessions/:sessionId/ws", async (c) => {
+    const env = c.env;
+    if (!env.SESSION_DO) {
+      return c.json({ error: "session_do_unbound" }, 503);
+    }
+    const upgrade = c.req.header("Upgrade")?.toLowerCase();
+    if (upgrade !== "websocket") {
+      return c.json({ error: "expected_websocket_upgrade" }, 426);
+    }
+    const sessionId = c.req.param("sessionId");
+    const ctx = c.var.authCtx;
+    const id = env.SESSION_DO.idFromName(sessionId);
+    const stub = env.SESSION_DO.get(id);
+
+    // Rewrite the request with attribution headers — the DO uses these for
+    // D1 inserts so it doesn't have to re-verify the JWT. We construct the
+    // forwarded Request from URL + init rather than `new Request(req, ...)`
+    // because the GET-with-WebSocket-upgrade case doesn't carry a body and
+    // some runtimes refuse to clone the original.
+    const headers = new Headers(c.req.raw.headers);
+    if (ctx.userId) headers.set("x-helm-user-id", ctx.userId);
+    headers.set("x-helm-session-id", sessionId);
+    const forwarded = new Request(c.req.raw.url, {
+      method: c.req.raw.method,
+      headers,
+      // GET upgrades have no body, but pass it through if present (e.g. test
+      // harness with a stubbed body).
+      body: c.req.raw.method === "GET" || c.req.raw.method === "HEAD"
+        ? undefined
+        : c.req.raw.body,
+      // @ts-expect-error: `duplex` is required when streaming a body in undici
+      // but absent on standard RequestInit; harmless on Workers runtime.
+      duplex: "half"
+    });
+    return stub.fetch(forwarded);
+  });
+
+  // ── 404 fallback ────────────────────────────────────────────────────────
+  app.all("*", () => notFound());
+
+  return app;
+}
+
+/** Singleton lazily created on first request — Hono apps are stateless. */
+let cachedApp: Hono<AppEnv> | null = null;
+export function appSingleton(): Hono<AppEnv> {
+  if (!cachedApp) cachedApp = createApp();
+  return cachedApp;
+}

--- a/cloudflare-control-plane/src/workers/control-plane.ts
+++ b/cloudflare-control-plane/src/workers/control-plane.ts
@@ -1,46 +1,30 @@
-import { auditInventory, createCloudflareClient, fetchInventory } from "../shared/cloudflare.js";
-import {
-  denyJwt,
-  extractHelmJwt,
-  issueHelmJwt,
-  recordAuthEvent,
-  requireHelmAuth,
-  validateDopplerToken,
-  verifyHelmJwt,
-  withAuditAttribution,
-  type AuthEnv,
-  type AuthenticatedRequestContext
-} from "../shared/auth.js";
-import {
-  health,
-  json,
-  methodNotAllowed,
-  notFound,
-  requireAccess,
-  verifyAccessJwt
-} from "../shared/http.js";
-import { assertEnvironment, manifestForRuntime, type HelmEnvironment } from "../shared/manifest.js";
-import { getDb, users } from "../db/index.js";
-import { eq } from "drizzle-orm";
+/**
+ * Helm control-plane Worker entry (PDX-19).
+ *
+ * Routing now lives in {@link ./app.ts} (Hono). This file is a thin shell
+ * that:
+ *   - Exports the `ControlPlaneRegistry` Durable Object class (preserved for
+ *     wrangler binding compatibility from PDX-19's earlier scaffold).
+ *   - Re-exports the PDX-20 Durable Object classes (`SessionDO`, `UserDO`,
+ *     `SwarmDO`, `RepoDO`) so the wrangler runtime can bind them.
+ *   - Re-exports the `AuthenticatedRequestContext` type for downstream tests.
+ *   - Mounts the Hono app under the default `fetch` export.
+ *   - Forwards Cron Triggers to the workflows scheduled handler shape so a
+ *     future deployment can run cron on this Worker without splitting in
+ *     two (PDX-25 already binds the workflows; the actual scheduled fan-out
+ *     stays with the workflows Worker today).
+ *
+ * The Hono app accepts the helm session JWT either via `Authorization: Bearer`
+ * or via a `?token=` query parameter — the WebSocket route relies on this so
+ * browser clients (which can't set custom headers on `new WebSocket(...)`)
+ * can still authenticate.
+ */
+import { json } from "../shared/http.js";
+import { appSingleton, type ControlPlaneEnv } from "./app.js";
 
 // Re-export the PDX-20 Durable Object classes so they are available to the
 // Workers runtime. wrangler.control-plane.toml lists each by `class_name`.
 export { SessionDO, UserDO, SwarmDO, RepoDO } from "./durable-objects/index.js";
-
-interface Env extends AuthEnv {
-  HELM_ENVIRONMENT: HelmEnvironment;
-  HELM_VERSION: string;
-  HELM_BUILD_ID: string;
-  HELM_MANIFEST_JSON: string;
-  CLOUDFLARE_API_TOKEN?: string;
-  CONTROL_PLANE_REGISTRY: DurableObjectNamespace;
-  DB: D1Database;
-  // PDX-20 — added in this PR. Workers route via these in PDX-19.
-  SESSION_DO?: DurableObjectNamespace;
-  USER_DO?: DurableObjectNamespace;
-  SWARM_DO?: DurableObjectNamespace;
-  REPO_DO?: DurableObjectNamespace;
-}
 
 export class ControlPlaneRegistry {
   constructor(private readonly state: DurableObjectState) {}
@@ -54,289 +38,22 @@ export class ControlPlaneRegistry {
   }
 }
 
-async function resources(env: Env): Promise<Response> {
-  const manifest = manifestForRuntime(env);
-  assertEnvironment(manifest, env.HELM_ENVIRONMENT);
-  if (!env.CLOUDFLARE_API_TOKEN) {
-    return json(
-      {
-        manifest,
-        reconciliation: {
-          skipped: true,
-          reason: "CLOUDFLARE_API_TOKEN is not configured."
-        }
-      },
-      { status: 200 },
-    );
-  }
-
-  const client = createCloudflareClient(env.CLOUDFLARE_API_TOKEN);
-  const inventory = await fetchInventory(client, manifest.accountId);
-  return json({
-    manifest,
-    reconciliation: auditInventory(manifest, env.HELM_ENVIRONMENT, inventory)
-  });
-}
-
-async function onboardingCheck(request: Request, env: Env): Promise<Response> {
-  if (request.method !== "POST") return methodNotAllowed();
-
-  const manifest = manifestForRuntime(env);
-  const body = (await request.json().catch(() => ({}))) as { environment?: string };
-  const targetEnvironment = body.environment ?? env.HELM_ENVIRONMENT;
-  assertEnvironment(manifest, targetEnvironment);
-
-  return json({
-    environment: targetEnvironment,
-    account: {
-      id: manifest.accountId,
-      configured: !manifest.accountId.startsWith("replace-with")
-    },
-    zone: {
-      id: manifest.zone.id,
-      domain: manifest.zone.domain,
-      configured: !manifest.zone.id.startsWith("replace-with")
-    },
-    access: {
-      required: manifest.access.required,
-      teamDomain: manifest.access.teamDomain,
-      audienceConfigured: Boolean(manifest.access.audiences[targetEnvironment])
-    },
-    resources: {
-      d1: Object.keys(manifest.resources.d1).filter((name) =>
-        manifest.resources.d1[name]?.environment === targetEnvironment ||
-        manifest.resources.d1[name]?.environment === "all"
-      ),
-      r2: Object.keys(manifest.resources.r2).filter((name) =>
-        manifest.resources.r2[name]?.environment === targetEnvironment ||
-        manifest.resources.r2[name]?.environment === "all"
-      ),
-      durableObjects: Object.keys(manifest.resources.durableObjects)
-    },
-    containers: manifest.containers[targetEnvironment]
-  });
-}
-
-// ── Auth routes (PDX-23) ────────────────────────────────────────────────────
-
-/**
- * Exchange a Cloudflare Access JWT (or a Doppler service token, when
- * Access is not required by the manifest) for a short-lived helm session
- * JWT. The session JWT is what downstream Workers — agent-runtime,
- * workflows — accept on every subsequent request.
- *
- * Records both success and rejection in `audit_log`.
- */
-async function authSession(request: Request, env: Env): Promise<Response> {
-  if (request.method !== "POST") return methodNotAllowed();
-  if (!env.HELM_JWT_SIGNING_KEY) {
-    return json(
-      { error: "misconfigured", message: "HELM_JWT_SIGNING_KEY is not set." },
-      { status: 500 }
-    );
-  }
-
-  const manifest = manifestForRuntime(env);
-  const ip = request.headers.get("CF-Connecting-IP") ?? null;
-  const userAgent = request.headers.get("User-Agent") ?? null;
-
-  // Path 1 — Cloudflare Access JWT (preferred).
-  const accessJwt = request.headers.get("Cf-Access-Jwt-Assertion");
-  if (accessJwt && manifest.access.required) {
-    const result = await verifyAccessJwt(
-      accessJwt,
-      manifest.access.teamDomain,
-      manifest.access.audiences[env.HELM_ENVIRONMENT],
-      env.AUTH_KV
-    );
-    if (!result.ok || !result.payload?.sub) {
-      return json({ error: "unauthorized", reason: "access_invalid" }, { status: 401 });
-    }
-    const userId = await ensureUser(env, result.payload.sub, result.payload.email);
-    const issued = await issueHelmJwt({
-      userId,
-      signingKey: env.HELM_JWT_SIGNING_KEY
-    });
-    await recordAuthEvent(env, {
-      userId,
-      action: "auth.session.issued",
-      jti: issued.payload.jti,
-      details: { ip, user_agent: userAgent, source: "access" }
-    });
-    return json({
-      token: issued.token,
-      expiresAt: issued.payload.exp,
-      jti: issued.payload.jti
-    });
-  }
-
-  // Path 2 — Doppler fallback. Only enabled when Access is not required.
-  if (!manifest.access.required) {
-    const dopplerToken = request.headers.get("X-Doppler-Token");
-    if (dopplerToken) {
-      const validation = await validateDopplerToken(dopplerToken);
-      if (!validation.ok || !validation.project) {
-        return json(
-          { error: "unauthorized", reason: validation.reason ?? "doppler_invalid" },
-          { status: 401 }
-        );
-      }
-      const userId = `doppler:${validation.project}`;
-      const issued = await issueHelmJwt({
-        userId,
-        signingKey: env.HELM_JWT_SIGNING_KEY,
-        scope: `doppler:${validation.project}`
-      });
-      await recordAuthEvent(env, {
-        userId: null, // Doppler principals are not in `users`.
-        action: "auth.session.issued.doppler_fallback",
-        jti: issued.payload.jti,
-        details: {
-          ip,
-          user_agent: userAgent,
-          project: validation.project,
-          source: "doppler"
-        }
-      });
-      return json({
-        token: issued.token,
-        expiresAt: issued.payload.exp,
-        jti: issued.payload.jti,
-        scope: `doppler:${validation.project}`
-      });
-    }
-  }
-
-  return json(
-    { error: "unauthorized", message: "An Access JWT or Doppler token is required." },
-    { status: 401 }
-  );
-}
-
-/**
- * Revoke the caller's helm session JWT by writing its `jti` to the
- * `AUTH_KV` denylist. Records the revocation in `audit_log`.
- */
-async function authLogout(request: Request, env: Env): Promise<Response> {
-  if (request.method !== "POST") return methodNotAllowed();
-  const token = extractHelmJwt(request);
-  if (!token) return json({ error: "no_token" }, { status: 400 });
-  if (!env.HELM_JWT_SIGNING_KEY) {
-    return json(
-      { error: "misconfigured", message: "HELM_JWT_SIGNING_KEY is not set." },
-      { status: 500 }
-    );
-  }
-  const result = await verifyHelmJwt(token, {
-    signingKey: env.HELM_JWT_SIGNING_KEY,
-    authKv: env.AUTH_KV
-  });
-  if (!result.ok) {
-    // Logging out an already-bad token is a no-op success — clients shouldn't
-    // get stuck because their token expired one second before they hit logout.
-    return json({ revoked: false, reason: result.reason });
-  }
-  if (env.AUTH_KV) {
-    await denyJwt(env.AUTH_KV, result.payload.jti, result.payload.exp);
-  }
-  await recordAuthEvent(env, {
-    userId: result.payload.sub.startsWith("doppler:") ? null : result.payload.sub,
-    action: "auth.session.revoked",
-    jti: result.payload.jti,
-    details: { source: result.payload.scope ? "doppler" : "helm" }
-  });
-  return json({ revoked: true, jti: result.payload.jti });
-}
-
-/**
- * Upsert a user row keyed on the Access `sub`. Returns the canonical
- * user_id used in audit_log attribution.
- *
- * For minimal coupling we use `sub` directly as the primary key; emails
- * may rotate, sub doesn't. If a future PR moves to UUID-keyed rows
- * lookup-by-sub we'll plug in here.
- */
-async function ensureUser(env: Env, sub: string, email?: string): Promise<string> {
-  const db = getDb(env);
-  const existing = await db.select().from(users).where(eq(users.id, sub)).all();
-  if (existing.length === 0) {
-    await db
-      .insert(users)
-      .values({ id: sub, email: email ?? `${sub}@unknown.local` })
-      .onConflictDoNothing();
-  }
-  return sub;
-}
-
-// ── Worker entry point ──────────────────────────────────────────────────────
-
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const url = new URL(request.url);
+  async fetch(request: Request, env: ControlPlaneEnv, ctx: ExecutionContext): Promise<Response> {
+    return appSingleton().fetch(request, env, ctx);
+  },
 
-    if (url.pathname === "/api/health") {
-      return health({
-        service: "helm-control-plane",
-        environment: env.HELM_ENVIRONMENT,
-        version: env.HELM_VERSION,
-        buildId: env.HELM_BUILD_ID
-      });
-    }
-
-    // Auth routes are special: `/api/auth/session` must be reachable with
-    // a Cloudflare Access JWT (we *exchange* it here), so we don't gate
-    // it behind `requireHelmAuth`. Instead it goes through `requireAccess`
-    // when Access is required by the manifest.
-    if (url.pathname === "/api/auth/session") {
-      const manifest = manifestForRuntime(env);
-      const accessFailure = await requireAccess(
-        request,
-        manifest.access,
-        env.HELM_ENVIRONMENT,
-        env.AUTH_KV
-      );
-      if (accessFailure && manifest.access.required) return accessFailure;
-      return authSession(request, env);
-    }
-
-    if (url.pathname === "/api/auth/logout") {
-      // Logout doesn't need Access — the helm JWT is enough proof of identity.
-      return authLogout(request, env);
-    }
-
-    // All other API routes require a helm session JWT. We resolve the
-    // caller, then dispatch through `withAuditAttribution` so each route
-    // automatically writes a row to `audit_log`.
-    const manifest = manifestForRuntime(env);
-    const auth = await requireHelmAuth(request, env, manifest, env.HELM_ENVIRONMENT);
-    if ("response" in auth) return auth.response;
-
-    const dispatch = withAuditAttribution<Env>(async (req, e, _ctx) => {
-      const u = new URL(req.url);
-      if (u.pathname === "/api/environments") {
-        if (req.method !== "GET") return methodNotAllowed();
-        return json({
-          environments: manifest.environments.map((environment) => ({
-            name: environment,
-            configured: Boolean(manifest.access.audiences[environment]),
-            containers: manifest.containers[environment]
-          }))
-        });
-      }
-      if (u.pathname === "/api/onboarding/check") {
-        return onboardingCheck(req, e);
-      }
-      if (u.pathname === "/api/resources") {
-        if (req.method !== "GET") return methodNotAllowed();
-        return resources(e);
-      }
-      return notFound();
-    });
-
-    return dispatch(request, env, auth.ctx);
+  /**
+   * Cron handler placeholder. Today the helm-workflows Worker owns the cron
+   * fan-out (see `src/workers/workflows/index.ts`). When the helm-cloud
+   * extraction merges everything into a single Worker, lift that handler in
+   * here. Until then, this is a no-op so a stray cron binding doesn't
+   * crash the deployment.
+   */
+  async scheduled(_controller: ScheduledController, _env: ControlPlaneEnv): Promise<void> {
+    return;
   }
 };
 
-// Re-export the auth context type so downstream tests can import it
-// without reaching into `../shared/auth.js`.
-export type { AuthenticatedRequestContext };
+export type { AuthenticatedRequestContext } from "../shared/auth.js";
+export type { ControlPlaneEnv } from "./app.js";

--- a/cloudflare-control-plane/test/control-plane-routes.test.ts
+++ b/cloudflare-control-plane/test/control-plane-routes.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Hono control-plane route tests (PDX-19).
+ *
+ * Covers:
+ *   - Health endpoint is public and returns the expected payload shape.
+ *   - Unauthenticated requests to protected routes get 401.
+ *   - Helm JWT in `Authorization: Bearer …` reaches the protected handler.
+ *   - Helm JWT in `?token=` (WebSocket clients) also reaches the handler.
+ *   - WS upgrade on `/api/sessions/:id/ws` delegates to SessionDO with
+ *     `x-helm-user-id` + `x-helm-session-id` headers populated.
+ *   - Webhook HMAC validators accept good signatures and reject bad ones.
+ *   - Auth `/api/auth/session` (Doppler fallback) issues a helm JWT.
+ *   - Auth `/api/auth/logout` writes the jti to the KV denylist.
+ *
+ * The Hono app is mounted directly against synthetic `Request`s — no actual
+ * Workers runtime — so we don't need miniflare. The only Cloudflare bindings
+ * the tests fake are `SESSION_DO`, `AUTH_KV`, `DB`, and the workflow
+ * bindings, all via lightweight in-memory stubs.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { createApp, type ControlPlaneEnv } from "../src/workers/app.js";
+import { issueHelmJwt } from "../src/shared/auth.js";
+import {
+  signGitHubPayload,
+  signGenericPayload,
+  signSlackPayload
+} from "../src/shared/webhooks.js";
+import type { HelmManifest } from "../src/shared/manifest.js";
+
+const SIGNING_KEY = "test-signing-key-control-plane";
+
+// ── Fakes ──────────────────────────────────────────────────────────────────
+
+class MemoryKv {
+  private store = new Map<string, string>();
+  async get<T = string>(key: string, type?: "json" | "text"): Promise<T | null> {
+    const v = this.store.get(key);
+    if (!v) return null;
+    if (type === "json") return JSON.parse(v) as T;
+    return v as unknown as T;
+  }
+  async put(key: string, value: string): Promise<void> {
+    this.store.set(key, value);
+  }
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+  has(key: string): boolean {
+    return this.store.has(key);
+  }
+  asKv(): KVNamespace {
+    return this as unknown as KVNamespace;
+  }
+}
+
+/** Trivial D1 stub — all writes are no-ops, all reads return empty. */
+const stubDb: D1Database = {
+  prepare: (() => ({
+    bind: () => ({
+      all: async () => ({ results: [] }),
+      first: async () => null,
+      run: async () => ({ success: true })
+    })
+  })) as unknown,
+  batch: async () => [],
+  exec: async () => ({ count: 0, duration: 0 }),
+  dump: async () => new ArrayBuffer(0)
+} as unknown as D1Database;
+
+/**
+ * SessionDO fake — records every fetch so the test can assert on attribution.
+ *
+ * In production the DO returns a 101 Switching Protocols. Node's undici-backed
+ * `Response` constructor refuses statuses below 200, so we return 200 plus a
+ * sentinel header instead — the test asserts on attribution headers landing
+ * on the forwarded request, which is the actual contract under test.
+ */
+class FakeSessionDoStub {
+  lastRequest: Request | null = null;
+  async fetch(req: Request): Promise<Response> {
+    this.lastRequest = req;
+    return new Response("ok-from-do", {
+      status: 200,
+      headers: { "x-session-do-status": "would-be-101" }
+    });
+  }
+}
+
+class FakeSessionDoNamespace {
+  stubs = new Map<string, FakeSessionDoStub>();
+  idFromName(name: string): DurableObjectId {
+    return { toString: () => `id:${name}`, name } as unknown as DurableObjectId;
+  }
+  get(id: DurableObjectId): FakeSessionDoStub {
+    const key = (id as unknown as { name: string }).name ?? id.toString();
+    let stub = this.stubs.get(key);
+    if (!stub) {
+      stub = new FakeSessionDoStub();
+      this.stubs.set(key, stub);
+    }
+    return stub;
+  }
+}
+
+function buildManifest(overrides?: Partial<HelmManifest["access"]>): HelmManifest {
+  return {
+    accountId: "acct-test",
+    zone: { id: "zone-test", domain: "test.example" },
+    environments: ["dev", "staging", "production"],
+    workers: {},
+    resources: { d1: {}, r2: {}, durableObjects: {}, kv: {}, aiGateways: {} },
+    containers: {
+      dev: { enabled: true, instanceClass: "dev" },
+      staging: { enabled: true, instanceClass: "dev" },
+      production: { enabled: true, instanceClass: "dev" }
+    },
+    access: {
+      required: false,
+      teamDomain: "test.cloudflareaccess.com",
+      audiences: { dev: "aud-dev", staging: "aud-staging", production: "aud-production" },
+      ...overrides
+    },
+    protected: []
+  };
+}
+
+interface BuildEnvOpts {
+  authKv?: MemoryKv;
+  sessionDo?: FakeSessionDoNamespace;
+  githubSecret?: string;
+  slackSecret?: string;
+  genericSecret?: string;
+  manifest?: HelmManifest;
+}
+
+function buildEnv(opts: BuildEnvOpts = {}): ControlPlaneEnv {
+  const manifest = opts.manifest ?? buildManifest();
+  return {
+    HELM_ENVIRONMENT: "dev",
+    HELM_VERSION: "0.0.1-test",
+    HELM_BUILD_ID: "test",
+    HELM_MANIFEST_JSON: JSON.stringify(manifest),
+    HELM_JWT_SIGNING_KEY: SIGNING_KEY,
+    AUTH_KV: opts.authKv?.asKv(),
+    SESSION_DO: opts.sessionDo as unknown as ControlPlaneEnv["SESSION_DO"],
+    GITHUB_WEBHOOK_SECRET: opts.githubSecret,
+    SLACK_WEBHOOK_SECRET: opts.slackSecret,
+    GENERIC_WEBHOOK_SECRET: opts.genericSecret,
+    DB: stubDb,
+    CONTROL_PLANE_REGISTRY: {} as DurableObjectNamespace
+  };
+}
+
+const noopCtx = {
+  waitUntil: (_: Promise<unknown>) => {},
+  passThroughOnException: () => {}
+} as unknown as ExecutionContext;
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("control-plane Hono app", () => {
+  describe("health", () => {
+    it("returns the service descriptor unauthenticated", async () => {
+      const app = createApp();
+      const res = await app.fetch(new Request("https://h/api/health"), buildEnv(), noopCtx);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { service: string; environment: string };
+      expect(body.service).toBe("helm-control-plane");
+      expect(body.environment).toBe("dev");
+    });
+  });
+
+  describe("auth middleware", () => {
+    it("rejects unauthenticated requests to protected routes", async () => {
+      const app = createApp();
+      const res = await app.fetch(
+        new Request("https://h/api/environments"),
+        buildEnv(),
+        noopCtx
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("accepts a helm JWT via Authorization header", async () => {
+      const app = createApp();
+      const issued = await issueHelmJwt({ userId: "user-1", signingKey: SIGNING_KEY });
+      const res = await app.fetch(
+        new Request("https://h/api/environments", {
+          headers: { Authorization: `Bearer ${issued.token}` }
+        }),
+        buildEnv(),
+        noopCtx
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { environments: Array<{ name: string }> };
+      expect(body.environments.map((e) => e.name)).toContain("dev");
+    });
+
+    it("accepts a helm JWT via ?token= for WebSocket clients", async () => {
+      const app = createApp();
+      const issued = await issueHelmJwt({ userId: "user-2", signingKey: SIGNING_KEY });
+      const res = await app.fetch(
+        new Request(`https://h/api/environments?token=${encodeURIComponent(issued.token)}`),
+        buildEnv(),
+        noopCtx
+      );
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("WebSocket upgrade → SessionDO", () => {
+    it("forwards the upgrade request with attribution headers", async () => {
+      const app = createApp();
+      const session = new FakeSessionDoNamespace();
+      const env = buildEnv({ sessionDo: session });
+      const issued = await issueHelmJwt({ userId: "user-42", signingKey: SIGNING_KEY });
+
+      const res = await app.fetch(
+        new Request("https://h/api/sessions/sess-abc/ws", {
+          headers: {
+            Upgrade: "websocket",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+            Authorization: `Bearer ${issued.token}`
+          }
+        }),
+        env,
+        noopCtx
+      );
+
+      // 200 instead of 101 because Node's undici can't materialize 101.
+      // The DO sets a sentinel header so we can confirm the response came
+      // from the stub (and not from a Hono error path).
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-session-do-status")).toBe("would-be-101");
+      // The fake DO recorded the forwarded request — assert attribution headers.
+      const stub = session.get(session.idFromName("sess-abc"));
+      expect(stub.lastRequest).not.toBeNull();
+      expect(stub.lastRequest?.headers.get("x-helm-user-id")).toBe("user-42");
+      expect(stub.lastRequest?.headers.get("x-helm-session-id")).toBe("sess-abc");
+      expect(stub.lastRequest?.headers.get("Upgrade")).toBe("websocket");
+    });
+
+    it("rejects when the request is not a WS upgrade", async () => {
+      const app = createApp();
+      const session = new FakeSessionDoNamespace();
+      const env = buildEnv({ sessionDo: session });
+      const issued = await issueHelmJwt({ userId: "user-1", signingKey: SIGNING_KEY });
+      const res = await app.fetch(
+        new Request("https://h/api/sessions/sess-abc/ws", {
+          headers: { Authorization: `Bearer ${issued.token}` }
+        }),
+        env,
+        noopCtx
+      );
+      expect(res.status).toBe(426);
+    });
+
+    it("returns 503 when SESSION_DO is not bound", async () => {
+      const app = createApp();
+      const env = buildEnv();
+      const issued = await issueHelmJwt({ userId: "user-1", signingKey: SIGNING_KEY });
+      const res = await app.fetch(
+        new Request("https://h/api/sessions/x/ws", {
+          headers: {
+            Upgrade: "websocket",
+            Authorization: `Bearer ${issued.token}`
+          }
+        }),
+        env,
+        noopCtx
+      );
+      expect(res.status).toBe(503);
+    });
+  });
+
+  describe("webhooks", () => {
+    it("github: accepts a valid signature", async () => {
+      const app = createApp();
+      const secret = "ghsec";
+      const body = JSON.stringify({ action: "opened" });
+      const sig = await signGitHubPayload(secret, body);
+
+      const res = await app.fetch(
+        new Request("https://h/api/webhooks/github", {
+          method: "POST",
+          body,
+          headers: {
+            "Content-Type": "application/json",
+            "X-GitHub-Event": "pull_request",
+            "X-GitHub-Delivery": "deadbeef",
+            "X-Hub-Signature-256": sig
+          }
+        }),
+        buildEnv({ githubSecret: secret }),
+        noopCtx
+      );
+      expect(res.status).toBe(202);
+      const json = (await res.json()) as { accepted: boolean; event: string };
+      expect(json.accepted).toBe(true);
+      expect(json.event).toBe("pull_request");
+    });
+
+    it("github: rejects a bad signature", async () => {
+      const app = createApp();
+      const res = await app.fetch(
+        new Request("https://h/api/webhooks/github", {
+          method: "POST",
+          body: "{}",
+          headers: { "X-Hub-Signature-256": "sha256=00".padEnd(71, "0") }
+        }),
+        buildEnv({ githubSecret: "ghsec" }),
+        noopCtx
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("github: 503 when secret not configured", async () => {
+      const app = createApp();
+      const res = await app.fetch(
+        new Request("https://h/api/webhooks/github", { method: "POST", body: "{}" }),
+        buildEnv(),
+        noopCtx
+      );
+      expect(res.status).toBe(503);
+    });
+
+    it("slack: accepts a valid signature", async () => {
+      const app = createApp();
+      const secret = "slksec";
+      const ts = Math.floor(Date.now() / 1000);
+      const body = "token=foo&team_id=T1";
+      const sig = await signSlackPayload(secret, ts, body);
+      const res = await app.fetch(
+        new Request("https://h/api/webhooks/slack", {
+          method: "POST",
+          body,
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "X-Slack-Signature": sig,
+            "X-Slack-Request-Timestamp": String(ts)
+          }
+        }),
+        buildEnv({ slackSecret: secret }),
+        noopCtx
+      );
+      expect(res.status).toBe(202);
+    });
+
+    it("slack: rejects a stale timestamp", async () => {
+      const app = createApp();
+      const secret = "slksec";
+      const ts = Math.floor(Date.now() / 1000) - 60 * 60;
+      const sig = await signSlackPayload(secret, ts, "");
+      const res = await app.fetch(
+        new Request("https://h/api/webhooks/slack", {
+          method: "POST",
+          body: "",
+          headers: {
+            "X-Slack-Signature": sig,
+            "X-Slack-Request-Timestamp": String(ts)
+          }
+        }),
+        buildEnv({ slackSecret: secret }),
+        noopCtx
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("generic: accepts a valid signature", async () => {
+      const app = createApp();
+      const secret = "gen";
+      const body = "hello";
+      const sig = await signGenericPayload(secret, body);
+      const res = await app.fetch(
+        new Request("https://h/api/webhooks/generic", {
+          method: "POST",
+          body,
+          headers: {
+            "X-Webhook-Source": "test",
+            "X-Webhook-Signature": sig
+          }
+        }),
+        buildEnv({ genericSecret: secret }),
+        noopCtx
+      );
+      expect(res.status).toBe(202);
+    });
+
+    it("generic: rejects when signature is absent", async () => {
+      const app = createApp();
+      const res = await app.fetch(
+        new Request("https://h/api/webhooks/generic", { method: "POST", body: "hi" }),
+        buildEnv({ genericSecret: "g" }),
+        noopCtx
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("auth/session — Doppler fallback", () => {
+    it("issues a helm JWT scoped to the doppler project", async () => {
+      // Hono uses global fetch when handlers re-call out — we patch global
+      // fetch for the duration of this test so the Doppler validator returns
+      // a deterministic project slug.
+      const realFetch = globalThis.fetch;
+      globalThis.fetch = (async (url: string) => {
+        if (typeof url === "string" && url.includes("/v3/me")) {
+          return new Response(JSON.stringify({ slug: "helm-test" }), { status: 200 });
+        }
+        return new Response("not found", { status: 404 });
+      }) as typeof fetch;
+      try {
+        const app = createApp();
+        const res = await app.fetch(
+          new Request("https://h/api/auth/session", {
+            method: "POST",
+            headers: { "X-Doppler-Token": "dp.st.fake" }
+          }),
+          buildEnv(),
+          noopCtx
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { token: string; scope: string };
+        expect(body.token.split(".")).toHaveLength(3);
+        expect(body.scope).toBe("doppler:helm-test");
+      } finally {
+        globalThis.fetch = realFetch;
+      }
+    });
+
+    it("rejects when Access is required but no Access JWT is present", async () => {
+      const app = createApp();
+      const res = await app.fetch(
+        new Request("https://h/api/auth/session", { method: "POST" }),
+        buildEnv({ manifest: buildManifest({ required: true }) }),
+        noopCtx
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("auth/logout", () => {
+    it("denylists the jti in AUTH_KV", async () => {
+      const app = createApp();
+      const kv = new MemoryKv();
+      const env = buildEnv({ authKv: kv });
+      const issued = await issueHelmJwt({ userId: "user-1", signingKey: SIGNING_KEY });
+      const res = await app.fetch(
+        new Request("https://h/api/auth/logout", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${issued.token}` }
+        }),
+        env,
+        noopCtx
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { revoked: boolean; jti: string };
+      expect(body.revoked).toBe(true);
+      expect(body.jti).toBe(issued.payload.jti);
+      expect(kv.has(`denylist:jti:${issued.payload.jti}`)).toBe(true);
+    });
+  });
+
+  describe("404 fallback", () => {
+    it("returns 404 for unknown paths", async () => {
+      const app = createApp();
+      const res = await app.fetch(new Request("https://h/api/nope"), buildEnv(), noopCtx);
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/cloudflare-control-plane/test/webhooks.test.ts
+++ b/cloudflare-control-plane/test/webhooks.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the webhook HMAC validators (PDX-19).
+ *
+ * Round-trips the test-side signers against the validators so a regression
+ * in either half of the pair surfaces immediately.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  signGenericPayload,
+  signGitHubPayload,
+  signSlackPayload,
+  verifyGenericSignature,
+  verifyGitHubSignature,
+  verifySlackSignature,
+  timingSafeEqual
+} from "../src/shared/webhooks.js";
+
+describe("timingSafeEqual", () => {
+  it("returns true for equal byte sequences", () => {
+    expect(timingSafeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]))).toBe(true);
+  });
+  it("returns false for unequal lengths", () => {
+    expect(timingSafeEqual(new Uint8Array([1, 2]), new Uint8Array([1, 2, 3]))).toBe(false);
+  });
+  it("returns false for different bytes of equal length", () => {
+    expect(timingSafeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 4]))).toBe(false);
+  });
+});
+
+describe("verifyGitHubSignature", () => {
+  const secret = "github-secret";
+  const body = '{"action":"opened"}';
+
+  it("accepts a valid signature", async () => {
+    const sig = await signGitHubPayload(secret, body);
+    expect(await verifyGitHubSignature(secret, body, sig)).toBe(true);
+  });
+
+  it("rejects a tampered body", async () => {
+    const sig = await signGitHubPayload(secret, body);
+    expect(await verifyGitHubSignature(secret, body + "x", sig)).toBe(false);
+  });
+
+  it("rejects when the prefix is missing", async () => {
+    const sig = await signGitHubPayload(secret, body);
+    const bare = sig.replace("sha256=", "");
+    expect(await verifyGitHubSignature(secret, body, bare)).toBe(false);
+  });
+
+  it("rejects null signature header", async () => {
+    expect(await verifyGitHubSignature(secret, body, null)).toBe(false);
+  });
+
+  it("rejects malformed hex", async () => {
+    expect(await verifyGitHubSignature(secret, body, "sha256=zz")).toBe(false);
+  });
+});
+
+describe("verifySlackSignature", () => {
+  const secret = "slack-secret";
+  const body = "token=foo&team_id=T1";
+  const ts = 1_700_000_000;
+
+  it("accepts a valid signature within the replay window", async () => {
+    const sig = await signSlackPayload(secret, ts, body);
+    expect(await verifySlackSignature(secret, body, sig, String(ts), ts + 30)).toBe(true);
+  });
+
+  it("rejects when the timestamp is outside the replay window", async () => {
+    const sig = await signSlackPayload(secret, ts, body);
+    expect(await verifySlackSignature(secret, body, sig, String(ts), ts + 60 * 60)).toBe(false);
+  });
+
+  it("rejects when the prefix is missing", async () => {
+    const sig = await signSlackPayload(secret, ts, body);
+    expect(
+      await verifySlackSignature(secret, body, sig.replace("v0=", ""), String(ts), ts)
+    ).toBe(false);
+  });
+
+  it("rejects when the timestamp header is missing", async () => {
+    const sig = await signSlackPayload(secret, ts, body);
+    expect(await verifySlackSignature(secret, body, sig, null, ts)).toBe(false);
+  });
+
+  it("rejects a non-numeric timestamp", async () => {
+    const sig = await signSlackPayload(secret, ts, body);
+    expect(await verifySlackSignature(secret, body, sig, "not-a-number", ts)).toBe(false);
+  });
+});
+
+describe("verifyGenericSignature", () => {
+  const secret = "shhh";
+  const body = "ping";
+
+  it("accepts the bare hex form", async () => {
+    const sig = await signGenericPayload(secret, body);
+    expect(await verifyGenericSignature(secret, body, sig)).toBe(true);
+  });
+
+  it("accepts the sha256= prefixed form", async () => {
+    const sig = await signGenericPayload(secret, body);
+    expect(await verifyGenericSignature(secret, body, `sha256=${sig}`)).toBe(true);
+  });
+
+  it("rejects a wrong-secret signature", async () => {
+    const sig = await signGenericPayload("other-secret", body);
+    expect(await verifyGenericSignature(secret, body, sig)).toBe(false);
+  });
+
+  it("rejects null signature", async () => {
+    expect(await verifyGenericSignature(secret, body, null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

PDX-19 [C3] — Hono migration of the helm control-plane Worker, plus the WebSocket Worker and webhook stubs that were waiting on PDX-20/22/23/25.

- `src/workers/app.ts` — new Hono app with the full route table:
  - **Public**: `GET /api/health`, `POST /api/auth/{session,logout}`, `POST /api/webhooks/{github,slack,generic}`
  - **Protected** (helm JWT, audit-logged): `GET /api/environments`, `POST /api/onboarding/check`, `GET /api/resources`, `POST /api/workflows/:slug/instances`, `POST /api/workflows/deploy/instances/:id/approve`, `GET /api/workflows/:slug/instances/:id`, `GET /api/sessions/:sessionId/ws`
- `src/workers/control-plane.ts` — slimmed to a Worker shell that exports `ControlPlaneRegistry` and dispatches into the Hono app.
- `src/shared/webhooks.ts` — constant-time HMAC validators for GitHub (sha256), Slack (v0 + 5min replay window), and generic webhooks.
- WebSocket path accepts the helm JWT via `Authorization` header *or* `?token=` query param (browser WebSocket clients can't set custom headers) and forwards the upgrade to the per-session DO with `x-helm-user-id` + `x-helm-session-id` attribution headers (PDX-20 contract).
- Webhook stubs validate, log, return 202. Event dispatch deferred to PDX-26 with TODO markers.

## Constraints honored

- No changes to `crates/`, `src/db/schema.ts`, `src/shared/auth.ts`, `src/workers/durable-objects/`, `src/workers/workflows/`, `Dockerfile.agent-runtime`, or `wrangler.agent-runtime.toml`.
- `SESSION_DO` and the workflow bindings are typed as optional on `ControlPlaneEnv` so the Worker still typechecks before PDX-20's wrangler additions reach master; routes that need them return 503 when unbound.
- Audit attribution is replicated as a Hono middleware that writes the same `audit_log` row shape as `withAuditAttribution`. Hono's `next()` semantics don't compose cleanly with the closure-style helper, but the row shape is identical.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 87 / 87 passing (9 test files), including:
  - 18 new control-plane Hono route tests (route table, JWT-via-header, JWT-via-query, WS attribution, webhook HMACs, Doppler fallback, logout denylist, 404)
  - 14 new HMAC validator unit tests
- [x] Existing test suite untouched
- [ ] Live-deploy WS upgrade (deferred — Workers runtime required for actual 101 Switching Protocols)

## Helm-cloud extraction note

`app.ts` is the natural seam for the eventual `helm-cloud` repo extraction — the Hono app has no tight binding to the Worker shell. Only `control-plane.ts` and the DO/workflow class exports stay coupled to wrangler bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)