### PR TITLE
PDX-18 [C2] cloud_client crate: WebSocket client + RemoteAgent impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,6 +2832,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloud_client"
+version = "0.1.0"
+dependencies = [
+ "agents",
+ "async-stream",
+ "async-trait",
+ "chrono",
+ "cloud_protocol",
+ "futures-util",
+ "orchestrator",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "cloud_protocol"
 version = "0.1.0"
 dependencies = [
@@ -13649,6 +13670,22 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.39",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ default-members = [
   "crates/agents",
   "crates/auto_healing",
   "crates/channel_versions",
+  "crates/cloud_client",
   "crates/cloud_protocol",
   "crates/command",
   "crates/doppler",
@@ -49,6 +50,7 @@ app-installation-detection = { path = "crates/app-installation-detection" }
 asset_cache = { path = "crates/asset_cache" }
 asset_macro = { path = "crates/asset_macro" }
 channel_versions = { path = "crates/channel_versions", default-features = false }
+cloud_client = { path = "crates/cloud_client" }
 cloud_protocol = { path = "crates/cloud_protocol" }
 command = { path = "crates/command" }
 command-signatures-v2 = { path = "crates/command-signatures-v2" }

--- a/crates/cloud_client/Cargo.toml
+++ b/crates/cloud_client/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "cloud_client"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "Native WebSocket client for the Warp cloud control plane (PDX-18)."
+
+# Native-only: this crate uses tokio-tungstenite and is intentionally not
+# part of the wasm32 build set. The transport layer is abstracted behind a
+# trait so the reconnect/resume state machine can be unit-tested without
+# real network IO.
+
+[dependencies]
+agents = { workspace = true }
+async-stream = { workspace = true }
+async-trait = { workspace = true }
+chrono = { workspace = true }
+cloud_protocol = { workspace = true }
+futures-util = { workspace = true }
+orchestrator = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = [
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "macros",
+    "time",
+    "io-util",
+] }
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
+tracing = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+futures-util = { workspace = true }
+tokio = { workspace = true, features = [
+    "rt-multi-thread",
+    "macros",
+    "sync",
+    "time",
+    "test-util",
+] }

--- a/crates/cloud_client/src/agent.rs
+++ b/crates/cloud_client/src/agent.rs
@@ -1,0 +1,446 @@
+//! `orchestrator::Agent` impl for the cloud backend.
+//!
+//! Each call to [`CloudAgent::execute`] spawns a driver task that:
+//!
+//! 1. Connects to the configured WebSocket URL via the supplied transport
+//!    factory (production = `tokio-tungstenite`; tests = in-memory pair).
+//! 2. Sends a [`cloud_protocol::TaskSubmit`] for the task.
+//! 3. Streams [`cloud_protocol::TaskEvent`]s back, translates them to
+//!    [`orchestrator::AgentEvent`]s, and pushes them into a channel that
+//!    the returned `AgentEventStream` drains.
+//! 4. On unexpected disconnect, applies the [`crate::ReconnectPolicy`],
+//!    flips the public health flag to `unhealthy`, reconnects, and sends
+//!    a [`crate::session::resume_message`] so the server can replay
+//!    events from `last_sequence + 1`.
+//! 5. Stops on the first terminal `TaskResult` (Success / Failed /
+//!    Cancelled) or on policy exhaustion.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_stream::stream;
+use async_trait::async_trait;
+use chrono::Utc;
+use cloud_protocol::{
+    Envelope, Message, OutputStream, TaskEvent, TaskEventKind, TaskResult, TaskSubmit, V1Message,
+};
+use orchestrator::{
+    Agent, AgentError, AgentEvent, AgentEventStream, AgentId, Capabilities, Health, Role, Task,
+    TaskId,
+};
+use serde_json::json;
+use tokio::sync::{mpsc, Mutex};
+use tracing::{debug, warn};
+
+use crate::error::ConnectError;
+use crate::reconnect::{ReconnectDecision, ReconnectPolicy};
+use crate::session::{resume_message, SessionState};
+use crate::transport::{Transport, TransportError, TungsteniteTransport};
+
+/// Context window the production cloud tier is expected to expose.
+/// Mirrors the value advertised by the (now-superseded) stub
+/// `agents::RemoteAgent` so the router sees consistent capabilities.
+pub const CLOUD_CONTEXT_TOKENS: u32 = 200_000;
+
+/// Boxed async factory for opening a fresh [`Transport`].
+///
+/// Returns `Err(ConnectError)` if the connect attempt itself fails (so
+/// the reconnect policy can apply); a returned transport is assumed
+/// usable until its `recv` produces `Closed`.
+pub type TransportFactory = Arc<
+    dyn Fn() -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<Box<dyn Transport>, ConnectError>> + Send>,
+        > + Send
+        + Sync,
+>;
+
+/// Config for a [`CloudAgent`].
+#[derive(Clone)]
+pub struct CloudAgentConfig {
+    /// Stable agent id surfaced to the orchestrator.
+    pub id: AgentId,
+    /// Reconnect / backoff policy.
+    pub reconnect: ReconnectPolicy,
+    /// Factory that opens a fresh [`Transport`] each connect attempt.
+    pub transport_factory: TransportFactory,
+}
+
+impl CloudAgentConfig {
+    /// Convenience constructor for the production case: connect to the
+    /// given `wss://…` URL using `tokio-tungstenite`.
+    pub fn websocket(id: AgentId, url: impl Into<String>, reconnect: ReconnectPolicy) -> Self {
+        let url: String = url.into();
+        let transport_factory: TransportFactory = Arc::new(move || {
+            let url = url.clone();
+            Box::pin(async move {
+                let t = TungsteniteTransport::connect(&url).await?;
+                let boxed: Box<dyn Transport> = Box::new(t);
+                Ok(boxed)
+            })
+        });
+        Self {
+            id,
+            reconnect,
+            transport_factory,
+        }
+    }
+}
+
+/// `orchestrator::Agent` backed by a WebSocket cloud worker.
+pub struct CloudAgent {
+    id: AgentId,
+    capabilities: Capabilities,
+    health: Arc<Mutex<Health>>,
+    config: CloudAgentConfig,
+}
+
+impl CloudAgent {
+    /// Construct a new agent. The transport is opened lazily on the
+    /// first call to [`Agent::execute`], so this is infallible.
+    pub fn new(config: CloudAgentConfig) -> Self {
+        let roles: HashSet<Role> = [
+            Role::Planner,
+            Role::Reviewer,
+            Role::Worker,
+            Role::BulkRefactor,
+            Role::Summarize,
+            Role::ToolRouter,
+            Role::Inline,
+        ]
+        .into_iter()
+        .collect();
+        let capabilities = Capabilities {
+            roles,
+            max_context_tokens: CLOUD_CONTEXT_TOKENS,
+            supports_tools: true,
+            supports_vision: true,
+        };
+        // We start optimistic; the driver will flip us unhealthy if
+        // reconnect is exhausted.
+        let health = Arc::new(Mutex::new(Health {
+            healthy: true,
+            last_check: Utc::now(),
+            error_rate: 0.0,
+        }));
+        Self {
+            id: config.id.clone(),
+            capabilities,
+            health,
+            config,
+        }
+    }
+
+    async fn set_healthy(health: &Arc<Mutex<Health>>, healthy: bool) {
+        let mut g = health.lock().await;
+        g.healthy = healthy;
+        g.last_check = Utc::now();
+    }
+}
+
+#[async_trait]
+impl Agent for CloudAgent {
+    fn id(&self) -> AgentId {
+        self.id.clone()
+    }
+
+    fn capabilities(&self) -> &Capabilities {
+        &self.capabilities
+    }
+
+    fn health(&self) -> Health {
+        if let Ok(g) = self.health.try_lock() {
+            g.clone()
+        } else {
+            // Conservative: if we can't read it, report best-effort fresh.
+            Health {
+                healthy: true,
+                last_check: Utc::now(),
+                error_rate: 0.0,
+            }
+        }
+    }
+
+    async fn execute(&self, task: Task) -> Result<AgentEventStream, AgentError> {
+        let (tx, mut rx) = mpsc::channel::<AgentEvent>(64);
+        let task_id = task.id;
+        let cloud_task_id = format!("{}", task_id.0);
+        let role = task.role;
+        let prompt = task.prompt.clone();
+        let cwd = task
+            .context
+            .cwd
+            .to_string_lossy()
+            .to_string();
+        let factory = self.config.transport_factory.clone();
+        let policy = self.config.reconnect.clone();
+        let health = self.health.clone();
+
+        tokio::spawn(async move {
+            run_session(
+                task_id,
+                cloud_task_id,
+                role,
+                prompt,
+                cwd,
+                factory,
+                policy,
+                health,
+                tx,
+            )
+            .await;
+        });
+
+        let s = stream! {
+            while let Some(ev) = rx.recv().await {
+                yield ev;
+            }
+        };
+        Ok(Box::pin(s))
+    }
+}
+
+/// Driver loop. Owns the session state and the reconnect policy, fans
+/// `AgentEvent`s into `tx`, and exits as soon as it observes a terminal
+/// `TaskResult` or runs out of reconnect budget.
+#[allow(clippy::too_many_arguments)]
+async fn run_session(
+    task_id: TaskId,
+    cloud_task_id: String,
+    role: Role,
+    prompt: String,
+    cwd: String,
+    factory: TransportFactory,
+    policy: ReconnectPolicy,
+    health: Arc<Mutex<Health>>,
+    tx: mpsc::Sender<AgentEvent>,
+) {
+    let mut session = SessionState::new();
+    session.mark_submitted(&cloud_task_id);
+    let mut started_emitted = false;
+    let mut attempt: u32 = 0;
+    let mut submitted = false;
+
+    loop {
+        // (Re)connect.
+        let transport = match (factory)().await {
+            Ok(t) => {
+                CloudAgent::set_healthy(&health, true).await;
+                attempt = 0;
+                t
+            }
+            Err(err) => {
+                warn!(?err, "cloud_client connect failed");
+                CloudAgent::set_healthy(&health, false).await;
+                attempt = attempt.saturating_add(1);
+                match policy.next_decision(attempt) {
+                    ReconnectDecision::Retry { delay, .. } => {
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    ReconnectDecision::GiveUp => {
+                        let _ = tx
+                            .send(AgentEvent::Failed {
+                                task_id,
+                                error: format!(
+                                    "cloud_client: reconnect exhausted: {err}"
+                                ),
+                            })
+                            .await;
+                        return;
+                    }
+                }
+            }
+        };
+
+        // Drive one connection. If it terminates without a final task
+        // result, the loop tries again per the reconnect policy.
+        let outcome = drive_connection(
+            transport,
+            &cloud_task_id,
+            role,
+            &prompt,
+            &cwd,
+            &mut session,
+            &mut started_emitted,
+            &mut submitted,
+            task_id,
+            &tx,
+        )
+        .await;
+
+        match outcome {
+            ConnectionOutcome::Terminal => {
+                // Task ended; we're done.
+                return;
+            }
+            ConnectionOutcome::Disconnected => {
+                CloudAgent::set_healthy(&health, false).await;
+                attempt = attempt.saturating_add(1);
+                match policy.next_decision(attempt) {
+                    ReconnectDecision::Retry { delay, .. } => {
+                        debug!(?delay, attempt, "cloud_client reconnecting");
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    ReconnectDecision::GiveUp => {
+                        let _ = tx
+                            .send(AgentEvent::Failed {
+                                task_id,
+                                error:
+                                    "cloud_client: reconnect attempts exhausted after disconnect"
+                                        .to_string(),
+                            })
+                            .await;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+enum ConnectionOutcome {
+    /// We saw a terminal `TaskResult` — the driver should exit.
+    Terminal,
+    /// The transport closed before any terminal event — let the policy
+    /// decide whether to reconnect.
+    Disconnected,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drive_connection(
+    mut transport: Box<dyn Transport>,
+    task_id_str: &str,
+    role: Role,
+    prompt: &str,
+    cwd: &str,
+    session: &mut SessionState,
+    started_emitted: &mut bool,
+    submitted: &mut bool,
+    task_id: TaskId,
+    tx: &mpsc::Sender<AgentEvent>,
+) -> ConnectionOutcome {
+    // Resume hints for any in-flight tasks, sent before re-submitting.
+    if *submitted {
+        for hint in session.resume_hints() {
+            let env = resume_message(&hint);
+            if transport.send(env).await.is_err() {
+                return ConnectionOutcome::Disconnected;
+            }
+        }
+    } else {
+        // First connection: submit the task.
+        let submit = TaskSubmit {
+            task_id: task_id_str.to_string(),
+            kind: "agent".to_string(),
+            payload: json!({
+                "role": format!("{role:?}"),
+                "prompt": prompt,
+                "cwd": cwd,
+            }),
+            metadata: Default::default(),
+        };
+        let env = Envelope::v1(V1Message::TaskSubmit(submit));
+        if transport.send(env).await.is_err() {
+            return ConnectionOutcome::Disconnected;
+        }
+        *submitted = true;
+    }
+
+    // Read events until terminal or disconnect.
+    loop {
+        let env_opt = match transport.recv().await {
+            Ok(opt) => opt,
+            Err(TransportError::Closed) => return ConnectionOutcome::Disconnected,
+            Err(e) => {
+                warn!(?e, "cloud_client recv error");
+                return ConnectionOutcome::Disconnected;
+            }
+        };
+        let env = match env_opt {
+            Some(e) => e,
+            None => return ConnectionOutcome::Disconnected,
+        };
+        let Message::V1(v1) = env.message;
+        let evt = match v1 {
+            V1Message::TaskEvent(e) => e,
+            _ => continue,
+        };
+        if evt.task_id != task_id_str {
+            continue;
+        }
+        if session.is_duplicate(&evt.task_id, evt.sequence) {
+            continue;
+        }
+        session.observe(&evt.task_id, evt.sequence);
+
+        if !*started_emitted {
+            *started_emitted = true;
+            if tx.send(AgentEvent::Started { task_id }).await.is_err() {
+                return ConnectionOutcome::Terminal; // consumer hung up
+            }
+        }
+
+        match translate(task_id, evt) {
+            TranslatedEvent::Forward(ev) => {
+                if tx.send(ev).await.is_err() {
+                    return ConnectionOutcome::Terminal;
+                }
+            }
+            TranslatedEvent::Terminal(ev) => {
+                let _ = tx.send(ev).await;
+                session.complete(task_id_str);
+                return ConnectionOutcome::Terminal;
+            }
+            TranslatedEvent::Drop => {}
+        }
+    }
+}
+
+enum TranslatedEvent {
+    /// Forward a single non-terminal `AgentEvent`.
+    Forward(AgentEvent),
+    /// Forward a terminal `AgentEvent` (Completed/Failed); the driver
+    /// must exit after sending it.
+    Terminal(AgentEvent),
+    /// Nothing of interest (e.g. Progress with no ergonomic mapping).
+    Drop,
+}
+
+fn translate(task_id: TaskId, evt: TaskEvent) -> TranslatedEvent {
+    match evt.kind {
+        TaskEventKind::StatusChanged { .. } => TranslatedEvent::Drop,
+        TaskEventKind::Progress { .. } => TranslatedEvent::Drop,
+        TaskEventKind::Output { stream, data } => {
+            // Map every output stream onto an OutputChunk; the prefix
+            // disambiguates stderr/log/agent if the consumer cares.
+            let text = match stream {
+                OutputStream::Stdout | OutputStream::Agent => data,
+                OutputStream::Stderr => format!("[stderr] {data}"),
+                OutputStream::Log => format!("[log] {data}"),
+            };
+            TranslatedEvent::Forward(AgentEvent::OutputChunk { text })
+        }
+        TaskEventKind::Completed { result } => match result {
+            TaskResult::Success { output } => {
+                let summary = output.and_then(|v| match v {
+                    serde_json::Value::String(s) => Some(s),
+                    other => Some(other.to_string()),
+                });
+                TranslatedEvent::Terminal(AgentEvent::Completed { task_id, summary })
+            }
+            TaskResult::Error {
+                code,
+                message,
+                details: _,
+            } => TranslatedEvent::Terminal(AgentEvent::Failed {
+                task_id,
+                error: format!("{code}: {message}"),
+            }),
+            TaskResult::Cancelled => TranslatedEvent::Terminal(AgentEvent::Failed {
+                task_id,
+                error: "cancelled".to_string(),
+            }),
+        },
+    }
+}

--- a/crates/cloud_client/src/error.rs
+++ b/crates/cloud_client/src/error.rs
@@ -1,0 +1,34 @@
+//! Error types for the cloud client.
+
+use thiserror::Error;
+
+/// Anything that can go wrong opening or driving a cloud connection.
+#[derive(Debug, Error)]
+pub enum CloudClientError {
+    /// Failed to open the underlying transport (network, TLS, handshake, …).
+    #[error(transparent)]
+    Connect(#[from] ConnectError),
+    /// Failed to encode/decode a wire frame.
+    #[error("protocol error: {0}")]
+    Protocol(String),
+    /// The transport ended cleanly without a terminal task event.
+    #[error("transport closed before terminal event")]
+    UnexpectedClose,
+    /// All reconnect attempts have been exhausted (or are exhausted by policy).
+    #[error("reconnect attempts exhausted")]
+    ReconnectExhausted,
+    /// Catch-all.
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Specific failures from the connect phase.
+#[derive(Debug, Error)]
+pub enum ConnectError {
+    /// The configured cloud URL was missing or malformed.
+    #[error("invalid cloud url: {0}")]
+    InvalidUrl(String),
+    /// The handshake or TCP/TLS connect failed.
+    #[error("transport handshake failed: {0}")]
+    Handshake(String),
+}

--- a/crates/cloud_client/src/lib.rs
+++ b/crates/cloud_client/src/lib.rs
@@ -1,0 +1,59 @@
+//! # `cloud_client`
+//!
+//! Native WebSocket client for the Warp cloud control plane.
+//!
+//! This crate implements the client side of the [`cloud_protocol`] wire
+//! format: it opens a WebSocket to a configured URL, submits tasks via
+//! [`cloud_protocol::TaskSubmit`], streams [`cloud_protocol::TaskEvent`]s
+//! back to the caller, and translates the protocol-level events into the
+//! [`orchestrator::AgentEvent`] vocabulary used by the rest of the app.
+//!
+//! ## Native-only
+//!
+//! `cloud_client` depends on `tokio-tungstenite` and is intentionally not
+//! part of the `wasm32-unknown-unknown` build set. The
+//! [`cloud_protocol`] crate is the part that's wasm-clean.
+//!
+//! ## Components
+//!
+//! * [`CloudAgent`] — `orchestrator::Agent` impl. The thing the rest of
+//!   the system talks to.
+//! * [`reconnect::ReconnectPolicy`] — exponential-backoff state machine,
+//!   independently testable.
+//! * [`transport::Transport`] — trait abstracting "send/recv a JSON frame".
+//!   The production impl wraps `tokio-tungstenite`; tests use an in-memory
+//!   channel pair.
+//!
+//! ## Resume on reconnect
+//!
+//! The protocol's [`cloud_protocol::TaskControl`] has a `Resume` variant,
+//! but in V1 it does not carry a sequence number. Forward-compat would let
+//! us add an optional field there, but since this PR cannot modify
+//! `cloud_protocol`, we send the resume hint via
+//! `TaskControl::Signal { name: "resume", payload: Some({"last_sequence":
+//! N}) }` instead. The Worker side (PDX-19) is expected to recognise
+//! either form. See [`session::resume_message`].
+//!
+//! ## Scope
+//!
+//! Per PDX-18, this PR delivers the standalone crate only. Wiring
+//! [`CloudAgent`] into the orchestrator's persistent Router is a future
+//! follow-up.
+
+#![cfg(not(target_family = "wasm"))]
+#![deny(missing_docs)]
+
+pub mod agent;
+pub mod error;
+pub mod reconnect;
+pub mod session;
+pub mod transport;
+
+#[cfg(test)]
+mod tests;
+
+pub use agent::{CloudAgent, CloudAgentConfig, CLOUD_CONTEXT_TOKENS};
+pub use error::{CloudClientError, ConnectError};
+pub use reconnect::{ReconnectDecision, ReconnectPolicy};
+pub use session::{ResumeHint, SessionState};
+pub use transport::{InMemoryTransport, Transport, TransportError, TungsteniteTransport};

--- a/crates/cloud_client/src/reconnect.rs
+++ b/crates/cloud_client/src/reconnect.rs
@@ -1,0 +1,133 @@
+//! Pure exponential-backoff reconnect policy.
+//!
+//! Holds no IO; all the time math is computed from the supplied attempt
+//! count so this is trivially unit-testable.
+
+use std::time::Duration;
+
+/// Decision returned by [`ReconnectPolicy::next_decision`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReconnectDecision {
+    /// Wait this long, then try again.
+    Retry {
+        /// Backoff delay before the next attempt.
+        delay: Duration,
+        /// 1-indexed attempt number (i.e. 1 for the first retry).
+        attempt: u32,
+    },
+    /// Give up — the policy's maximum has been reached.
+    GiveUp,
+}
+
+/// Exponential backoff with optional cap and a maximum number of attempts.
+///
+/// `delay = min(initial * 2^(attempt-1), max_delay)`.
+///
+/// The policy is deliberately deterministic (no jitter) so it's easy to
+/// reason about in tests; the production `CloudAgent` is welcome to add
+/// jitter on top if desired without changing this type.
+#[derive(Debug, Clone)]
+pub struct ReconnectPolicy {
+    initial: Duration,
+    max_delay: Duration,
+    max_attempts: Option<u32>,
+}
+
+impl ReconnectPolicy {
+    /// Construct a policy with the given initial delay, max delay cap, and
+    /// optional attempt ceiling. Pass `max_attempts = None` for "retry
+    /// forever".
+    pub fn new(initial: Duration, max_delay: Duration, max_attempts: Option<u32>) -> Self {
+        Self {
+            initial,
+            max_delay,
+            max_attempts,
+        }
+    }
+
+    /// A reasonable default: 200ms initial, 10s cap, retry forever.
+    pub fn default_forever() -> Self {
+        Self::new(Duration::from_millis(200), Duration::from_secs(10), None)
+    }
+
+    /// Compute what to do after `attempt` failed connect attempts.
+    /// `attempt` is 1-indexed: passing `1` means "we just failed once,
+    /// what now?".
+    pub fn next_decision(&self, attempt: u32) -> ReconnectDecision {
+        if let Some(cap) = self.max_attempts {
+            if attempt > cap {
+                return ReconnectDecision::GiveUp;
+            }
+        }
+        // attempt=1 → 2^0=1; attempt=2 → 2^1=2; etc.
+        // saturate to avoid overflow on absurd attempt counts.
+        let shift = attempt.saturating_sub(1).min(20);
+        let multiplier = 1u64.checked_shl(shift).unwrap_or(u64::MAX);
+        let raw = self.initial.saturating_mul(multiplier as u32);
+        let delay = if raw > self.max_delay {
+            self.max_delay
+        } else {
+            raw
+        };
+        ReconnectDecision::Retry { delay, attempt }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn doubles_until_cap() {
+        let p = ReconnectPolicy::new(
+            Duration::from_millis(100),
+            Duration::from_millis(800),
+            None,
+        );
+        let d = |a| match p.next_decision(a) {
+            ReconnectDecision::Retry { delay, .. } => delay,
+            ReconnectDecision::GiveUp => panic!("unexpected give-up"),
+        };
+        assert_eq!(d(1), Duration::from_millis(100));
+        assert_eq!(d(2), Duration::from_millis(200));
+        assert_eq!(d(3), Duration::from_millis(400));
+        assert_eq!(d(4), Duration::from_millis(800));
+        // Cap holds.
+        assert_eq!(d(5), Duration::from_millis(800));
+        assert_eq!(d(20), Duration::from_millis(800));
+    }
+
+    #[test]
+    fn gives_up_after_max_attempts() {
+        let p = ReconnectPolicy::new(
+            Duration::from_millis(10),
+            Duration::from_millis(100),
+            Some(3),
+        );
+        assert!(matches!(
+            p.next_decision(1),
+            ReconnectDecision::Retry { .. }
+        ));
+        assert!(matches!(
+            p.next_decision(3),
+            ReconnectDecision::Retry { .. }
+        ));
+        assert_eq!(p.next_decision(4), ReconnectDecision::GiveUp);
+    }
+
+    #[test]
+    fn never_overflows_on_huge_attempt_counts() {
+        let p = ReconnectPolicy::new(
+            Duration::from_millis(50),
+            Duration::from_millis(1000),
+            None,
+        );
+        // Should saturate at the cap, not panic.
+        match p.next_decision(u32::MAX) {
+            ReconnectDecision::Retry { delay, .. } => {
+                assert_eq!(delay, Duration::from_millis(1000));
+            }
+            _ => panic!("retry expected"),
+        }
+    }
+}

--- a/crates/cloud_client/src/session.rs
+++ b/crates/cloud_client/src/session.rs
@@ -1,0 +1,165 @@
+//! Per-task session state for resume-on-reconnect.
+//!
+//! On reconnect the client must tell the server which events it has
+//! already seen so the server can replay only the missing tail. We track
+//! the highest delivered `sequence` per task and emit a resume hint
+//! whenever a connection comes back up while a task is still in flight.
+
+use std::collections::HashMap;
+
+use cloud_protocol::{Envelope, TaskControl, V1Message};
+use serde_json::json;
+
+/// What the server needs to know to replay events from the right place.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResumeHint {
+    /// Which task to resume.
+    pub task_id: String,
+    /// Highest `sequence` the client has already observed for this task.
+    /// The server should replay events with `sequence > last_sequence`.
+    pub last_sequence: u64,
+}
+
+/// Tracks the high-water sequence number for each in-flight task so we
+/// can build a [`ResumeHint`] on reconnect.
+#[derive(Debug, Default, Clone)]
+pub struct SessionState {
+    /// Map of task_id → highest sequence observed.
+    inflight: HashMap<String, u64>,
+}
+
+impl SessionState {
+    /// Empty state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark this task as in-flight (no events yet observed).
+    pub fn mark_submitted(&mut self, task_id: &str) {
+        self.inflight.entry(task_id.to_string()).or_insert(0);
+    }
+
+    /// Record an observed event sequence for this task. The high-water
+    /// is monotonic — out-of-order/duplicate events do not lower it.
+    pub fn observe(&mut self, task_id: &str, sequence: u64) {
+        let entry = self.inflight.entry(task_id.to_string()).or_insert(0);
+        if sequence > *entry {
+            *entry = sequence;
+        }
+    }
+
+    /// Drop tracking for a task that has reached a terminal event. After
+    /// this the task is considered finished and no resume hint should be
+    /// emitted for it on reconnect.
+    pub fn complete(&mut self, task_id: &str) {
+        self.inflight.remove(task_id);
+    }
+
+    /// Return `true` if this is the very first event observed for the
+    /// task (used for dedupe-on-reconnect).
+    pub fn is_duplicate(&self, task_id: &str, sequence: u64) -> bool {
+        match self.inflight.get(task_id) {
+            // We've already seen at least this sequence number for this task.
+            // sequence == 0 with stored == 0 is ambiguous (could be the very
+            // first event or a replay) — treat strictly less-or-equal-and-
+            // already-observed as duplicate. We special-case sequence 0 only
+            // when we've recorded a higher sequence, otherwise let it through.
+            Some(&hw) => sequence != 0 && sequence <= hw,
+            None => false,
+        }
+    }
+
+    /// Snapshot all in-flight tasks as resume hints, in unspecified order.
+    pub fn resume_hints(&self) -> Vec<ResumeHint> {
+        self.inflight
+            .iter()
+            .map(|(task_id, &last_sequence)| ResumeHint {
+                task_id: task_id.clone(),
+                last_sequence,
+            })
+            .collect()
+    }
+}
+
+/// Build a `TaskControl` envelope that carries a resume hint.
+///
+/// The protocol's V1 `Resume` variant only takes `task_id`; to thread the
+/// `last_sequence` through without modifying `cloud_protocol`, we send a
+/// `Signal { name: "resume" }` whose `payload` carries the sequence
+/// number. This is forward-compatible with a future `Resume {
+/// last_sequence }` variant: a server that understands the new variant
+/// can keep accepting the signal form alongside it.
+pub fn resume_message(hint: &ResumeHint) -> Envelope {
+    Envelope::v1(V1Message::TaskControl(TaskControl::Signal {
+        task_id: hint.task_id.clone(),
+        name: "resume".to_string(),
+        payload: Some(json!({ "last_sequence": hint.last_sequence })),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn high_water_is_monotonic() {
+        let mut s = SessionState::new();
+        s.mark_submitted("t1");
+        s.observe("t1", 0);
+        s.observe("t1", 5);
+        s.observe("t1", 3); // out-of-order: should not regress
+        let hints = s.resume_hints();
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].task_id, "t1");
+        assert_eq!(hints[0].last_sequence, 5);
+    }
+
+    #[test]
+    fn complete_drops_from_resume_set() {
+        let mut s = SessionState::new();
+        s.mark_submitted("t1");
+        s.mark_submitted("t2");
+        s.observe("t1", 2);
+        s.observe("t2", 7);
+        s.complete("t1");
+        let hints = s.resume_hints();
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].task_id, "t2");
+        assert_eq!(hints[0].last_sequence, 7);
+    }
+
+    #[test]
+    fn is_duplicate_after_observe() {
+        let mut s = SessionState::new();
+        s.mark_submitted("t1");
+        s.observe("t1", 5);
+        assert!(s.is_duplicate("t1", 3));
+        assert!(s.is_duplicate("t1", 5));
+        assert!(!s.is_duplicate("t1", 6));
+        assert!(!s.is_duplicate("t2", 1));
+    }
+
+    #[test]
+    fn resume_message_round_trips() {
+        let hint = ResumeHint {
+            task_id: "task-42".into(),
+            last_sequence: 17,
+        };
+        let env = resume_message(&hint);
+        let bytes = serde_json::to_vec(&env).unwrap();
+        let parsed = cloud_protocol::parse_message(&bytes).unwrap();
+        match parsed.message {
+            cloud_protocol::Message::V1(V1Message::TaskControl(TaskControl::Signal {
+                task_id,
+                name,
+                payload,
+            })) => {
+                assert_eq!(task_id, "task-42");
+                assert_eq!(name, "resume");
+                let p = payload.expect("payload");
+                assert_eq!(p["last_sequence"], 17);
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+}

--- a/crates/cloud_client/src/tests.rs
+++ b/crates/cloud_client/src/tests.rs
@@ -1,0 +1,444 @@
+//! End-to-end tests using the in-memory transport.
+//!
+//! The reconnect/resume state machine is unit-tested in
+//! `reconnect.rs` and `session.rs`; this module proves the pieces wire
+//! together correctly: a [`crate::CloudAgent`] paired with a server-side
+//! [`crate::InMemoryTransport`] should round-trip a TaskSubmit into a
+//! TaskEvent stream that surfaces as `AgentEvent`s on the orchestrator
+//! side.
+
+use std::path::PathBuf;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
+use std::time::Duration;
+
+use cloud_protocol::{
+    Envelope, Message, OutputStream, TaskControl, TaskEvent, TaskEventKind, TaskResult,
+    V1Message,
+};
+use futures_util::StreamExt;
+use orchestrator::{Agent, AgentEvent, AgentId, Role, Task, TaskContext, TaskId};
+use tokio::sync::mpsc;
+
+use crate::agent::{CloudAgent, CloudAgentConfig, TransportFactory};
+use crate::error::ConnectError;
+use crate::reconnect::ReconnectPolicy;
+use crate::transport::{InMemoryTransport, Transport};
+
+/// Build a synthetic Task that the cloud agent will dispatch.
+fn make_task() -> Task {
+    Task {
+        id: TaskId::new(),
+        role: Role::Worker,
+        prompt: "do the thing".into(),
+        context: TaskContext {
+            cwd: PathBuf::from("/tmp"),
+            env: Default::default(),
+            metadata: Default::default(),
+        },
+        budget_hint: None,
+    }
+}
+
+/// Server-side helper: pop the next frame from the transport, asserting
+/// it parses as the expected variant.
+async fn expect_submit(t: &mut InMemoryTransport) -> String {
+    let env = t.recv().await.unwrap().expect("frame");
+    let Message::V1(v1) = env.message;
+    match v1 {
+        V1Message::TaskSubmit(s) => s.task_id,
+        other => panic!("expected TaskSubmit, got {other:?}"),
+    }
+}
+
+async fn send_event(t: &mut InMemoryTransport, evt: TaskEvent) {
+    let env = Envelope::v1(V1Message::TaskEvent(evt));
+    t.send(env).await.unwrap();
+}
+
+/// Wrap a single in-memory transport in a one-shot factory: the first
+/// connect attempt yields the transport, subsequent attempts fail.
+fn one_shot_factory(t: InMemoryTransport) -> TransportFactory {
+    let cell = Arc::new(Mutex::new(Some(t)));
+    Arc::new(move || {
+        let cell = cell.clone();
+        Box::pin(async move {
+            let mut g = cell.lock().unwrap();
+            match g.take() {
+                Some(t) => {
+                    let boxed: Box<dyn Transport> = Box::new(t);
+                    Ok(boxed)
+                }
+                None => Err(ConnectError::Handshake("one-shot exhausted".into())),
+            }
+        })
+    })
+}
+
+#[tokio::test]
+async fn submit_round_trips_to_event_stream() {
+    let (client_t, mut server_t) = InMemoryTransport::pair();
+    let policy = ReconnectPolicy::new(
+        Duration::from_millis(5),
+        Duration::from_millis(20),
+        Some(0), // no retries
+    );
+    let factory = one_shot_factory(client_t);
+    let agent = CloudAgent::new(CloudAgentConfig {
+        id: AgentId("cloud".into()),
+        reconnect: policy,
+        transport_factory: factory,
+    });
+
+    let task = make_task();
+    let task_id = task.id;
+
+    let stream = agent.execute(task).await.unwrap();
+    tokio::pin!(stream);
+
+    // Server reads the submit, then drives a synthetic task lifecycle.
+    let cloud_task_id = expect_submit(&mut server_t).await;
+    send_event(
+        &mut server_t,
+        TaskEvent {
+            task_id: cloud_task_id.clone(),
+            sequence: 0,
+            timestamp: None,
+            kind: TaskEventKind::Output {
+                stream: OutputStream::Stdout,
+                data: "hello\n".into(),
+            },
+        },
+    )
+    .await;
+    send_event(
+        &mut server_t,
+        TaskEvent {
+            task_id: cloud_task_id.clone(),
+            sequence: 1,
+            timestamp: None,
+            kind: TaskEventKind::Completed {
+                result: TaskResult::Success {
+                    output: Some(serde_json::json!("done!")),
+                },
+            },
+        },
+    )
+    .await;
+
+    // Collect events until terminal.
+    let mut got_started = false;
+    let mut got_chunk: Option<String> = None;
+    let mut got_completed = false;
+    while let Some(ev) = stream.next().await {
+        match ev {
+            AgentEvent::Started { task_id: t } => {
+                assert_eq!(t, task_id);
+                got_started = true;
+            }
+            AgentEvent::OutputChunk { text } => got_chunk = Some(text),
+            AgentEvent::Completed {
+                task_id: t,
+                summary,
+            } => {
+                assert_eq!(t, task_id);
+                assert_eq!(summary.as_deref(), Some("done!"));
+                got_completed = true;
+                break;
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+    assert!(got_started, "Started not emitted");
+    assert_eq!(got_chunk.as_deref(), Some("hello\n"));
+    assert!(got_completed, "Completed not emitted");
+}
+
+#[tokio::test]
+async fn task_failure_translates_to_failed_event() {
+    let (client_t, mut server_t) = InMemoryTransport::pair();
+    let factory = one_shot_factory(client_t);
+    let agent = CloudAgent::new(CloudAgentConfig {
+        id: AgentId("cloud".into()),
+        reconnect: ReconnectPolicy::new(
+            Duration::from_millis(5),
+            Duration::from_millis(20),
+            Some(0),
+        ),
+        transport_factory: factory,
+    });
+
+    let task = make_task();
+    let task_id = task.id;
+    let stream = agent.execute(task).await.unwrap();
+    tokio::pin!(stream);
+
+    let cloud_task_id = expect_submit(&mut server_t).await;
+    send_event(
+        &mut server_t,
+        TaskEvent {
+            task_id: cloud_task_id,
+            sequence: 0,
+            timestamp: None,
+            kind: TaskEventKind::Completed {
+                result: TaskResult::Error {
+                    code: "boom".into(),
+                    message: "kaboom".into(),
+                    details: None,
+                },
+            },
+        },
+    )
+    .await;
+
+    let mut saw_failed = false;
+    while let Some(ev) = stream.next().await {
+        if let AgentEvent::Failed {
+            task_id: t,
+            error,
+        } = ev
+        {
+            assert_eq!(t, task_id);
+            assert!(error.contains("boom"));
+            assert!(error.contains("kaboom"));
+            saw_failed = true;
+            break;
+        }
+    }
+    assert!(saw_failed, "Failed event not emitted");
+}
+
+#[tokio::test]
+async fn cancelled_terminal_translates_to_failed_cancelled() {
+    let (client_t, mut server_t) = InMemoryTransport::pair();
+    let factory = one_shot_factory(client_t);
+    let agent = CloudAgent::new(CloudAgentConfig {
+        id: AgentId("cloud".into()),
+        reconnect: ReconnectPolicy::new(
+            Duration::from_millis(5),
+            Duration::from_millis(20),
+            Some(0),
+        ),
+        transport_factory: factory,
+    });
+
+    let task = make_task();
+    let stream = agent.execute(task).await.unwrap();
+    tokio::pin!(stream);
+
+    let cloud_task_id = expect_submit(&mut server_t).await;
+    send_event(
+        &mut server_t,
+        TaskEvent {
+            task_id: cloud_task_id,
+            sequence: 0,
+            timestamp: None,
+            kind: TaskEventKind::Completed {
+                result: TaskResult::Cancelled,
+            },
+        },
+    )
+    .await;
+
+    let mut saw = false;
+    while let Some(ev) = stream.next().await {
+        if let AgentEvent::Failed { error, .. } = ev {
+            assert_eq!(error, "cancelled");
+            saw = true;
+            break;
+        }
+    }
+    assert!(saw);
+}
+
+#[tokio::test]
+async fn reconnect_resumes_with_last_sequence_signal() {
+    // Two transports: the server-side of the FIRST connection drops mid-
+    // task; the SECOND connection should see a Resume signal that names
+    // the high-water sequence the client already saw.
+    let (client_a, mut server_a) = InMemoryTransport::pair();
+    let (client_b, mut server_b) = InMemoryTransport::pair();
+
+    let queue: Arc<Mutex<Vec<InMemoryTransport>>> = Arc::new(Mutex::new(vec![client_b, client_a]));
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_factory = attempts.clone();
+
+    let factory: TransportFactory = Arc::new(move || {
+        let queue = queue.clone();
+        let attempts = attempts_for_factory.clone();
+        Box::pin(async move {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            let mut g = queue.lock().unwrap();
+            match g.pop() {
+                Some(t) => {
+                    let boxed: Box<dyn Transport> = Box::new(t);
+                    Ok(boxed)
+                }
+                None => Err(ConnectError::Handshake("queue empty".into())),
+            }
+        })
+    });
+
+    let agent = CloudAgent::new(CloudAgentConfig {
+        id: AgentId("cloud".into()),
+        // Tight backoff so the test runs fast.
+        reconnect: ReconnectPolicy::new(
+            Duration::from_millis(1),
+            Duration::from_millis(5),
+            Some(5),
+        ),
+        transport_factory: factory,
+    });
+
+    let task = make_task();
+    let stream = agent.execute(task).await.unwrap();
+    tokio::pin!(stream);
+
+    // First connection: client submits, server delivers seq=3, then closes.
+    let cloud_task_id = expect_submit(&mut server_a).await;
+    send_event(
+        &mut server_a,
+        TaskEvent {
+            task_id: cloud_task_id.clone(),
+            sequence: 3,
+            timestamp: None,
+            kind: TaskEventKind::Output {
+                stream: OutputStream::Stdout,
+                data: "first\n".into(),
+            },
+        },
+    )
+    .await;
+    server_a.close().await.unwrap();
+
+    // Second connection: expect a Resume signal carrying last_sequence = 3.
+    let env = server_b.recv().await.unwrap().expect("resume frame");
+    let Message::V1(v1) = env.message;
+    let last = match v1 {
+        V1Message::TaskControl(TaskControl::Signal {
+            task_id,
+            name,
+            payload,
+        }) => {
+            assert_eq!(task_id, cloud_task_id);
+            assert_eq!(name, "resume");
+            payload.expect("payload")["last_sequence"]
+                .as_u64()
+                .expect("u64")
+        }
+        other => panic!("expected resume signal, got {other:?}"),
+    };
+    assert_eq!(last, 3);
+
+    // Server replays seq=4 and then completes. Client must not deliver a
+    // duplicate of seq=3 (which it already saw on the first connection)
+    // and should surface seq=4 plus the terminal Completed.
+    send_event(
+        &mut server_b,
+        TaskEvent {
+            task_id: cloud_task_id.clone(),
+            sequence: 3, // duplicate of what we already delivered
+            timestamp: None,
+            kind: TaskEventKind::Output {
+                stream: OutputStream::Stdout,
+                data: "should be deduped\n".into(),
+            },
+        },
+    )
+    .await;
+    send_event(
+        &mut server_b,
+        TaskEvent {
+            task_id: cloud_task_id.clone(),
+            sequence: 4,
+            timestamp: None,
+            kind: TaskEventKind::Output {
+                stream: OutputStream::Stdout,
+                data: "second\n".into(),
+            },
+        },
+    )
+    .await;
+    send_event(
+        &mut server_b,
+        TaskEvent {
+            task_id: cloud_task_id,
+            sequence: 5,
+            timestamp: None,
+            kind: TaskEventKind::Completed {
+                result: TaskResult::Success { output: None },
+            },
+        },
+    )
+    .await;
+
+    let mut chunks: Vec<String> = vec![];
+    let mut completed = false;
+    let (done_tx, mut done_rx) = mpsc::channel::<()>(1);
+    let collect = async {
+        while let Some(ev) = stream.next().await {
+            match ev {
+                AgentEvent::Started { .. } => {}
+                AgentEvent::OutputChunk { text } => chunks.push(text),
+                AgentEvent::Completed { .. } => {
+                    completed = true;
+                    let _ = done_tx.send(()).await;
+                    break;
+                }
+                AgentEvent::Failed { error, .. } => panic!("unexpected fail: {error}"),
+                _ => {}
+            }
+        }
+    };
+    tokio::select! {
+        _ = collect => {}
+        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+            panic!("test timed out; chunks so far: {chunks:?} completed={completed}");
+        }
+    }
+    let _ = done_rx.recv().await;
+
+    assert!(completed, "Completed not emitted");
+    assert_eq!(chunks, vec!["first\n".to_string(), "second\n".to_string()]);
+    assert!(attempts.load(Ordering::SeqCst) >= 2);
+}
+
+#[tokio::test]
+async fn reconnect_exhausted_flips_health_and_fails() {
+    // Factory always errors → policy gives up after 1 attempt.
+    let factory: TransportFactory = Arc::new(|| {
+        Box::pin(async {
+            Err::<Box<dyn Transport>, _>(ConnectError::Handshake("nope".into()))
+        })
+    });
+    let agent = CloudAgent::new(CloudAgentConfig {
+        id: AgentId("cloud".into()),
+        reconnect: ReconnectPolicy::new(
+            Duration::from_millis(1),
+            Duration::from_millis(2),
+            Some(1),
+        ),
+        transport_factory: factory,
+    });
+
+    let task = make_task();
+    let stream = agent.execute(task).await.unwrap();
+    tokio::pin!(stream);
+
+    let mut saw = false;
+    while let Some(ev) = stream.next().await {
+        if let AgentEvent::Failed { error, .. } = ev {
+            assert!(
+                error.contains("reconnect exhausted") || error.contains("nope"),
+                "unexpected error string: {error}"
+            );
+            saw = true;
+            break;
+        }
+    }
+    assert!(saw);
+    // Health should be flipped to unhealthy by the time the driver gave up.
+    assert!(!agent.health().healthy);
+}

--- a/crates/cloud_client/src/transport.rs
+++ b/crates/cloud_client/src/transport.rs
@@ -1,0 +1,198 @@
+//! Transport abstraction for the cloud client.
+//!
+//! The reconnect / resume / event-streaming logic in [`crate::agent`] is
+//! written against this trait so it can be exercised in unit and
+//! integration tests without opening a real socket. The production impl
+//! is [`TungsteniteTransport`]; tests use [`InMemoryTransport`].
+
+use async_trait::async_trait;
+use cloud_protocol::Envelope;
+use thiserror::Error;
+use tokio::sync::mpsc;
+
+use crate::error::ConnectError;
+
+/// Errors a [`Transport`] can surface.
+#[derive(Debug, Error)]
+pub enum TransportError {
+    /// Failed to establish a connection.
+    #[error(transparent)]
+    Connect(#[from] ConnectError),
+    /// The connection ended (cleanly or unexpectedly).
+    #[error("transport closed")]
+    Closed,
+    /// A wire frame failed to encode/decode.
+    #[error("encode/decode error: {0}")]
+    Codec(String),
+    /// The underlying socket reported an error.
+    #[error("io: {0}")]
+    Io(String),
+}
+
+/// Sink/stream pair for sending and receiving [`Envelope`]s.
+///
+/// Implementations must be `Send` so the agent can hand them off across
+/// task boundaries.
+#[async_trait]
+pub trait Transport: Send {
+    /// Send one frame. Returns `Err(Closed)` if the peer has gone away.
+    async fn send(&mut self, env: Envelope) -> Result<(), TransportError>;
+    /// Receive one frame. Returns `Ok(None)` when the peer closed cleanly,
+    /// `Err(Closed)` for an abrupt close, and `Err(Codec)` for malformed
+    /// frames.
+    async fn recv(&mut self) -> Result<Option<Envelope>, TransportError>;
+    /// Best-effort close.
+    async fn close(&mut self) -> Result<(), TransportError>;
+}
+
+// ---------------------------------------------------------------------------
+// Production: tokio-tungstenite
+// ---------------------------------------------------------------------------
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{Error as TungError, Message as WsMessage},
+    MaybeTlsStream, WebSocketStream,
+};
+
+/// Production [`Transport`] backed by `tokio-tungstenite`.
+///
+/// All non-text frames (binary, ping, pong, close) are handled
+/// transparently — only payload-bearing text frames are surfaced as
+/// [`Envelope`]s.
+pub struct TungsteniteTransport {
+    socket: WebSocketStream<MaybeTlsStream<TcpStream>>,
+}
+
+impl TungsteniteTransport {
+    /// Open a new connection to `url`.
+    pub async fn connect(url: &str) -> Result<Self, ConnectError> {
+        // Validate URL up-front so we surface a useful error before the
+        // tungstenite library digs into TLS / DNS.
+        let parsed =
+            url::Url::parse(url).map_err(|e| ConnectError::InvalidUrl(e.to_string()))?;
+        match parsed.scheme() {
+            "ws" | "wss" => {}
+            other => {
+                return Err(ConnectError::InvalidUrl(format!(
+                    "unsupported scheme: {other}"
+                )))
+            }
+        }
+        let (socket, _resp) = connect_async(url)
+            .await
+            .map_err(|e| ConnectError::Handshake(e.to_string()))?;
+        Ok(Self { socket })
+    }
+}
+
+#[async_trait]
+impl Transport for TungsteniteTransport {
+    async fn send(&mut self, env: Envelope) -> Result<(), TransportError> {
+        let bytes = serde_json::to_string(&env).map_err(|e| TransportError::Codec(e.to_string()))?;
+        self.socket
+            .send(WsMessage::Text(bytes))
+            .await
+            .map_err(map_tung_err)
+    }
+
+    async fn recv(&mut self) -> Result<Option<Envelope>, TransportError> {
+        loop {
+            let msg = match self.socket.next().await {
+                Some(Ok(m)) => m,
+                Some(Err(e)) => return Err(map_tung_err(e)),
+                None => return Ok(None),
+            };
+            match msg {
+                WsMessage::Text(t) => {
+                    let env = cloud_protocol::parse_message(t.as_bytes())
+                        .map_err(|e| TransportError::Codec(e.to_string()))?;
+                    return Ok(Some(env));
+                }
+                WsMessage::Binary(b) => {
+                    let env = cloud_protocol::parse_message(&b)
+                        .map_err(|e| TransportError::Codec(e.to_string()))?;
+                    return Ok(Some(env));
+                }
+                WsMessage::Close(_) => return Ok(None),
+                // Tungstenite handles ping/pong automatically when configured
+                // with default settings; ignore stray ones here for safety.
+                WsMessage::Ping(_) | WsMessage::Pong(_) | WsMessage::Frame(_) => continue,
+            }
+        }
+    }
+
+    async fn close(&mut self) -> Result<(), TransportError> {
+        self.socket.close(None).await.map_err(map_tung_err)
+    }
+}
+
+fn map_tung_err(err: TungError) -> TransportError {
+    match err {
+        TungError::ConnectionClosed | TungError::AlreadyClosed => TransportError::Closed,
+        TungError::Io(io) => TransportError::Io(io.to_string()),
+        other => TransportError::Io(other.to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test: in-memory pair
+// ---------------------------------------------------------------------------
+
+/// In-memory bidirectional transport for tests.
+///
+/// Use [`InMemoryTransport::pair`] to get two halves wired to each other.
+/// Calling [`InMemoryTransport::close`] on one half is observable as a
+/// clean EOF (`Ok(None)`) on the other half's next `recv`, simulating a
+/// remote close.
+pub struct InMemoryTransport {
+    /// Wrapped in `Option` so `close()` can drop the sender, which
+    /// causes the peer's `recv()` to return `Ok(None)`.
+    tx: Option<mpsc::UnboundedSender<Envelope>>,
+    rx: mpsc::UnboundedReceiver<Envelope>,
+}
+
+impl InMemoryTransport {
+    /// Construct two transports wired such that frames sent on one are
+    /// received on the other and vice versa.
+    pub fn pair() -> (Self, Self) {
+        let (a_tx, b_rx) = mpsc::unbounded_channel();
+        let (b_tx, a_rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                tx: Some(a_tx),
+                rx: a_rx,
+            },
+            Self {
+                tx: Some(b_tx),
+                rx: b_rx,
+            },
+        )
+    }
+}
+
+#[async_trait]
+impl Transport for InMemoryTransport {
+    async fn send(&mut self, env: Envelope) -> Result<(), TransportError> {
+        match self.tx.as_ref() {
+            Some(tx) => tx.send(env).map_err(|_| TransportError::Closed),
+            None => Err(TransportError::Closed),
+        }
+    }
+
+    async fn recv(&mut self) -> Result<Option<Envelope>, TransportError> {
+        Ok(self.rx.recv().await)
+    }
+
+    async fn close(&mut self) -> Result<(), TransportError> {
+        // Drop our send half: the peer's recv() will return None once the
+        // queue drains, simulating a clean remote close.
+        self.tx = None;
+        // Also close our own recv: any pending in-flight frames get
+        // delivered, then we return None.
+        self.rx.close();
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

New native-only `crates/cloud_client/` crate that consumes `cloud_protocol` (PDX-17, already on master) and exposes the cloud backend to the orchestrator as an `Agent` trait impl.

- `CloudAgent`: `orchestrator::Agent` backed by a `tokio-tungstenite` WebSocket client. Submits tasks via `TaskSubmit`, streams `TaskEvent`s back as `AgentEvent`s, terminates on `TaskResult::{Success, Failed, Cancelled}`. Health flips to unhealthy on connect/reconnect failure and back on successful (re)connect.
- `ReconnectPolicy`: pure exponential-backoff state machine (no IO), independently unit-tested.
- `SessionState`: per-task high-water sequence tracker for dedupe-on-reconnect.
- `Transport` trait + `InMemoryTransport` pair so the reconnect/resume logic is exercisable without real sockets. Production impl is `TungsteniteTransport`.
- Resume hint encoded as `TaskControl::Signal { name: \"resume\", payload: { last_sequence } }`. The V1 `TaskControl::Resume` variant in `cloud_protocol` does not (yet) carry a sequence number, and this PR is forbidden from modifying `cloud_protocol`. The signal form is forward-compatible with a future `Resume { last_sequence }` variant — a server that understands the new variant can keep accepting the signal alongside it. PDX-19 (Workers) should recognise either form.

### Out of scope

Per the issue, this PR delivers the standalone crate only:
- Wiring `CloudAgent` into the persistent Router / `local_orchestrator.rs` is a follow-up.
- The `helm-cloud` Worker (PDX-19) is the server-side counterpart and lives in its own PR.

### Notes for downstream PRs

- **Router registration** can swap `agents::RemoteAgent` (the stub) for `cloud_client::CloudAgent` directly — the trait impl is drop-in and the advertised `Capabilities` mirror the stub's (all roles, 200k context, tools+vision).
- **PDX-19 (Workers)**: the resume signal carries `payload.last_sequence: u64`; replay should send events with `sequence > last_sequence`. Until the protocol gets a `Resume { last_sequence }` variant, treat `Signal { name: \"resume\" }` as the canonical resume request.
- macOS-first: the crate is gated `#![cfg(not(target_family = \"wasm\"))]`. `cloud_protocol` remains the wasm-clean part.

## Test plan

- [x] `cargo check -p cloud_client` — clean
- [x] `cargo test -p cloud_client` — 12/12 passing (3 reconnect, 4 session, 5 agent including 1 reconnect+resume integration via in-memory transport pair)
- [ ] Reviewer: confirm the resume-as-signal encoding is acceptable until `cloud_protocol` gets a `Resume { last_sequence }` variant
- [ ] Reviewer: confirm `CloudAgent`'s capability set mirrors the now-superseded `agents::RemoteAgent` stub

Linear: https://linear.app/pdx-software/issue/PDX-18

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>