### PR TITLE
PDX-120 [E8] Strip Oz agent UI surfaces from Helm client

### DIFF
--- a/app/src/ai/agent_management/agent_type_selector.rs
+++ b/app/src/ai/agent_management/agent_type_selector.rs
@@ -72,6 +72,8 @@ pub enum AgentTypeSelectorEvent {
 
 pub struct AgentTypeSelector {
     close_button_mouse_state: MouseStateHandle,
+    // PDX-120 [E8]: only used by the Warp-hosted "Cloud agent" row.
+    #[cfg_attr(not(feature = "warp_hosted"), allow(dead_code))]
     cloud_agent_mouse_state: MouseStateHandle,
     local_agent_mouse_state: MouseStateHandle,
     dialog_mouse_state: MouseStateHandle,
@@ -112,12 +114,15 @@ pub fn init(app: &mut AppContext) {
 
 impl AgentTypeSelector {
     pub fn new(_ctx: &mut ViewContext<Self>) -> Self {
+        // PDX-120 [E8]: index 0 is the cloud-agent row in the Warp-hosted
+        // build and the local-agent row in the Helm client (where the
+        // cloud option is hidden). Either way we start with the first
+        // visible option selected.
         Self {
             close_button_mouse_state: MouseStateHandle::default(),
             cloud_agent_mouse_state: MouseStateHandle::default(),
             local_agent_mouse_state: MouseStateHandle::default(),
             dialog_mouse_state: MouseStateHandle::default(),
-            // Cloud agent is selected by default (index 0).
             selected_option_index: 0,
         }
     }
@@ -330,6 +335,11 @@ impl AgentTypeSelector {
             .with_padding_right(HEADER_PADDING_HORIZONTAL)
             .finish();
 
+        // PDX-120 [E8]: the hosted-Oz "Cloud agent" entry only renders in
+        // the Warp-hosted fork. The Helm client routes cloud creation
+        // through the helm-cloud Workers (PDX-19/PDX-119), so this modal
+        // only offers the local agent path here.
+        #[cfg(feature = "warp_hosted")]
         let cloud_agent_option = self.render_option(
             0,
             Icon::OzCloud,
@@ -341,8 +351,13 @@ impl AgentTypeSelector {
             appearance,
         );
 
+        // Local-agent index follows whatever rows precede it.
+        #[cfg(feature = "warp_hosted")]
+        let local_agent_index = 1;
+        #[cfg(not(feature = "warp_hosted"))]
+        let local_agent_index = 0;
         let local_agent_option = self.render_option(
-            1,
+            local_agent_index,
             Icon::Oz,
             "Local agent",
             "Runs on your machine and requires supervision. Best for quick, interactive tasks.",
@@ -352,12 +367,14 @@ impl AgentTypeSelector {
             appearance,
         );
 
-        let options = Flex::column()
+        let mut options_flex = Flex::column()
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch)
-            .with_spacing(OPTIONS_VERTICAL_GAP)
-            .with_child(cloud_agent_option)
-            .with_child(local_agent_option)
-            .finish();
+            .with_spacing(OPTIONS_VERTICAL_GAP);
+        #[cfg(feature = "warp_hosted")]
+        {
+            options_flex = options_flex.with_child(cloud_agent_option);
+        }
+        let options = options_flex.with_child(local_agent_option).finish();
 
         let body = Container::new(options)
             .with_padding_top(BODY_PADDING_VERTICAL)
@@ -438,15 +455,21 @@ impl TypedActionView for AgentTypeSelector {
                 ctx.notify();
             }
             AgentTypeSelectorAction::ArrowUp | AgentTypeSelectorAction::ArrowDown => {
-                // Toggle between the two options.
-                self.selected_option_index = if self.selected_option_index == 0 {
-                    1
-                } else {
-                    0
-                };
+                // PDX-120 [E8]: in the Helm client only the local-agent
+                // row is visible, so arrow nav is a no-op. In the
+                // Warp-hosted build it toggles between the two rows.
+                #[cfg(feature = "warp_hosted")]
+                {
+                    self.selected_option_index = if self.selected_option_index == 0 {
+                        1
+                    } else {
+                        0
+                    };
+                }
                 ctx.notify();
             }
             AgentTypeSelectorAction::Enter => {
+                #[cfg(feature = "warp_hosted")]
                 match self.selected_option_index {
                     0 => {
                         ctx.emit(AgentTypeSelectorEvent::Selected(AgentType::Cloud));
@@ -455,6 +478,11 @@ impl TypedActionView for AgentTypeSelector {
                         ctx.emit(AgentTypeSelectorEvent::Selected(AgentType::Local));
                     }
                     _ => {}
+                }
+                #[cfg(not(feature = "warp_hosted"))]
+                {
+                    // Only the local agent is selectable in the Helm client.
+                    ctx.emit(AgentTypeSelectorEvent::Selected(AgentType::Local));
                 }
                 ctx.notify();
             }

--- a/app/src/ai/agent_management/cloud_setup_guide_view.rs
+++ b/app/src/ai/agent_management/cloud_setup_guide_view.rs
@@ -58,6 +58,8 @@ pub struct CloudSetupGuideView {
     docs_link_mouse_state: MouseStateHandle,
     env_docs_link_mouse_state: MouseStateHandle,
     integration_docs_link_mouse_state: MouseStateHandle,
+    // PDX-120 [E8]: only used by the Warp-hosted quick-start banner.
+    #[cfg_attr(not(feature = "warp_hosted"), allow(dead_code))]
     visit_oz_button: ViewHandle<ActionButton>,
     parsed_tokens: HashMap<&'static str, ParsedTokensSnapshot>,
     vertical_scroll_state: ClippedScrollStateHandle,
@@ -150,7 +152,7 @@ impl CloudSetupGuideView {
         let mut header_container = Flex::column().with_spacing(8.);
 
         let title = Text::new(
-            "Getting started with Oz cloud agents",
+            "Getting started with cloud agents",
             appearance.ui_font_family(),
             title_font_size,
         )
@@ -160,7 +162,7 @@ impl CloudSetupGuideView {
         header_container.add_child(title);
 
         let subtitle = Text::new(
-            "Start Oz cloud agents directly in Warp from an integration (Linear, Slack), with an event (GitHub, built-in schedule), or programmatically with the Oz SDK or CLI.",
+            "Start cloud agents from an integration (Linear, Slack), with an event (GitHub, built-in schedule), or programmatically with the agent SDK or CLI.",
             appearance.ui_font_family(),
             subtitle_font_size,
         )
@@ -183,7 +185,7 @@ impl CloudSetupGuideView {
                 appearance
                     .ui_builder()
                     .link(
-                        "Oz documentation".to_string(),
+                        "Cloud agent documentation".to_string(),
                         None,
                         Some(Box::new(|ctx| {
                             ctx.dispatch_typed_action(CloudSetupGuideAction::OpenDocs {
@@ -214,6 +216,7 @@ impl CloudSetupGuideView {
     }
 
     /// Render the quick start banner with link to oz.warp.dev.
+    #[cfg_attr(not(feature = "warp_hosted"), allow(dead_code))]
     fn render_quick_start_banner(&self, appearance: &Appearance) -> Box<dyn Element> {
         let theme = appearance.theme();
         let font_size = 16.;
@@ -253,7 +256,7 @@ impl CloudSetupGuideView {
         let font_size = 16.;
 
         Text::new(
-            "Manual setup: Create a Slack or Linear integration with the Oz CLI",
+            "Manual setup: Create a Slack or Linear integration with the agent CLI",
             appearance.ui_font_family(),
             font_size,
         )
@@ -592,7 +595,13 @@ impl View for CloudSetupGuideView {
             .with_cross_axis_alignment(CrossAxisAlignment::Stretch);
 
         content.add_child(self.render_header(appearance));
-        content.add_child(self.render_quick_start_banner(appearance));
+        // PDX-120 [E8]: the quick-start banner advertises oz.warp.dev which
+        // only exists in the Warp-hosted fork. Hide it entirely for the
+        // Helm client; upstream rebases keep the banner under warp_hosted.
+        #[cfg(feature = "warp_hosted")]
+        {
+            content.add_child(self.render_quick_start_banner(appearance));
+        }
         content.add_child(self.render_manual_setup_header(appearance));
         content.add_child(steps);
 

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -323,7 +323,7 @@ impl DefaultSessionMode {
         match self {
             DefaultSessionMode::Terminal => "Terminal",
             DefaultSessionMode::Agent => "Agent",
-            DefaultSessionMode::CloudAgent => "Cloud Oz",
+            DefaultSessionMode::CloudAgent => "Cloud agent",
             DefaultSessionMode::TabConfig => "Tab Config",
             DefaultSessionMode::DockerSandbox => "Local Docker Sandbox",
         }

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -1516,12 +1516,17 @@ impl AISettingsPageView {
                 widgets.push(Box::new(AwsBedrockWidget::new(ctx)));
                 widgets.push(Box::new(AgentAttributionWidget::default()));
                 widgets.push(Box::new(OtherAIWidget::default()));
+                // PDX-120 [E8]: the cloud-agent computer-use widget is the
+                // settings counterpart of the hosted-Oz "Cloud agent" mode.
+                // The Helm fork ships without that hosted surface, so the
+                // widget only renders when the warp_hosted feature is on.
+                #[cfg(feature = "warp_hosted")]
                 if FeatureFlag::AgentModeComputerUse.is_enabled() {
                     widgets.push(Box::new(CloudAgentComputerUseWidget::default()));
                 }
             }
             Some(AISubpage::WarpAgent) => {
-                // Oz page: global toggle + Active AI + Input + Other
+                // Cloud agent page: global toggle + Active AI + Input + Other
                 widgets.push(Box::new(GlobalAIWidget::default()));
                 if ai_settings
                     .intelligent_autosuggestions_enabled_internal
@@ -1560,6 +1565,9 @@ impl AISettingsPageView {
                 widgets.push(Box::new(AwsBedrockWidget::new(ctx)));
                 widgets.push(Box::new(AgentAttributionWidget::default()));
                 widgets.push(Box::new(OtherAIWidget::default()));
+                // PDX-120 [E8]: same hosted-Oz gating as the CLI agents
+                // subpage above.
+                #[cfg(feature = "warp_hosted")]
                 if FeatureFlag::AgentModeComputerUse.is_enabled() {
                     widgets.push(Box::new(CloudAgentComputerUseWidget::default()));
                 }
@@ -6336,6 +6344,11 @@ impl SettingsWidget for AgentAttributionWidget {
 #[path = "ai_page_tests.rs"]
 mod tests;
 
+// PDX-120 [E8]: only pushed onto the AI page widget stack in the
+// Warp-hosted build. The Helm client routes cloud agents through the
+// helm-cloud Workers (PDX-19/PDX-119) and does not surface this widget,
+// but the type stays around so upstream rebases keep compiling.
+#[cfg_attr(not(feature = "warp_hosted"), allow(dead_code))]
 #[derive(Default)]
 struct CloudAgentComputerUseWidget {
     toggle: SwitchStateHandle,

--- a/app/src/settings_view/mod.rs
+++ b/app/src/settings_view/mod.rs
@@ -248,7 +248,7 @@ impl Display for SettingsSection {
             SettingsSection::CodeIndexing => write!(f, "Indexing and projects"),
             SettingsSection::EditorAndCodeReview => write!(f, "Editor and Code Review"),
             SettingsSection::CloudEnvironments => write!(f, "Environments"),
-            SettingsSection::OzCloudAPIKeys => write!(f, "Oz Cloud API Keys"),
+            SettingsSection::OzCloudAPIKeys => write!(f, "Cloud Agent API Keys"),
             SettingsSection::Doppler => write!(f, "Secrets (Doppler)"),
             _ => write!(f, "{self:?}"),
         }
@@ -350,7 +350,12 @@ impl FromStr for SettingsSection {
             "Indexing and projects" | "CodeIndexing" => Ok(Self::CodeIndexing),
             "Editor and Code Review" | "EditorAndCodeReview" => Ok(Self::EditorAndCodeReview),
             "CloudEnvironments" => Ok(Self::CloudEnvironments),
-            "Oz Cloud API Keys" | "OzCloudAPIKeys" => Ok(Self::OzCloudAPIKeys),
+            // PDX-120 [E8]: renamed to "Cloud Agent API Keys" in the UI;
+            // accept the legacy "Oz Cloud API Keys" string for backward
+            // compatibility with persisted user settings.
+            "Cloud Agent API Keys" | "Oz Cloud API Keys" | "OzCloudAPIKeys" => {
+                Ok(Self::OzCloudAPIKeys)
+            }
             "Secrets (Doppler)" | "Doppler" => Ok(Self::Doppler),
             _ => Err(()),
         }

--- a/app/src/settings_view/mod_test.rs
+++ b/app/src/settings_view/mod_test.rs
@@ -192,7 +192,7 @@ fn subpage_display_names_are_correct() {
     );
     assert_eq!(
         SettingsSection::OzCloudAPIKeys.to_string(),
-        "Oz Cloud API Keys"
+        "Cloud Agent API Keys"
     );
 }
 

--- a/app/src/settings_view/platform_page.rs
+++ b/app/src/settings_view/platform_page.rs
@@ -413,7 +413,7 @@ impl PlatformPageWidget {
             Flex::row()
                 .with_cross_axis_alignment(CrossAxisAlignment::Center)
                 .with_child(
-                    Text::new_inline("Oz Cloud API Keys", appearance.ui_font_family(), 16.)
+                    Text::new_inline("Cloud Agent API Keys", appearance.ui_font_family(), 16.)
                         .with_style(Properties::default().weight(Weight::Bold))
                         .with_color(appearance.theme().active_ui_text_color().into())
                         .finish(),

--- a/app/src/workspace/view.rs
+++ b/app/src/workspace/view.rs
@@ -6119,12 +6119,17 @@ impl Workspace {
             }
         }
 
-        // 3. Cloud Oz (if flags enabled)
+        // 3. Cloud agent (if flags enabled)
+        // PDX-120 [E8]: this entry routes through `AddAmbientAgentTab`,
+        // which calls Warp's hosted billing API. The Helm client uses
+        // helm-cloud Workers (PDX-19/PDX-119) for cloud envs instead, so
+        // hide this menu item from the default Helm build.
+        #[cfg(feature = "warp_hosted")]
         if is_any_ai_enabled
             && FeatureFlag::AgentView.is_enabled()
             && FeatureFlag::CloudMode.is_enabled()
         {
-            let mut cloud_item = MenuItemFields::new("Cloud Oz")
+            let mut cloud_item = MenuItemFields::new("Cloud agent")
                 .with_on_select_action(WorkspaceAction::AddAmbientAgentTab)
                 .with_icon(icons::Icon::LayoutAlt01);
             if effective_default == DefaultSessionMode::CloudAgent {


### PR DESCRIPTION
## Summary

Final piece of the cloud-environment migration: hide the Warp-hosted "Cloud agent" UI entry points and rebrand the remaining cloud-agent surfaces in the Helm client. The user-reported "Your team has run out of add-on credits" error came from clicking the new-tab dropdown's "Cloud Oz" item, which dispatched `WorkspaceAction::AddAmbientAgentTab` and hit the hosted billing API. That entry point and its peers are now gated behind `cfg(feature = "warp_hosted")`, so the default Helm build never surfaces them.

## Inventory (every site touched)

- `app/src/workspace/view.rs:6122-6134` - new-tab dropdown "Cloud Oz" menu item: gated `cfg(feature = "warp_hosted")` and label renamed to "Cloud agent". This was the entry point hitting hosted billing.
- `app/src/ai/agent_management/agent_type_selector.rs` - the "Choose your agent" modal:
  - Cloud row (`render_option` index 0) gated `cfg(feature = "warp_hosted")`
  - Local row reuses index 0 in the Helm build
  - `ArrowUp`/`ArrowDown` no-op when only one row is visible
  - `Enter` dispatches `Local` directly when `warp_hosted` is off
  - `cloud_agent_mouse_state` field marked `#[cfg_attr(not(feature = "warp_hosted"), allow(dead_code))]`
- `app/src/settings_view/ai_page.rs:1519-1521,1563-1565` - both `CloudAgentComputerUseWidget::default()` push sites gated `cfg(feature = "warp_hosted")`. Widget definition kept (with `cfg_attr(... allow(dead_code))`) so `warp_hosted` builds compile.
- `app/src/settings_view/ai_page.rs:1524` - inline comment `// Oz page` -> `// Cloud agent page`.
- `app/src/ai/agent_management/cloud_setup_guide_view.rs`:
  - "Getting started with Oz cloud agents" -> "Getting started with cloud agents"
  - Subtitle reworded to drop "Oz SDK"/"Oz" and "Warp" branding
  - "Oz documentation" link -> "Cloud agent documentation"
  - "Manual setup ... with the Oz CLI" -> "... with the agent CLI"
  - `render_quick_start_banner` (the oz.warp.dev "Visit Oz" banner) call site gated `cfg(feature = "warp_hosted")`; the method and `visit_oz_button` field carry `#[cfg_attr(not(feature = "warp_hosted"), allow(dead_code))]`
- `app/src/settings/ai.rs:326` - `DefaultSessionMode::CloudAgent` display name "Cloud Oz" -> "Cloud agent"
- `app/src/settings_view/mod.rs:251` - `SettingsSection::OzCloudAPIKeys` Display "Oz Cloud API Keys" -> "Cloud Agent API Keys"; `from_str` accepts both new and legacy strings for persisted-settings backward compat
- `app/src/settings_view/mod_test.rs:194-196` - `to_string` test updated to match new label
- `app/src/settings_view/platform_page.rs:416` - heading "Oz Cloud API Keys" -> "Cloud Agent API Keys"

## Out of scope (intentionally left alone)

- `app/src/ai/ambient_agents/`, `app/src/ai/execution_profiles/` - already feature-flagged in PDX-34
- `app/src/ai/cloud_environments/mod.rs`, `app/src/ai/agent_sdk/environment.rs::create_environment_after_auth_check`, `app/src/settings_view/cli_agent_sign_in_widget.rs` - PDX-118/PDX-119 contention zones
- `crates/warp_server_client/`, `crates/server_api/` - rebase compatibility with upstream
- `FeatureFlag::CloudEnvironments` left intact (gates UI surfaces, not the API boundary)
- Slash commands `/cloud-agent`, `/create-environment` and `EnterCloudAgentView` keybinding - already gated by `FeatureFlag::CloudMode` / `FeatureFlag::CreateEnvironmentSlashCommand`, off by default in the Helm config
- `app/src/ai/ambient_agents/task.rs:190` ("Oz Web") - inside PDX-34 territory
- `agent_tips.rs` docs.warp.dev URLs - functional documentation links, not Oz branding
- `app/src/ai/agent_management/cloud_setup_guide_view.rs:39` `OZ_URL` const - already gated to "" when `warp_hosted` is off (PDX-34)

## Test plan

- [x] `cargo build -p warp --no-default-features` succeeds (Helm fork build)
- [x] `cargo build -p warp` succeeds (warp_hosted build, default features)
- [x] `git grep` confirms "Cloud Oz", "Oz documentation", "Visit oz.warp.dev", "Getting started with Oz", and "Oz Cloud API Keys" no longer appear as default-rendered visible UI strings
- [ ] Manual smoke: launch the Helm client, click the new-tab `+` dropdown, confirm the "Cloud agent" item is absent and only "Terminal" / "Agent" / "Local Docker Sandbox" / tab-config rows remain (cannot run from worktree)
- [ ] Manual smoke: open Settings > AI > CLI agents, confirm no "Cloud Agent Computer Use" widget renders
- [ ] Manual smoke: trigger the agent management "New agent" button, confirm the type selector only shows "Local agent" (Cloud row is hidden)
- Note: `cargo test -p warp --lib` test compilation succeeded; the test binary fails at runtime in the worktree environment due to a missing `libswift_Concurrency.dylib` (unrelated to this PR).