### PR TITLE
PDX-111 [A9.4] Live WORKFLOW.md reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12779,6 +12779,7 @@ dependencies = [
  "github_webhook_receiver",
  "liquid",
  "mockall",
+ "notify-debouncer-full",
  "orchestrator",
  "reqwest",
  "rustls 0.23.39",

--- a/crates/symphony/Cargo.toml
+++ b/crates/symphony/Cargo.toml
@@ -41,6 +41,7 @@ uuid = { workspace = true }
 async-trait = { workspace = true }
 futures-util = { workspace = true }
 tokio-stream = "0.1"
+notify-debouncer-full = { workspace = true }
 # rustls 0.23 requires an explicit crypto provider; reqwest's rustls-tls feature
 # in this workspace doesn't auto-install one. We install ring at startup in main.rs.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/crates/symphony/src/audit.rs
+++ b/crates/symphony/src/audit.rs
@@ -44,6 +44,16 @@ pub enum AuditEventKind {
     RetryDispatched,
     /// Retry attempts exhausted; the issue is left in its current state.
     RetryGivenUp,
+    /// `WORKFLOW.md` was re-read from disk and the new definition is live.
+    /// Emitted by the live-reload watcher (PDX-111).
+    WorkflowReloaded,
+    /// A reload re-read `WORKFLOW.md` but parsing failed; the previous
+    /// definition is kept live. Emitted by the live-reload watcher.
+    WorkflowReloadFailed,
+    /// A reload parsed successfully but mutated an immutable field
+    /// (currently only `workspace.root`); the previous definition is kept
+    /// live. Emitted by the live-reload watcher.
+    WorkflowReloadRejected,
 }
 
 /// Single audit-log entry.

--- a/crates/symphony/src/lib.rs
+++ b/crates/symphony/src/lib.rs
@@ -16,6 +16,7 @@ pub mod diff_guard;
 pub mod linear_graphql;
 pub mod numstat;
 pub mod orchestrator;
+pub mod reload;
 pub mod tracker;
 pub mod triggers;
 pub mod workflow;
@@ -25,6 +26,7 @@ pub use audit::{AuditEvent, AuditLog};
 pub use diff_guard::{DiffGuard, DiffGuardError, DiffStat};
 pub use linear_graphql::{LinearGraphQlExecutor, LinearGraphQlTool, DEFAULT_RATE_PER_MINUTE, TOOL_NAME};
 pub use orchestrator::{Orchestrator, OrchestratorError};
+pub use reload::{apply_reload, WatchError, WorkflowHandle, WorkflowWatcher};
 pub use tracker::{BlockerRef, Issue, LinearClient, TrackerError};
 pub use triggers::{spawn_triggers, TriggerError, TriggerSurfaces};
 pub use workflow::{

--- a/crates/symphony/src/main.rs
+++ b/crates/symphony/src/main.rs
@@ -12,6 +12,7 @@ use orchestrator::{AgentRegistration, Budget, Cap, Provider, Router};
 use symphony::audit::AuditLog;
 use symphony::orchestrator::{IssueSource, Orchestrator};
 use symphony::linear_graphql::LinearGraphQlTool;
+use symphony::reload::{WorkflowHandle, WorkflowWatcher};
 use symphony::tracker::LinearClient;
 use symphony::workflow::WorkflowDefinition;
 use symphony::workspace::WorkspaceManager;
@@ -45,26 +46,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
     let workflow = WorkflowDefinition::load(&cli.workflow)?;
+    // PDX-111: wrap the parsed definition in a swap-able handle so the live
+    // reload watcher and the orchestrator share the same authoritative
+    // pointer. All static-at-startup wiring below (workspace root, tracker
+    // endpoint, hooks) reads the *initial* snapshot — those surfaces are
+    // not hot-reloadable on purpose; only `polling`, `agent.*`, and
+    // `tracker.active_states`/labels actually take effect on subsequent
+    // ticks. Mutating `workspace.root` is rejected by the reload watcher.
+    let workflow_handle = Arc::new(WorkflowHandle::new(workflow));
+    let initial = workflow_handle.load();
 
-    let api_key = resolve_api_key(&workflow.config.tracker.api_key).await?;
+    let api_key = resolve_api_key(&initial.config.tracker.api_key).await?;
 
-    let tracker = match &workflow.config.tracker.team_key {
+    let tracker = match &initial.config.tracker.team_key {
         Some(team_key) => LinearClient::new_with_team(
-            workflow.config.tracker.endpoint.clone(),
+            initial.config.tracker.endpoint.clone(),
             api_key,
-            workflow.config.tracker.project_slug.clone(),
+            initial.config.tracker.project_slug.clone(),
             team_key.clone(),
         )?,
         None => LinearClient::new(
-            workflow.config.tracker.endpoint.clone(),
+            initial.config.tracker.endpoint.clone(),
             api_key,
-            workflow.config.tracker.project_slug.clone(),
+            initial.config.tracker.project_slug.clone(),
         )?,
     };
 
     let workspaces = Arc::new(WorkspaceManager::new(
-        workflow.config.workspace.root.clone(),
-        workflow.config.hooks.clone(),
+        initial.config.workspace.root.clone(),
+        initial.config.hooks.clone(),
     ));
 
     let mut caps: HashMap<Provider, Cap> = HashMap::new();
@@ -95,7 +105,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // GitHub/Slack/generic webhook receiver) before the orchestrator
     // takes over the main task. These run in their own tokio tasks and
     // never block the orchestrator. PDX-26 D3.
-    let trigger_surfaces = symphony::spawn_triggers(&workflow.config.server, audit.clone()).await;
+    let trigger_surfaces = symphony::spawn_triggers(&initial.config.server, audit.clone()).await;
     if let Err(e) = &trigger_surfaces {
         tracing::warn!(error = %e, "trigger surfaces failed to start; continuing without them");
     }
@@ -118,21 +128,40 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // executes GraphQL on the agent's behalf without ever exposing the
     // API token to the subprocess.
     let tracker_arc = Arc::new(tracker);
-    let rate_per_minute = workflow.config.agent.linear_graphql_rate_per_minute;
+    let rate_per_minute = initial.config.agent.linear_graphql_rate_per_minute;
     let linear_graphql_tool = LinearGraphQlTool::with_rate(
         Arc::clone(&tracker_arc) as Arc<dyn symphony::linear_graphql::LinearGraphQlExecutor>,
         rate_per_minute,
     );
+    // Drop the local snapshot ref so the watcher and orchestrator share the
+    // handle as the only authoritative pointer.
+    drop(initial);
+
     let orch = Arc::new(
-        Orchestrator::new(
-            workflow,
+        Orchestrator::with_handle(
+            Arc::clone(&workflow_handle),
             tracker_arc as Arc<dyn IssueSource>,
             workspaces,
             router,
-            audit,
+            audit.clone(),
         )
         .with_linear_graphql_tool(linear_graphql_tool),
     );
+
+    // PDX-111: kick off the live-reload watcher. Failure to start the
+    // watcher is logged but non-fatal — the daemon still runs against the
+    // initial config.
+    let _reload_guard = match WorkflowWatcher::start(
+        cli.workflow.clone(),
+        Arc::clone(&workflow_handle),
+        audit.clone(),
+    ) {
+        Ok(w) => Some(w),
+        Err(e) => {
+            tracing::warn!(error = %e, "symphony: live workflow reload disabled (watcher failed to start)");
+            None
+        }
+    };
 
     if cli.once {
         orch.tick().await?;

--- a/crates/symphony/src/orchestrator.rs
+++ b/crates/symphony/src/orchestrator.rs
@@ -33,6 +33,7 @@ use crate::audit::{AuditEvent, AuditEventKind, AuditLog};
 use crate::diff_guard::{DiffGuard, DiffGuardError};
 use crate::linear_graphql::{LinearGraphQlTool, TOOL_NAME as LINEAR_GRAPHQL_TOOL};
 use crate::numstat::collect_workspace_diffs;
+use crate::reload::WorkflowHandle;
 use crate::tracker::{Issue, TrackerError};
 use crate::workflow::WorkflowDefinition;
 use crate::workspace::{Workspace, WorkspaceError, WorkspaceManager};
@@ -190,7 +191,11 @@ pub struct RuntimeState {
 
 /// Orchestrator core.
 pub struct Orchestrator {
-    workflow: WorkflowDefinition,
+    /// Live, swap-able workflow definition. Reads go through
+    /// [`WorkflowHandle::load`] to obtain a per-call snapshot
+    /// (`Arc<WorkflowDefinition>`); writes are performed by the live-reload
+    /// watcher (see [`crate::reload`]). PDX-111.
+    workflow: Arc<WorkflowHandle>,
     tracker: Arc<dyn IssueSource>,
     workspaces: Arc<WorkspaceManager>,
     router: Arc<Router>,
@@ -212,6 +217,11 @@ pub struct Orchestrator {
 
 impl Orchestrator {
     /// Construct a new orchestrator wiring all collaborators.
+    ///
+    /// Accepts an owned [`WorkflowDefinition`] for ergonomics; it is wrapped
+    /// in a fresh [`WorkflowHandle`]. Callers that already hold a handle
+    /// (e.g. `main.rs`, which shares the handle with the live-reload
+    /// watcher) should use [`Orchestrator::with_handle`] instead.
     pub fn new(
         workflow: WorkflowDefinition,
         tracker: Arc<dyn IssueSource>,
@@ -219,7 +229,27 @@ impl Orchestrator {
         router: Arc<Router>,
         audit: Arc<AuditLog>,
     ) -> Self {
-        let max_diff = workflow.config.agent.max_diff_lines;
+        Self::with_handle(
+            Arc::new(WorkflowHandle::new(workflow)),
+            tracker,
+            workspaces,
+            router,
+            audit,
+        )
+    }
+
+    /// Construct a new orchestrator with an externally-owned
+    /// [`WorkflowHandle`]. Use this in production so the live-reload watcher
+    /// and the orchestrator share the same handle and the next tick after a
+    /// successful reload picks up the new config without restart (PDX-111).
+    pub fn with_handle(
+        workflow: Arc<WorkflowHandle>,
+        tracker: Arc<dyn IssueSource>,
+        workspaces: Arc<WorkspaceManager>,
+        router: Arc<Router>,
+        audit: Arc<AuditLog>,
+    ) -> Self {
+        let max_diff = workflow.load().config.agent.max_diff_lines;
         Self {
             workflow,
             tracker,
@@ -246,6 +276,14 @@ impl Orchestrator {
         self.linear_graphql_tool.is_some()
     }
 
+    /// Snapshot the live workflow definition. Cheap (`Arc::clone` under a
+    /// brief read lock); call once per logical operation that needs the
+    /// config and reuse the snapshot — both for consistency *within* an
+    /// operation and to take only one lock round-trip.
+    pub fn workflow_snapshot(&self) -> Arc<WorkflowDefinition> {
+        self.workflow.load()
+    }
+
     /// Snapshot of current runtime state. Useful for tests.
     pub async fn state_snapshot(&self) -> (HashMap<String, RunningEntry>, HashSet<String>) {
         let s = self.state.read().await;
@@ -253,9 +291,14 @@ impl Orchestrator {
     }
 
     /// Main loop: tick on `polling.interval_ms` until `shutdown` resolves.
+    ///
+    /// The interval is re-read from the live workflow handle at the top of
+    /// every loop iteration, so a `polling.interval_ms` edit (PDX-111 live
+    /// reload) takes effect on the *next* tick without restart.
     pub async fn run(self: Arc<Self>, mut shutdown: tokio::sync::oneshot::Receiver<()>) {
-        let interval = Duration::from_millis(self.workflow.config.polling.interval_ms);
         loop {
+            let interval =
+                Duration::from_millis(self.workflow.load().config.polling.interval_ms);
             tokio::select! {
                 _ = tokio::time::sleep(interval) => {
                     if let Err(e) = self.tick().await {
@@ -285,8 +328,11 @@ impl Orchestrator {
         // §8.4: process retry queue (issues whose backoff has elapsed).
         self.process_retry_queue().await;
 
-        let active = &self.workflow.config.tracker.active_states;
-        let candidates = self.tracker.fetch_candidate_issues(active).await?;
+        // PDX-111: snapshot the live workflow once per tick. Live edits
+        // arrive between ticks; reads within a single tick are consistent.
+        let wf = self.workflow.load();
+        let active = wf.config.tracker.active_states.clone();
+        let candidates = self.tracker.fetch_candidate_issues(&active).await?;
 
         // Snapshot state to filter without holding the lock during the
         // filter pass — we only re-acquire it to mutate `claimed`/`running`.
@@ -299,7 +345,7 @@ impl Orchestrator {
             )
         };
 
-        let max = self.workflow.config.agent.max_concurrent_agents;
+        let max = wf.config.agent.max_concurrent_agents;
         if running.len() >= max {
             tracing::debug!(
                 running = running.len(),
@@ -309,8 +355,7 @@ impl Orchestrator {
             return Ok(());
         }
 
-        let label = &self.workflow.config.agent.agent_label_required;
-        let label_lc = label.to_lowercase();
+        let label_lc = wf.config.agent.agent_label_required.to_lowercase();
         let active_set: HashSet<&str> = active.iter().map(|s| s.as_str()).collect();
         let mut eligible: Vec<Issue> = candidates
             .into_iter()
@@ -373,8 +418,12 @@ impl Orchestrator {
             }
         };
 
-        let prompt = self
-            .workflow
+        // PDX-111: snapshot the workflow at dispatch time so this run keeps
+        // operating against the config that was live when it started, even
+        // if the live-reload watcher swaps in a new definition while the
+        // agent is mid-flight.
+        let wf_snapshot = self.workflow.load();
+        let prompt = wf_snapshot
             .render_prompt(&issue, None)
             .map_err(|e| OrchestratorError::Other(e.to_string()))?;
 
@@ -645,7 +694,8 @@ impl Orchestrator {
         // Optional Linear write-back: post a comment summarizing the run.
         // Skipped if `agent.comment_on_completion = false` in WORKFLOW.md
         // OR if the issue source is a mock that doesn't implement add_comment.
-        if self.workflow.config.agent.comment_on_completion {
+        let wf = self.workflow.load();
+        if wf.config.agent.comment_on_completion {
             let body = self.compose_completion_comment(provider, &diff_summary, &outcome);
             if let Err(e) = self.tracker.add_comment(&issue.id, &body).await {
                 tracing::warn!(
@@ -661,9 +711,9 @@ impl Orchestrator {
         // handoff_state_on_success (e.g. "In Review"); failures go to
         // handoff_state_on_failure (e.g. "Backlog") if configured.
         let target = if outcome.success {
-            self.workflow.config.agent.handoff_state_on_success.as_deref()
+            wf.config.agent.handoff_state_on_success.as_deref()
         } else {
-            self.workflow.config.agent.handoff_state_on_failure.as_deref()
+            wf.config.agent.handoff_state_on_failure.as_deref()
         };
         if let Some(target_state) = target {
             if let Err(e) = self.tracker.transition_issue(&issue.id, target_state).await {
@@ -734,7 +784,7 @@ impl Orchestrator {
     /// `now - last_event_at > stall_timeout_ms`. Aborted runs are queued
     /// for retry with backoff. `stall_timeout_ms <= 0` disables.
     async fn reconcile_stalled(&self) {
-        let stall_ms = self.workflow.config.agent.stall_timeout_ms;
+        let stall_ms = self.workflow.load().config.agent.stall_timeout_ms;
         if stall_ms == 0 {
             return;
         }
@@ -801,8 +851,9 @@ impl Orchestrator {
 
         for retry in due {
             // Re-fetch the issue to validate it's still active & eligible.
-            let active = &self.workflow.config.tracker.active_states;
-            let candidates = match self.tracker.fetch_candidate_issues(active).await {
+            let wf = self.workflow.load();
+            let active = wf.config.tracker.active_states.clone();
+            let candidates = match self.tracker.fetch_candidate_issues(&active).await {
                 Ok(c) => c,
                 Err(e) => {
                     tracing::warn!(error = %e, "retry candidate fetch failed; deferring");
@@ -817,12 +868,7 @@ impl Orchestrator {
                     continue;
                 }
             };
-            let label_lc = self
-                .workflow
-                .config
-                .agent
-                .agent_label_required
-                .to_lowercase();
+            let label_lc = wf.config.agent.agent_label_required.to_lowercase();
             let issue = candidates.into_iter().find(|i| {
                 i.id == retry.issue_id && i.labels.iter().any(|l| l == &label_lc)
             });
@@ -864,7 +910,8 @@ impl Orchestrator {
         attempt: u32,
         error: Option<String>,
     ) {
-        let max_attempts = self.workflow.config.agent.max_retry_attempts;
+        let wf = self.workflow.load();
+        let max_attempts = wf.config.agent.max_retry_attempts;
         if attempt > max_attempts {
             tracing::warn!(
                 issue = %identifier,
@@ -879,7 +926,7 @@ impl Orchestrator {
             );
             return;
         }
-        let max_backoff = self.workflow.config.agent.max_retry_backoff_ms;
+        let max_backoff = wf.config.agent.max_retry_backoff_ms;
         let delay_ms = retry_backoff_ms(attempt, max_backoff);
         let due_at = Instant::now() + Duration::from_millis(delay_ms);
 

--- a/crates/symphony/src/reload.rs
+++ b/crates/symphony/src/reload.rs
@@ -1,0 +1,339 @@
+//! Live `WORKFLOW.md` reload (PDX-111 / Symphony §6.2).
+//!
+//! Wraps the loaded [`WorkflowDefinition`] in a swap-able handle and runs a
+//! debounced filesystem watcher that re-parses the workflow file on changes.
+//!
+//! ## Semantics
+//!
+//! * The watcher subscribes to the *file path* supplied at startup, not the
+//!   parent directory — replacing the file (`mv tmp WORKFLOW.md`) is treated
+//!   as a deliberate "reload" gesture and triggers a re-read.
+//! * Debounce is 200ms; rapid edits coalesce into a single reload attempt.
+//! * Re-parse failures are logged via [`tracing::warn!`] and **the previously
+//!   loaded definition stays live** — no surface is torn down on bad edits.
+//! * `workspace.root` is **immutable** at runtime. Switching root mid-run
+//!   would orphan the open per-issue workspaces, so a reload that mutates
+//!   `workspace.root` is rejected: the previous definition is kept and a
+//!   [`AuditEventKind::WorkflowReloadRejected`] event is recorded.
+//! * In-flight runs continue under the snapshot they captured at dispatch
+//!   time; only the next tick (the orchestrator re-loads via the handle) sees
+//!   the new config.
+//!
+//! ## Atomicity
+//!
+//! The handle uses `std::sync::RwLock<Arc<WorkflowDefinition>>`. Readers call
+//! [`WorkflowHandle::load`], which clones the `Arc` under a brief read lock —
+//! cheap and contention-free in the common case. Writers (the watcher
+//! callback) hold the write lock only long enough to swap the `Arc`.
+
+use std::path::{Path, PathBuf};
+use std::sync::{mpsc as std_mpsc, Arc, RwLock};
+use std::thread;
+use std::time::Duration;
+
+use notify_debouncer_full::{
+    new_debouncer_opt,
+    notify::{Config, EventKind, RecommendedWatcher, RecursiveMode},
+    DebounceEventHandler, DebounceEventResult, NoCache,
+};
+use thiserror::Error;
+use tokio::sync::mpsc;
+
+use crate::audit::{AuditEvent, AuditEventKind, AuditLog};
+use crate::workflow::{WorkflowDefinition, WorkflowError};
+
+const DEBOUNCE_MS: u64 = 200;
+
+/// Atomic, swap-able container around a [`WorkflowDefinition`].
+///
+/// Cheap to clone via `Arc`. All readers should call [`WorkflowHandle::load`]
+/// to obtain a snapshot `Arc<WorkflowDefinition>` and read from it; the
+/// snapshot stays valid even if the watcher swaps in a new definition
+/// concurrently.
+pub struct WorkflowHandle {
+    inner: RwLock<Arc<WorkflowDefinition>>,
+}
+
+impl std::fmt::Debug for WorkflowHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkflowHandle").finish_non_exhaustive()
+    }
+}
+
+impl WorkflowHandle {
+    /// Wrap an initial definition.
+    pub fn new(initial: WorkflowDefinition) -> Self {
+        Self {
+            inner: RwLock::new(Arc::new(initial)),
+        }
+    }
+
+    /// Cheap snapshot read. The returned `Arc` is independent of the handle:
+    /// once cloned, a concurrent swap will not invalidate it.
+    pub fn load(&self) -> Arc<WorkflowDefinition> {
+        // `RwLock::read` poisons only on writer panic — fall back to a fresh
+        // wrapper around the inner value so we don't crash the orchestrator
+        // on observability surfaces.
+        match self.inner.read() {
+            Ok(g) => Arc::clone(&g),
+            Err(poisoned) => Arc::clone(&poisoned.into_inner()),
+        }
+    }
+
+    /// Replace the live definition. Called by the watcher when a parse
+    /// succeeds and the new config is compatible with the running daemon.
+    fn store(&self, new: Arc<WorkflowDefinition>) {
+        match self.inner.write() {
+            Ok(mut g) => {
+                *g = new;
+            }
+            Err(poisoned) => {
+                let mut g = poisoned.into_inner();
+                *g = new;
+            }
+        }
+    }
+}
+
+/// Errors raised when starting the [`WorkflowWatcher`].
+#[derive(Debug, Error)]
+pub enum WatchError {
+    /// The OS-level file watcher could not be constructed.
+    #[error("failed to create file watcher: {0}")]
+    Watcher(String),
+}
+
+/// Background watcher that re-loads `WORKFLOW.md` on debounced changes.
+///
+/// The watcher owns:
+///
+///   * an OS-level [`notify_debouncer_full`] instance running on a dedicated
+///     thread,
+///   * a Tokio task that drains debounced events and applies them via
+///     [`apply_reload`].
+///
+/// Drop the [`WorkflowWatcher`] to stop both.
+pub struct WorkflowWatcher {
+    /// Dropping this signals the watcher thread to exit cleanly.
+    _stop: std_mpsc::SyncSender<()>,
+    /// Dropping this aborts the Tokio fan-in task.
+    _task: tokio::task::JoinHandle<()>,
+}
+
+impl WorkflowWatcher {
+    /// Start watching `path`. Reload events update `handle`; rejections are
+    /// recorded against `audit`.
+    ///
+    /// Returns an error only if the OS file-watcher itself cannot be
+    /// constructed — a failure to register the path (e.g. parent directory
+    /// missing) is logged but not fatal.
+    pub fn start(
+        path: PathBuf,
+        handle: Arc<WorkflowHandle>,
+        audit: Arc<AuditLog>,
+    ) -> Result<Self, WatchError> {
+        let (raw_tx, mut raw_rx) = mpsc::unbounded_channel::<PathBuf>();
+        let (stop_tx, stop_rx) = std_mpsc::sync_channel::<()>(0);
+        let (setup_tx, setup_rx) = std_mpsc::sync_channel::<Result<(), WatchError>>(0);
+
+        let watch_path = path.clone();
+        thread::Builder::new()
+            .name("symphony-workflow-reload".into())
+            .spawn(move || {
+                watcher_thread(watch_path, raw_tx, stop_rx, setup_tx);
+            })
+            .map_err(|e| WatchError::Watcher(e.to_string()))?;
+
+        setup_rx
+            .recv()
+            .unwrap_or_else(|_| {
+                Err(WatchError::Watcher(
+                    "watcher thread exited before signalling setup".into(),
+                ))
+            })?;
+
+        let task = tokio::spawn(async move {
+            while let Some(changed) = raw_rx.recv().await {
+                apply_reload(&changed, &handle, &audit);
+            }
+        });
+
+        Ok(Self {
+            _stop: stop_tx,
+            _task: task,
+        })
+    }
+}
+
+/// Re-parse `path` and atomically swap the new definition into `handle`.
+///
+/// Public for unit-testability — callers in production go through
+/// [`WorkflowWatcher::start`].
+pub fn apply_reload(path: &Path, handle: &WorkflowHandle, audit: &AuditLog) {
+    let new_def = match WorkflowDefinition::load(path) {
+        Ok(d) => d,
+        Err(e) => {
+            log_and_audit_failure(path, &e, audit);
+            return;
+        }
+    };
+
+    let prev = handle.load();
+    if new_def.config.workspace.root != prev.config.workspace.root {
+        let msg = format!(
+            "rejected workflow reload: workspace.root changed from {} to {} \
+             (mid-run root changes orphan open workspaces); keeping previous root",
+            prev.config.workspace.root.display(),
+            new_def.config.workspace.root.display(),
+        );
+        tracing::error!(
+            path = %path.display(),
+            previous_root = %prev.config.workspace.root.display(),
+            attempted_root = %new_def.config.workspace.root.display(),
+            "workflow reload rejected: workspace.root is immutable at runtime"
+        );
+        audit.record(
+            AuditEvent::new(AuditEventKind::WorkflowReloadRejected)
+                .with_error(msg),
+        );
+        return;
+    }
+
+    handle.store(Arc::new(new_def));
+    tracing::info!(
+        path = %path.display(),
+        "workflow reloaded; new config will take effect on the next tick"
+    );
+    audit.record(
+        AuditEvent::new(AuditEventKind::WorkflowReloaded)
+            .with_message(path.display().to_string()),
+    );
+}
+
+fn log_and_audit_failure(path: &Path, err: &WorkflowError, audit: &AuditLog) {
+    tracing::warn!(
+        path = %path.display(),
+        error = %err,
+        "workflow reload failed; keeping previous definition live"
+    );
+    audit.record(
+        AuditEvent::new(AuditEventKind::WorkflowReloadFailed)
+            .with_message(path.display().to_string())
+            .with_error(err.to_string()),
+    );
+}
+
+/// Runs in the dedicated watcher thread. Configures a debounced
+/// `notify-debouncer-full` against the *file* (not the directory) and parks
+/// until [`WorkflowWatcher`] is dropped.
+fn watcher_thread(
+    path: PathBuf,
+    tx: mpsc::UnboundedSender<PathBuf>,
+    stop_rx: std_mpsc::Receiver<()>,
+    setup_tx: std_mpsc::SyncSender<Result<(), WatchError>>,
+) {
+    let watch_target = path.clone();
+    let bridge = WatcherBridge {
+        tx,
+        target: watch_target,
+    };
+    let mut debouncer = match new_debouncer_opt::<_, RecommendedWatcher, _>(
+        Duration::from_millis(DEBOUNCE_MS),
+        None,
+        bridge,
+        NoCache,
+        Config::default(),
+    ) {
+        Ok(d) => d,
+        Err(e) => {
+            let _ = setup_tx.send(Err(WatchError::Watcher(e.to_string())));
+            return;
+        }
+    };
+
+    // Watch the file path itself. On macOS FSEvents (the backend used in
+    // this workspace's pinned `notify` fork) this surfaces both modify and
+    // rename events even when an editor saves via "atomic write" (rename
+    // tmp → target), which is precisely the deliberate "reload gesture"
+    // PDX-111 calls out.
+    if let Err(e) = debouncer.watch(&path, RecursiveMode::NonRecursive) {
+        tracing::warn!(
+            path = %path.display(),
+            error = %e,
+            "symphony workflow watcher: cannot watch path"
+        );
+        // Still signal "ready" so the daemon can continue without live
+        // reload — this matches Symphony's design that reload is a
+        // best-effort observability surface, not load-bearing.
+    }
+
+    let _ = setup_tx.send(Ok(()));
+    tracing::info!(path = %path.display(), "symphony: watching WORKFLOW.md for live reloads");
+
+    // Park until the WorkflowWatcher is dropped (stop_tx drop ⇒ RecvError).
+    let _ = stop_rx.recv();
+    tracing::debug!("symphony workflow watcher thread exiting");
+    // `debouncer` drops here, releasing OS resources.
+}
+
+/// Bridges debounced `notify` events into a Tokio channel. We forward only
+/// events whose paths intersect the watched target (defence against stray
+/// directory events that some backends emit alongside file events).
+struct WatcherBridge {
+    tx: mpsc::UnboundedSender<PathBuf>,
+    target: PathBuf,
+}
+
+impl DebounceEventHandler for WatcherBridge {
+    fn handle_event(&mut self, result: DebounceEventResult) {
+        match result {
+            Ok(events) => {
+                for event in events {
+                    match event.event.kind {
+                        EventKind::Create(_)
+                        | EventKind::Modify(_)
+                        | EventKind::Remove(_) => {
+                            // Some backends emit events with empty `paths`
+                            // (FSEvents historic-flag flushes); fall back to
+                            // a synthetic "target" event so a deliberate
+                            // `mv tmp WORKFLOW.md` still triggers a reload.
+                            if event.paths.is_empty() {
+                                if self.tx.send(self.target.clone()).is_err() {
+                                    return;
+                                }
+                                continue;
+                            }
+                            // `event` is a `&DebouncedEvent`, so iterate by
+                            // reference and clone matching paths.
+                            for p in event.paths.iter() {
+                                if path_matches(p, &self.target) {
+                                    if self.tx.send(p.clone()).is_err() {
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Err(errors) => {
+                for e in errors {
+                    tracing::warn!(error = ?e, "symphony workflow watcher error");
+                }
+            }
+        }
+    }
+}
+
+/// `true` if `event` references the target file. We compare canonicalized
+/// paths when both are available so symlinks and `./` prefixes match.
+fn path_matches(event: &Path, target: &Path) -> bool {
+    if event == target {
+        return true;
+    }
+    match (event.canonicalize(), target.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => event.file_name() == target.file_name() && event.parent() == target.parent(),
+    }
+}

--- a/crates/symphony/tests/workflow_reload.rs
+++ b/crates/symphony/tests/workflow_reload.rs
@@ -1,0 +1,178 @@
+//! Tests for live `WORKFLOW.md` reload (PDX-111).
+//!
+//! These exercise the lower-level `apply_reload` directly against a
+//! [`WorkflowHandle`] + tempfile pair, which is the deterministic surface.
+//! End-to-end watcher tests would have to wait on filesystem-event timing,
+//! which is flaky on busy CI; the watcher's wiring (debouncer + Tokio
+//! channel) is shared with `crates/prompts::hot_reload` and exercised there.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use symphony::audit::AuditLog;
+use symphony::reload::{apply_reload, WorkflowHandle};
+use symphony::workflow::WorkflowDefinition;
+use tempfile::TempDir;
+
+/// Workflow front-matter template parameterised on a few values that the
+/// reload tests poke at. Body is a constant Liquid template.
+fn workflow_yaml(interval_ms: u64, max_concurrent: usize, root: &Path) -> String {
+    format!(
+        r#"---
+tracker:
+  api_key: literal-key
+  project_slug: x
+polling:
+  interval_ms: {interval_ms}
+workspace:
+  root: {root_str}
+agent:
+  max_concurrent_agents: {max_concurrent}
+  agent_label_required: "agent:claude"
+---
+Issue {{{{ issue.identifier }}}}: {{{{ issue.title }}}}
+"#,
+        interval_ms = interval_ms,
+        max_concurrent = max_concurrent,
+        root_str = root.display(),
+    )
+}
+
+fn audit_log(dir: &Path) -> Arc<AuditLog> {
+    Arc::new(AuditLog::open(dir.join("audit.log")))
+}
+
+fn read_audit_kinds(audit_path: &Path) -> Vec<String> {
+    let raw = std::fs::read_to_string(audit_path).unwrap_or_default();
+    raw.lines()
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .filter_map(|v| v.get("kind").and_then(|k| k.as_str()).map(str::to_string))
+        .collect()
+}
+
+#[test]
+fn apply_reload_picks_up_polling_interval_change() {
+    let dir = TempDir::new().unwrap();
+    let workflow_path = dir.path().join("WORKFLOW.md");
+    let root = dir.path().join("ws");
+    std::fs::create_dir_all(&root).unwrap();
+
+    std::fs::write(&workflow_path, workflow_yaml(30_000, 1, &root)).unwrap();
+    let initial = WorkflowDefinition::load(&workflow_path).unwrap();
+    let handle = Arc::new(WorkflowHandle::new(initial));
+    assert_eq!(handle.load().config.polling.interval_ms, 30_000);
+
+    // Edit the file in place and re-apply.
+    std::fs::write(&workflow_path, workflow_yaml(5_000, 1, &root)).unwrap();
+    let audit = audit_log(dir.path());
+    apply_reload(&workflow_path, &handle, &audit);
+
+    assert_eq!(
+        handle.load().config.polling.interval_ms,
+        5_000,
+        "new interval should be live after a successful reload"
+    );
+
+    let kinds = read_audit_kinds(&dir.path().join("audit.log"));
+    assert!(
+        kinds.iter().any(|k| k == "workflow_reloaded"),
+        "expected workflow_reloaded audit event, got {kinds:?}"
+    );
+}
+
+#[test]
+fn apply_reload_keeps_previous_definition_on_yaml_error() {
+    let dir = TempDir::new().unwrap();
+    let workflow_path = dir.path().join("WORKFLOW.md");
+    let root = dir.path().join("ws");
+    std::fs::create_dir_all(&root).unwrap();
+
+    std::fs::write(&workflow_path, workflow_yaml(30_000, 2, &root)).unwrap();
+    let initial = WorkflowDefinition::load(&workflow_path).unwrap();
+    let handle = Arc::new(WorkflowHandle::new(initial));
+
+    // Corrupt the file with intentionally broken YAML.
+    std::fs::write(
+        &workflow_path,
+        "---\ntracker:\n  api_key: literal-key\n  project_slug: x\n  active_states: [unterminated\n---\nbody\n",
+    )
+    .unwrap();
+
+    let audit = audit_log(dir.path());
+    apply_reload(&workflow_path, &handle, &audit);
+
+    // Previous definition stays live.
+    let now = handle.load();
+    assert_eq!(now.config.polling.interval_ms, 30_000);
+    assert_eq!(now.config.agent.max_concurrent_agents, 2);
+
+    let kinds = read_audit_kinds(&dir.path().join("audit.log"));
+    assert!(
+        kinds.iter().any(|k| k == "workflow_reload_failed"),
+        "expected workflow_reload_failed audit event, got {kinds:?}"
+    );
+    assert!(
+        !kinds.iter().any(|k| k == "workflow_reloaded"),
+        "must not record a successful reload on parse failure: {kinds:?}"
+    );
+}
+
+#[test]
+fn apply_reload_rejects_workspace_root_change() {
+    let dir = TempDir::new().unwrap();
+    let workflow_path = dir.path().join("WORKFLOW.md");
+    let root_a = dir.path().join("ws_a");
+    let root_b = dir.path().join("ws_b");
+    std::fs::create_dir_all(&root_a).unwrap();
+    std::fs::create_dir_all(&root_b).unwrap();
+
+    std::fs::write(&workflow_path, workflow_yaml(30_000, 1, &root_a)).unwrap();
+    let initial = WorkflowDefinition::load(&workflow_path).unwrap();
+    assert_eq!(initial.config.workspace.root, root_a);
+    let handle = Arc::new(WorkflowHandle::new(initial));
+
+    // Re-write with a *different* workspace root. Reload must reject this.
+    std::fs::write(&workflow_path, workflow_yaml(15_000, 1, &root_b)).unwrap();
+    let audit = audit_log(dir.path());
+    apply_reload(&workflow_path, &handle, &audit);
+
+    // Previous root preserved; previous interval preserved (we reject the
+    // whole reload, not just the root field).
+    let now = handle.load();
+    assert_eq!(now.config.workspace.root, root_a, "root must be unchanged");
+    assert_eq!(
+        now.config.polling.interval_ms, 30_000,
+        "rejected reloads do not partially apply"
+    );
+
+    let kinds = read_audit_kinds(&dir.path().join("audit.log"));
+    assert!(
+        kinds.iter().any(|k| k == "workflow_reload_rejected"),
+        "expected workflow_reload_rejected audit event, got {kinds:?}"
+    );
+}
+
+#[test]
+fn apply_reload_handles_replace_via_rename() {
+    // Simulates an editor's "atomic save": write to a tempfile, then rename
+    // over the target. PDX-111 calls out that this is a deliberate "reload
+    // gesture" and must trigger a re-parse against the new contents.
+    let dir = TempDir::new().unwrap();
+    let workflow_path = dir.path().join("WORKFLOW.md");
+    let staging = dir.path().join("WORKFLOW.md.tmp");
+    let root = dir.path().join("ws");
+    std::fs::create_dir_all(&root).unwrap();
+
+    std::fs::write(&workflow_path, workflow_yaml(30_000, 1, &root)).unwrap();
+    let initial = WorkflowDefinition::load(&workflow_path).unwrap();
+    let handle = Arc::new(WorkflowHandle::new(initial));
+
+    std::fs::write(&staging, workflow_yaml(7_500, 4, &root)).unwrap();
+    std::fs::rename(&staging, &workflow_path).unwrap();
+    let audit = audit_log(dir.path());
+    apply_reload(&workflow_path, &handle, &audit);
+
+    let now = handle.load();
+    assert_eq!(now.config.polling.interval_ms, 7_500);
+    assert_eq!(now.config.agent.max_concurrent_agents, 4);
+}


### PR DESCRIPTION
## Summary

Wires a debounced filesystem watcher into the Symphony daemon so edits to `WORKFLOW.md` take effect without a restart (Symphony §6.2 / Linear PDX-111).

- New `crates/symphony/src/reload.rs` introduces `WorkflowHandle` (`RwLock<Arc<WorkflowDefinition>>`, cheap `load()` snapshots) and `WorkflowWatcher` (a `notify-debouncer-full` thread + Tokio fan-in task).
- `Orchestrator` now stores `Arc<WorkflowHandle>` and snapshots it per-tick / per-dispatch, so in-flight runs continue under their dispatch-time config and only the next tick observes new values.
- Bad YAML logs via `tracing::warn!` and keeps the previous definition live (`WorkflowReloadFailed` audit kind).
- `workspace.root` mutations are rejected wholesale to avoid orphaning open per-issue workspaces (`WorkflowReloadRejected`).
- The watcher subscribes to the *file path* (not the parent dir), so atomic-save flows (`mv tmp WORKFLOW.md`) also reload.
- New audit kinds: `WorkflowReloaded`, `WorkflowReloadFailed`, `WorkflowReloadRejected`.

## Acceptance / Test plan

`cargo test -p symphony` (all suites pass; smoke is ignored as before because it needs a real `LINEAR_API_KEY`):

- [x] `apply_reload_picks_up_polling_interval_change` — edit `polling.interval_ms`, new value live after reload.
- [x] `apply_reload_keeps_previous_definition_on_yaml_error` — corrupted YAML preserves prior config.
- [x] `apply_reload_rejects_workspace_root_change` — `workspace.root` mutation refused, both root and other fields unchanged.
- [x] `apply_reload_handles_replace_via_rename` — atomic-save (`rename tmp -> target`) re-parses the new contents.
- [x] Pre-existing `orchestrator_state`, `workflow_loader`, `workspace_safety` tests remain green.

## Notes

- macOS-first: leverages the workspace's pinned `notify` fork (FSEvents backend on macOS); no `cfg` gates needed.
- No other crates were modified — only `crates/symphony/` files (plus `Cargo.lock`).
- The watcher is best-effort: failure to start logs a warning and the daemon proceeds against the initial config.

Closes PDX-111.