### PR TITLE
PDX-121 [E9] Default coding-agent setting + selector visibility

### DIFF
--- a/app/src/ai/agent_sdk/driver.rs
+++ b/app/src/ai/agent_sdk/driver.rs
@@ -744,6 +744,17 @@ impl AgentDriver {
         // the in-prompt selector. The latch is consume-and-clear and now
         // covers all three providers (Claude Code, Codex, Ollama), not
         // just Claude.
+        //
+        // PDX-121 [E9] task 4: before consulting the per-turn latch, give
+        // the user's persisted `DefaultCodingAgent` setting a chance to
+        // populate the latch. `apply_default_coding_agent_pin` is a
+        // no-op when (a) the default is `Auto` (default cleared) or
+        // (b) an explicit per-turn pin from the selector already exists.
+        // This preserves the "explicit wins over default" precedence the
+        // PDX-105 tests assert.
+        if pinned_provider.is_none() {
+            local_orchestrator::apply_default_coding_agent_pin();
+        }
         let pinned_provider =
             pinned_provider.or_else(local_orchestrator::consume_provider_pin);
 

--- a/app/src/ai/agent_sdk/driver/local_orchestrator.rs
+++ b/app/src/ai/agent_sdk/driver/local_orchestrator.rs
@@ -231,11 +231,7 @@ impl LocalOrchestratorAgent {
     /// Returns `None` if nothing is staged (which shouldn't happen on the
     /// hot path; the caller stages immediately before reading).
     pub(crate) async fn peek_staged_prompt(&self) -> Option<AgentRunPrompt> {
-        self.staged
-            .lock()
-            .await
-            .as_ref()
-            .map(|s| s.prompt.clone())
+        self.staged.lock().await.as_ref().map(|s| s.prompt.clone())
     }
 }
 
@@ -284,12 +280,10 @@ impl Agent for LocalOrchestratorAgent {
     /// Pulls the staged foreground+prompt off the mutex, then translates the
     /// driver's [`SDKConversationOutputStatus`] into orchestrator events.
     async fn execute(&self, task: Task) -> Result<AgentEventStream, AgentError> {
-        let staged = self
-            .staged
-            .lock()
-            .await
-            .take()
-            .ok_or_else(|| AgentError::Other("local orchestrator: no staged run".to_string()))?;
+        let staged =
+            self.staged.lock().await.take().ok_or_else(|| {
+                AgentError::Other("local orchestrator: no staged run".to_string())
+            })?;
         let StagedRun { foreground, prompt } = staged;
         let task_id = task.id;
 
@@ -449,10 +443,8 @@ pub(crate) fn persistent_enforcer() -> Arc<super::budget_enforcer::BudgetEnforce
 /// Returns the `Arc<LocalOrchestratorAgent>` so the caller can stage a run on
 /// it via [`LocalOrchestratorAgent::stage_run`] without re-fetching it from
 /// the router (the router stores `Arc<dyn Agent>` and downcasting is awkward).
-pub(crate) async fn ensure_persistent_router() -> (
-    Arc<AsyncMutex<Router>>,
-    Arc<LocalOrchestratorAgent>,
-) {
+pub(crate) async fn ensure_persistent_router(
+) -> (Arc<AsyncMutex<Router>>, Arc<LocalOrchestratorAgent>) {
     // Note: the `Arc<LocalOrchestratorAgent>` we return is the *same* one
     // registered into the router, so `stage_run` and `Agent::execute` race
     // through the same mutex.
@@ -466,9 +458,7 @@ pub(crate) async fn ensure_persistent_router() -> (
             // Build the budget once and stash it in `GLOBAL_BUDGET` so
             // PDX-27's budget enforcer can debit and read the same
             // accounting state the router consults at select-time.
-            let budget = GLOBAL_BUDGET
-                .get_or_init(build_persistent_budget)
-                .clone();
+            let budget = GLOBAL_BUDGET.get_or_init(build_persistent_budget).clone();
             let mut router = Router::new(budget);
             router.register(AgentRegistration {
                 agent: local_agent.clone() as Arc<dyn Agent>,
@@ -511,8 +501,10 @@ pub(crate) async fn ensure_persistent_router() -> (
 pub(crate) async fn ensure_claude_code_registered(router: &Arc<AsyncMutex<Router>>) {
     use agents::{ClaudeCodeAgent, ClaudeModel};
 
-    match ClaudeCodeAgent::new(AgentId(CLAUDE_CODE_SONNET_46_ID.to_string()), ClaudeModel::Sonnet46)
-    {
+    match ClaudeCodeAgent::new(
+        AgentId(CLAUDE_CODE_SONNET_46_ID.to_string()),
+        ClaudeModel::Sonnet46,
+    ) {
         Ok(agent) => {
             let mut router = router.lock().await;
             router.register(AgentRegistration {
@@ -560,8 +552,10 @@ pub(crate) async fn refresh_claude_code_registration() {
 pub(crate) async fn ensure_claude_code_haiku_registered(router: &Arc<AsyncMutex<Router>>) {
     use agents::{ClaudeCodeAgent, ClaudeModel};
 
-    match ClaudeCodeAgent::new(AgentId(CLAUDE_CODE_HAIKU_45_ID.to_string()), ClaudeModel::Haiku45)
-    {
+    match ClaudeCodeAgent::new(
+        AgentId(CLAUDE_CODE_HAIKU_45_ID.to_string()),
+        ClaudeModel::Haiku45,
+    ) {
         Ok(agent) => {
             let mut router = router.lock().await;
             router.register(AgentRegistration {
@@ -725,10 +719,7 @@ pub(crate) fn codex_signed_in() -> Option<bool> {
             .and_then(|v| v.as_str())
             .map(|s| !s.is_empty())
             .unwrap_or(false)
-        || json
-            .get("tokens")
-            .map(|v| !v.is_null())
-            .unwrap_or(false);
+        || json.get("tokens").map(|v| !v.is_null()).unwrap_or(false);
     Some(signed_in)
 }
 
@@ -949,6 +940,81 @@ pub(crate) fn consume_claude_code_pin() -> bool {
     }
 }
 
+/// PDX-121 [E9] task 4 — process-wide latch for the user's
+/// `DefaultCodingAgent` setting.
+///
+/// The AI page action handler
+/// (`AISettingsPageAction::SetDefaultCodingAgent`) writes here whenever
+/// the persisted setting changes; the dispatcher
+/// (`run_via_local_orchestrator`) reads via [`apply_default_coding_agent_pin`]
+/// and pre-pins the matching [`Provider`] *only* when no explicit
+/// in-prompt selector pin is currently set. The latch is keyed by
+/// `Provider` (or `None` for `Auto`) so the dispatch site does not need
+/// to know about the higher-level `DefaultCodingAgent` enum.
+///
+/// The fallback ordering matches PDX-105's contract — the in-prompt
+/// selector still wins, and the default only applies on turns where the
+/// user did not explicitly pick a provider for that turn.
+static DEFAULT_CODING_AGENT_PROVIDER: OnceLock<StdMutex<Option<Provider>>> = OnceLock::new();
+
+fn default_coding_agent_slot() -> &'static StdMutex<Option<Provider>> {
+    DEFAULT_CODING_AGENT_PROVIDER.get_or_init(|| StdMutex::new(None))
+}
+
+/// PDX-121 [E9] task 4 — set the process-wide default coding agent
+/// provider. `None` clears the default (matches `DefaultCodingAgent::Auto`).
+///
+/// Called from the AI page action handler whenever
+/// `AISettings::default_coding_agent` is mutated. Idempotent and cheap.
+pub(crate) fn set_default_coding_agent(provider: Option<Provider>) {
+    let mut slot = default_coding_agent_slot()
+        .lock()
+        .expect("DEFAULT_CODING_AGENT_PROVIDER mutex is never poisoned");
+    *slot = provider;
+}
+
+/// Read the current default coding agent provider without consuming it.
+/// Unlike [`consume_provider_pin`], the default is *not* a per-turn
+/// latch — it persists for the life of the process (until the user
+/// changes the setting again).
+pub(crate) fn current_default_coding_agent() -> Option<Provider> {
+    let slot = default_coding_agent_slot()
+        .lock()
+        .expect("DEFAULT_CODING_AGENT_PROVIDER mutex is never poisoned");
+    *slot
+}
+
+/// PDX-121 [E9] task 4 — apply the default coding agent pin for the
+/// upcoming turn iff no explicit per-turn pin already exists.
+///
+/// The dispatcher calls this *before* it reads the per-turn pin via
+/// [`consume_provider_pin`]. If the user has set a default
+/// (`DefaultCodingAgent != Auto`) and there is no current per-turn pin
+/// from the in-prompt selector, the default is written into the
+/// per-turn slot so the existing dispatch logic picks it up uniformly.
+///
+/// Returns `true` if a default was applied, `false` otherwise (either
+/// because there is no default set, or because an explicit pin already
+/// exists). The return value is mostly useful for tests.
+pub(crate) fn apply_default_coding_agent_pin() -> bool {
+    let default = current_default_coding_agent();
+    let Some(provider) = default else {
+        return false;
+    };
+
+    // Only apply the default when there is no explicit per-turn pin.
+    // Locking the per-turn slot for inspect-and-write keeps the
+    // explicit-pin-wins guarantee atomic.
+    let mut slot = provider_pin_slot()
+        .lock()
+        .expect("PROVIDER_PIN mutex is never poisoned");
+    if slot.is_some() {
+        return false;
+    }
+    *slot = Some(provider);
+    true
+}
+
 /// Process-wide [`McpForwarder`] (PDX-105 [B3] task 1).
 ///
 /// One forwarder per process. The persistent [`Router`] dispatches every
@@ -1019,9 +1085,7 @@ mod tests {
         // while holding the guard. We unwrap-or-into-inner to keep
         // running on the same data; the data is `()` so there's
         // nothing to recover.
-        PIN_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        PIN_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     fn worker_task() -> Task {
@@ -1110,11 +1174,7 @@ mod tests {
         set_provider_pin(None);
         assert_eq!(consume_provider_pin(), None);
 
-        for provider in [
-            Provider::ClaudeCode,
-            Provider::Codex,
-            Provider::Ollama,
-        ] {
+        for provider in [Provider::ClaudeCode, Provider::Codex, Provider::Ollama] {
             set_provider_pin(Some(provider));
             assert_eq!(consume_provider_pin(), Some(provider));
             // Read-and-clear: next consume is `None`.
@@ -1228,6 +1288,68 @@ mod tests {
         assert_eq!(consume_provider_pin(), None);
     }
 
+    /// PDX-121 [E9] task 4: setting the default coding agent and then
+    /// invoking the dispatch hook plants the matching `Provider` into the
+    /// per-turn pin slot, so the existing `consume_provider_pin` /
+    /// `or_else` chain in `run_via_local_orchestrator` picks it up
+    /// without any additional plumbing.
+    #[test]
+    fn default_coding_agent_pin_seeds_per_turn_slot_when_unset() {
+        let _g = pin_test_guard();
+        // Reset both latches to a known baseline; other tests in the
+        // same process may have left state behind.
+        set_provider_pin(None);
+        set_default_coding_agent(None);
+        assert_eq!(consume_provider_pin(), None);
+
+        // ClaudeCode default + no explicit per-turn pin → default applied.
+        set_default_coding_agent(Some(Provider::ClaudeCode));
+        assert!(apply_default_coding_agent_pin());
+        assert_eq!(consume_provider_pin(), Some(Provider::ClaudeCode));
+
+        // Cleanup.
+        set_default_coding_agent(None);
+    }
+
+    /// PDX-121 [E9] task 4 + task 6: when an explicit per-turn pin
+    /// already exists (from the in-prompt selector), the default coding
+    /// agent must NOT overwrite it. The selector wins per-turn; the
+    /// default is just the fallback.
+    #[test]
+    fn default_coding_agent_respects_explicit_per_turn_pin() {
+        let _g = pin_test_guard();
+        set_provider_pin(None);
+        set_default_coding_agent(None);
+
+        // Simulate the in-prompt selector setting Codex for this turn.
+        set_provider_pin(Some(Provider::Codex));
+        // Then user has Claude Code as default in settings.
+        set_default_coding_agent(Some(Provider::ClaudeCode));
+
+        // Apply the default — must be a no-op because Codex is already
+        // pinned for this turn.
+        assert!(!apply_default_coding_agent_pin());
+
+        // Per-turn pin still reflects Codex (explicit wins over default).
+        assert_eq!(consume_provider_pin(), Some(Provider::Codex));
+
+        // Cleanup.
+        set_default_coding_agent(None);
+    }
+
+    /// PDX-121 [E9] task 4: with the default cleared
+    /// (`DefaultCodingAgent::Auto`), the dispatch hook is a no-op even
+    /// when no per-turn pin exists — preserves Router tie-break behaviour.
+    #[test]
+    fn default_coding_agent_auto_is_a_noop() {
+        let _g = pin_test_guard();
+        set_provider_pin(None);
+        set_default_coding_agent(None);
+
+        assert!(!apply_default_coding_agent_pin());
+        assert_eq!(consume_provider_pin(), None);
+    }
+
     /// PDX-103 [B1] task 4: `encode_prompt_for_subprocess` round-trips
     /// `Local` prompts losslessly and falls back to an empty string for
     /// `ServerSide` prompts.
@@ -1288,9 +1410,7 @@ mod tests {
     #[test]
     fn infer_role_uses_local_text_and_falls_back_for_server_side() {
         assert_eq!(
-            infer_role_from_prompt(&AgentRunPrompt::Local(
-                "Summarize git history".to_string()
-            )),
+            infer_role_from_prompt(&AgentRunPrompt::Local("Summarize git history".to_string())),
             Role::Summarize
         );
         assert_eq!(

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -394,6 +394,76 @@ impl ThinkingDisplayMode {
     }
 }
 
+/// PDX-121 [E9] task 2 — user-selectable default coding agent.
+///
+/// When set to anything other than `Auto`, the dispatcher pre-pins the
+/// matching `orchestrator::Provider` for any session that hasn't been
+/// pinned by the in-prompt selector. `Auto` (the default) preserves the
+/// existing Router tie-break behaviour.
+///
+/// Persisted under `agents.default_coding_agent` so this is a *new* TOML
+/// key — it does not touch any existing serde keys, which means upgrading
+/// users land on `Auto` with zero migration churn.
+#[derive(
+    Default,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    PartialEq,
+    Eq,
+    Copy,
+    Clone,
+    EnumIter,
+    schemars::JsonSchema,
+    settings_value::SettingsValue,
+)]
+#[schemars(
+    description = "The provider to default to when dispatching coding-agent tasks.",
+    rename_all = "kebab-case"
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum DefaultCodingAgent {
+    /// Defer to the orchestrator Router's tie-break (current behaviour).
+    #[default]
+    Auto,
+    /// The local Warp orchestrator agent. Aliased to FoundationModels under
+    /// the hood since that is the Provider variant the local agent
+    /// registers as today.
+    Local,
+    /// Anthropic Claude Code CLI.
+    ClaudeCode,
+    /// OpenAI Codex CLI.
+    Codex,
+    /// Local Ollama models.
+    Ollama,
+    /// Apple FoundationModels-backed local agent.
+    FoundationModels,
+}
+
+settings::macros::implement_setting_for_enum!(
+    DefaultCodingAgent,
+    AISettings,
+    SupportedPlatforms::ALL,
+    SyncToCloud::Globally(RespectUserSyncSetting::Yes),
+    private: false,
+    toml_path: "agents.default_coding_agent",
+    description: "The default coding agent provider used when dispatching agent tasks.",
+);
+
+impl DefaultCodingAgent {
+    /// Display name for the settings dropdown.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            DefaultCodingAgent::Auto => "Auto (router decides)",
+            DefaultCodingAgent::Local => "Local (Warp)",
+            DefaultCodingAgent::ClaudeCode => "Claude Code",
+            DefaultCodingAgent::Codex => "Codex",
+            DefaultCodingAgent::Ollama => "Ollama",
+            DefaultCodingAgent::FoundationModels => "Foundation Models",
+        }
+    }
+}
+
 /// Tracks the state of the quota reset banner
 #[derive(
     Debug,
@@ -1388,6 +1458,13 @@ define_settings_group!(AISettings, settings: [
     // Controls how agent thinking/reasoning traces are displayed.
     thinking_display_mode: ThinkingDisplayMode,
 
+    // PDX-121 [E9] task 2: user-selectable default coding agent. When set
+    // to anything other than `Auto`, the dispatcher pre-pins the matching
+    // `orchestrator::Provider` for any session that has not been pinned by
+    // the in-prompt selector. `Auto` defers to Router tie-break (the
+    // pre-PDX-121 behaviour). Use `default_coding_agent()` getter.
+    default_coding_agent: DefaultCodingAgent,
+
     // Whether agent-executed shell commands should be included in command history
     // (up-arrow, Ctrl-R search, inline history menu).
     // When false, commands run by the AI agent are excluded from history.
@@ -1505,6 +1582,19 @@ impl AISettings {
         *self.is_any_ai_enabled
             && !is_anonymous_or_logged_out
             && !self.is_ai_disabled_due_to_remote_session_org_policy(app)
+    }
+
+    /// PDX-121 [E9] task 2 — current default coding agent.
+    ///
+    /// Returns the persisted [`DefaultCodingAgent`] (defaults to
+    /// [`DefaultCodingAgent::Auto`] for fresh installs / users who never
+    /// touched the setting). The dispatcher consults this through the
+    /// process-wide `local_orchestrator::DEFAULT_CODING_AGENT` latch which
+    /// is updated by the AI page's
+    /// `AISettingsPageAction::SetDefaultCodingAgent` handler — this
+    /// getter is the read side for that wiring and for tests.
+    pub fn default_coding_agent(&self) -> DefaultCodingAgent {
+        *self.default_coding_agent.value()
     }
 
     pub fn default_session_mode(&self, app: &AppContext) -> DefaultSessionMode {

--- a/app/src/settings/ai_tests.rs
+++ b/app/src/settings/ai_tests.rs
@@ -746,3 +746,22 @@ fn test_mark_quota_banner_as_dismissed() {
         });
     });
 }
+
+/// PDX-121 [E9] task 6: a fresh install (no TOML overrides applied) must
+/// surface `DefaultCodingAgent::Auto` from `AISettings::default_coding_agent()`.
+/// `Auto` preserves the legacy Router tie-break behaviour so the new
+/// setting is non-breaking by default.
+#[test]
+fn test_default_coding_agent_auto_for_fresh_install() {
+    App::test((), |mut app| async move {
+        initialize_settings_for_tests(&mut app);
+
+        AISettings::handle(&app).read(&app, |settings, _ctx| {
+            assert_eq!(
+                settings.default_coding_agent(),
+                DefaultCodingAgent::Auto,
+                "fresh install must default to DefaultCodingAgent::Auto"
+            );
+        });
+    });
+}

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -27,10 +27,10 @@ use crate::settings::{
     AgentModeCodingPermissionsType, AgentModeCommandExecutionDenylist,
     AgentModeCommandExecutionPredicate, AgentModeQuerySuggestionsEnabled, AwsBedrockAutoLogin,
     AwsBedrockCredentialsEnabled, CanUseWarpCreditsWithByok, CodeSettings, CodebaseContextEnabled,
-    FileBasedMcpEnabled, GitOperationsAutogenEnabled, IncludeAgentCommandsInHistory,
-    IntelligentAutosuggestionsEnabled, MemoryEnabled, NLDInTerminalEnabled,
-    NaturalLanguageAutosuggestionsEnabled, OrchestrationEnabled, RuleSuggestionsEnabled,
-    SharedBlockTitleGenerationEnabled, ShouldRenderCLIAgentToolbar,
+    DefaultCodingAgent, FileBasedMcpEnabled, GitOperationsAutogenEnabled,
+    IncludeAgentCommandsInHistory, IntelligentAutosuggestionsEnabled, MemoryEnabled,
+    NLDInTerminalEnabled, NaturalLanguageAutosuggestionsEnabled, OrchestrationEnabled,
+    RuleSuggestionsEnabled, SharedBlockTitleGenerationEnabled, ShouldRenderCLIAgentToolbar,
     ShouldRenderUseAgentToolbarForUserCommands, ShouldShowOzUpdatesInZeroState, ShowAgentTips,
     ShowConversationHistory, ShowHintText, ThinkingDisplayMode, VoiceInputEnabled,
     WarpDriveContextEnabled,
@@ -448,6 +448,10 @@ pub struct AISettingsPageView {
     last_synced_context_window_editor_value: Option<u32>,
 
     thinking_display_mode_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
+    /// PDX-121 [E9] task 3: dropdown driving the persisted
+    /// `AISettings::default_coding_agent` setting (renders inside
+    /// `DefaultCodingAgentWidget`).
+    default_coding_agent_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
     #[cfg(feature = "local_fs")]
     conversation_layout_dropdown: ViewHandle<Dropdown<AISettingsPageAction>>,
 
@@ -584,6 +588,37 @@ impl AISettingsPageView {
                     ctx,
                 );
             });
+        }
+
+        // PDX-121 [E9] task 3: build the default-coding-agent dropdown and
+        // sync its selection from the persisted setting. We also push the
+        // current setting into the local orchestrator's process-wide
+        // latch so the dispatcher honours the user's choice from the
+        // very first turn after app start (not just after they touch the
+        // dropdown again).
+        let default_coding_agent_dropdown = DefaultCodingAgentWidget::create_dropdown(ctx);
+        {
+            let current = AISettings::as_ref(ctx).default_coding_agent();
+            default_coding_agent_dropdown.update(ctx, |dropdown, ctx| {
+                dropdown.set_selected_by_action(
+                    AISettingsPageAction::SetDefaultCodingAgent(current),
+                    ctx,
+                );
+            });
+            #[cfg(not(target_family = "wasm"))]
+            {
+                use crate::ai::agent_sdk::driver::local_orchestrator;
+                let provider = match current {
+                    DefaultCodingAgent::Auto => None,
+                    DefaultCodingAgent::Local | DefaultCodingAgent::FoundationModels => {
+                        Some(orchestrator::Provider::FoundationModels)
+                    }
+                    DefaultCodingAgent::ClaudeCode => Some(orchestrator::Provider::ClaudeCode),
+                    DefaultCodingAgent::Codex => Some(orchestrator::Provider::Codex),
+                    DefaultCodingAgent::Ollama => Some(orchestrator::Provider::Ollama),
+                };
+                local_orchestrator::set_default_coding_agent(provider);
+            }
         }
 
         let autonomy_dropdown_menu = ctx.add_typed_action_view(|ctx| {
@@ -983,6 +1018,16 @@ impl AISettingsPageView {
                         .update(ctx, |dropdown, ctx| {
                             dropdown.set_selected_by_action(
                                 AISettingsPageAction::SetThinkingDisplayMode(current_mode),
+                                ctx,
+                            );
+                        });
+                }
+                AISettingsChangedEvent::DefaultCodingAgent { .. } => {
+                    let current = AISettings::as_ref(ctx).default_coding_agent();
+                    me.default_coding_agent_dropdown
+                        .update(ctx, |dropdown, ctx| {
+                            dropdown.set_selected_by_action(
+                                AISettingsPageAction::SetDefaultCodingAgent(current),
                                 ctx,
                             );
                         });
@@ -1426,6 +1471,7 @@ impl AISettingsPageView {
             mcp_denylist_dropdown,
             mcp_denylist_mouse_state_handles,
             thinking_display_mode_dropdown,
+            default_coding_agent_dropdown,
             #[cfg(feature = "local_fs")]
             conversation_layout_dropdown,
             profile_views,
@@ -1506,6 +1552,10 @@ impl AISettingsPageView {
                     widgets.push(Box::new(VoiceWidget::default()));
                 }
                 widgets.push(Box::new(CLIAgentWidget::default()));
+                // PDX-121 [E9] task 3: default-coding-agent setting sits
+                // immediately above the sign-in row so the dropdown lives
+                // on the same page where users wire up their CLIs.
+                widgets.push(Box::new(DefaultCodingAgentWidget));
                 // PDX-103 [B1] task 6: coding-agent sign-in row sits ABOVE
                 // the API keys (BYOK) section. PDX-104 (B2) appends Codex +
                 // Ollama rows inside this widget.
@@ -1557,6 +1607,9 @@ impl AISettingsPageView {
                 if voice_supported {
                     widgets.push(Box::new(VoiceWidget::default()));
                 }
+                // PDX-121 [E9] task 3: default-coding-agent setting sits
+                // immediately above the sign-in row.
+                widgets.push(Box::new(DefaultCodingAgentWidget));
                 // PDX-103 [B1] task 6: same sign-in row above BYOK on this subpage.
                 widgets.push(Box::new(
                     super::cli_agent_sign_in_widget::CliAgentSignInWidget::default(),
@@ -1585,6 +1638,10 @@ impl AISettingsPageView {
             }
             Some(AISubpage::ThirdPartyCLIAgents) => {
                 widgets.push(Box::new(CLIAgentWidget::default()));
+                // PDX-121 [E9] task 3: default-coding-agent setting sits
+                // immediately above the sign-in row on the dedicated
+                // third-party agents subpage too.
+                widgets.push(Box::new(DefaultCodingAgentWidget));
                 // PDX-103 [B1] task 6: same sign-in row reused on the
                 // dedicated third-party agents subpage.
                 widgets.push(Box::new(
@@ -2240,6 +2297,10 @@ pub enum AISettingsPageAction {
     ToggleShowAgentTips,
     ToggleShowOzUpdatesInZeroState,
     SetThinkingDisplayMode(ThinkingDisplayMode),
+    /// PDX-121 [E9] task 3: change the persisted default coding agent and
+    /// push the matching `Provider` into the local orchestrator's
+    /// process-wide latch so subsequent dispatches honour it.
+    SetDefaultCodingAgent(crate::settings::DefaultCodingAgent),
     AttemptLoginGatedUpgrade,
     RemoveCLIAgentToolbarEnabledCommand(String),
     RemoveFromCommandExecutionAllowlist(AgentModeCommandExecutionPredicate),
@@ -2927,6 +2988,34 @@ impl TypedActionView for AISettingsPageView {
                 AISettings::handle(ctx).update(ctx, |settings, ctx| {
                     report_if_error!(settings.thinking_display_mode.set_value(*mode, ctx));
                 });
+                ctx.notify();
+            }
+            AISettingsPageAction::SetDefaultCodingAgent(default) => {
+                // Persist the new default in AISettings.
+                AISettings::handle(ctx).update(ctx, |settings, ctx| {
+                    report_if_error!(settings.default_coding_agent.set_value(*default, ctx));
+                });
+
+                // PDX-121 [E9] task 4: notify the local orchestrator so the
+                // dispatcher's process-wide latch reflects the user's choice
+                // immediately (no app restart). The wasm build does not
+                // dispatch through the local orchestrator, so the bridge is
+                // gated to the same `cfg` as the rest of the dispatch path.
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    use crate::ai::agent_sdk::driver::local_orchestrator;
+                    use crate::settings::DefaultCodingAgent;
+                    let provider = match default {
+                        DefaultCodingAgent::Auto => None,
+                        DefaultCodingAgent::Local | DefaultCodingAgent::FoundationModels => {
+                            Some(orchestrator::Provider::FoundationModels)
+                        }
+                        DefaultCodingAgent::ClaudeCode => Some(orchestrator::Provider::ClaudeCode),
+                        DefaultCodingAgent::Codex => Some(orchestrator::Provider::Codex),
+                        DefaultCodingAgent::Ollama => Some(orchestrator::Provider::Ollama),
+                    };
+                    local_orchestrator::set_default_coding_agent(provider);
+                }
                 ctx.notify();
             }
             AISettingsPageAction::AttemptLoginGatedUpgrade => {
@@ -6008,6 +6097,90 @@ impl SettingsWidget for OtherAIWidget {
         }
 
         column.finish()
+    }
+}
+
+/// PDX-121 [E9] task 3 — settings widget that hosts the default
+/// coding-agent dropdown.
+///
+/// Renders a single dropdown bound to
+/// [`AISettingsPageAction::SetDefaultCodingAgent`]. The dropdown view
+/// itself lives on [`AISettingsPageView::default_coding_agent_dropdown`]
+/// so it survives across rebuilds of the widget list.
+///
+/// Pushed onto the AI subpage widget stack immediately above the
+/// `CliAgentSignInWidget` so users see the default-agent control on the
+/// same page as the coding-agent sign-in flows.
+struct DefaultCodingAgentWidget;
+
+impl DefaultCodingAgentWidget {
+    fn create_dropdown(
+        ctx: &mut ViewContext<AISettingsPageView>,
+    ) -> ViewHandle<Dropdown<AISettingsPageAction>> {
+        let items: Vec<DropdownItem<AISettingsPageAction>> = DefaultCodingAgent::iter()
+            .map(|variant| {
+                DropdownItem::new(
+                    variant.display_name(),
+                    AISettingsPageAction::SetDefaultCodingAgent(variant),
+                )
+            })
+            .collect();
+
+        ctx.add_typed_action_view(|ctx| {
+            let mut dropdown = Dropdown::new(ctx);
+            dropdown.set_top_bar_max_width(AI_SETTINGS_DROPDOWN_WIDTH);
+            dropdown.set_menu_width(AI_SETTINGS_DROPDOWN_WIDTH, ctx);
+            dropdown.set_menu_max_height(AI_SETTINGS_DROPDOWN_MAX_HEIGHT, ctx);
+            dropdown.add_items(items, ctx);
+            dropdown
+        })
+    }
+}
+
+impl SettingsWidget for DefaultCodingAgentWidget {
+    type View = AISettingsPageView;
+
+    fn search_terms(&self) -> &str {
+        "default coding agent provider claude code codex ollama foundation models local warp router auto pin"
+    }
+
+    fn render(
+        &self,
+        view: &Self::View,
+        appearance: &Appearance,
+        app: &AppContext,
+    ) -> Box<dyn Element> {
+        let ai_settings = AISettings::as_ref(app);
+        let is_any_ai_enabled = ai_settings.is_any_ai_enabled(app);
+
+        Flex::column()
+            .with_child(render_separator(appearance))
+            .with_child(
+                build_sub_header(
+                    appearance,
+                    "Default coding agent",
+                    Some(styles::header_font_color(is_any_ai_enabled, app)),
+                )
+                .with_padding_bottom(HEADER_PADDING)
+                .finish(),
+            )
+            .with_child(render_dropdown_item(
+                appearance,
+                "Default coding agent",
+                Some(
+                    "Provider used when dispatching agent tasks. \"Auto\" defers to the orchestrator's tie-break (current behaviour). Pick a specific agent to make it the default for new sessions; the in-prompt selector still wins per-turn.",
+                ),
+                None,
+                LocalOnlyIconState::for_setting(
+                    DefaultCodingAgent::storage_key(),
+                    DefaultCodingAgent::sync_to_cloud(),
+                    &mut view.local_only_icon_tooltip_states.borrow_mut(),
+                    app,
+                ),
+                (!is_any_ai_enabled).then(|| appearance.theme().disabled_ui_text_color()),
+                &view.default_coding_agent_dropdown,
+            ))
+            .finish()
     }
 }
 

--- a/app/src/settings_view/cli_agent_sign_in_widget.rs
+++ b/app/src/settings_view/cli_agent_sign_in_widget.rs
@@ -25,7 +25,7 @@ use warpui::ui_components::{
     button::ButtonVariant,
     components::{Coords, UiComponent, UiComponentStyles},
 };
-use warpui::AppContext;
+use warpui::{AppContext, SingletonEntity};
 
 use super::ai_page::{AISettingsPageAction, AISettingsPageView};
 use super::settings_page::{
@@ -321,10 +321,39 @@ impl SettingsWidget for CliAgentSignInWidget {
         &self,
         _view: &Self::View,
         appearance: &Appearance,
-        _app: &AppContext,
+        app: &AppContext,
     ) -> Box<dyn Element> {
         let ui_builder = appearance.ui_builder();
         let theme = appearance.theme();
+
+        // PDX-121 [E9] task 5 — informational header showing whether the
+        // in-prompt model selector is currently visible. Read-only: the
+        // toggle itself lives in Settings → AI → AI features → Show model
+        // selectors in prompt; this line just surfaces its state at the
+        // top of the agent sign-in widget so users know where to look
+        // when they ask "why don't I see an agent picker in my terminal?"
+        let selector_on = *crate::terminal::session_settings::SessionSettings::as_ref(app)
+            .show_model_selectors_in_prompt;
+        let selector_indicator_text: &'static str = if selector_on {
+            "In-prompt agent selector: ON"
+        } else {
+            "In-prompt agent selector: OFF — Settings → AI → AI features → Show model selectors in prompt"
+        };
+        let selector_indicator = Container::new(
+            Align::new(
+                Text::new_inline(
+                    selector_indicator_text,
+                    appearance.ui_font_family(),
+                    CONTENT_FONT_SIZE,
+                )
+                .with_color(theme.nonactive_ui_text_color().into())
+                .finish(),
+            )
+            .left()
+            .finish(),
+        )
+        .with_padding_bottom(8.)
+        .finish();
 
         let header = Container::new(
             Align::new(
@@ -412,15 +441,14 @@ impl SettingsWidget for CliAgentSignInWidget {
         .with_padding_bottom(8.)
         .finish();
 
-        let gateway_endpoint_banner: Box<dyn Element> = Container::new(
-            render_settings_info_banner(
+        let gateway_endpoint_banner: Box<dyn Element> =
+            Container::new(render_settings_info_banner(
                 "Gateway endpoint",
                 Some(&gateway.endpoint_summary()),
                 appearance,
-            ),
-        )
-        .with_padding_bottom(12.)
-        .finish();
+            ))
+            .with_padding_bottom(12.)
+            .finish();
 
         let gateway_claude_btn_label = if gateway.claude_enabled {
             "Disable gateway routing for Claude Code"
@@ -466,16 +494,11 @@ impl SettingsWidget for CliAgentSignInWidget {
 
         // ── Claude Code row ────────────────────────────────────────────
         let claude_state = CliAgentAuthState::detect_claude();
-        let claude_banner: Option<Box<dyn Element>> = claude_state
-            .banner(CliAgent::Claude)
-            .map(|(title, sub)| {
-                Container::new(render_settings_info_banner(
-                    &title,
-                    Some(&sub),
-                    appearance,
-                ))
-                .with_padding_bottom(12.)
-                .finish()
+        let claude_banner: Option<Box<dyn Element>> =
+            claude_state.banner(CliAgent::Claude).map(|(title, sub)| {
+                Container::new(render_settings_info_banner(&title, Some(&sub), appearance))
+                    .with_padding_bottom(12.)
+                    .finish()
             });
         let claude_btn_builder = ui_builder
             .button(ButtonVariant::Accent, self.claude_button.clone())
@@ -494,16 +517,11 @@ impl SettingsWidget for CliAgentSignInWidget {
 
         // ── Codex row (PDX-104 [B2] task 5) ────────────────────────────
         let codex_state = CliAgentAuthState::detect_codex();
-        let codex_banner: Option<Box<dyn Element>> = codex_state
-            .banner(CliAgent::Codex)
-            .map(|(title, sub)| {
-                Container::new(render_settings_info_banner(
-                    &title,
-                    Some(&sub),
-                    appearance,
-                ))
-                .with_padding_bottom(12.)
-                .finish()
+        let codex_banner: Option<Box<dyn Element>> =
+            codex_state.banner(CliAgent::Codex).map(|(title, sub)| {
+                Container::new(render_settings_info_banner(&title, Some(&sub), appearance))
+                    .with_padding_bottom(12.)
+                    .finish()
             });
         let codex_btn_builder = ui_builder
             .button(ButtonVariant::Accent, self.codex_button.clone())
@@ -559,6 +577,9 @@ impl SettingsWidget for CliAgentSignInWidget {
 
         // ── Compose ────────────────────────────────────────────────────
         let mut children: Vec<Box<dyn Element>> = vec![
+            // PDX-121 [E9] task 5: informational header — stays at the
+            // very top, ABOVE the gateway routing block.
+            selector_indicator,
             // PDX-118 [E6]: gateway routing block.
             gateway_header,
             gateway_description,


### PR DESCRIPTION
## Summary

Closes the user-reported "no toggle appears in terminals to set agent and no default setting in settings" gap from PDX-121 [E9].

- New `DefaultCodingAgent` setting under `agents.default_coding_agent` (TOML) with variants `Auto` (default), `Local`, `ClaudeCode`, `Codex`, `Ollama`, `FoundationModels`. `Auto` preserves the existing Router tie-break behaviour, so this is a non-breaking add.
- New `DefaultCodingAgentWidget` rendered immediately above the `CliAgentSignInWidget` on every AI subpage that hosts the sign-in widget (WarpAgent main, WarpAgent subpage, ThirdPartyCLIAgents).
- Dispatcher hook (`local_orchestrator::apply_default_coding_agent_pin`) called from `run_via_local_orchestrator` *before* `consume_provider_pin`. No-op when the user picked `Auto` or when the in-prompt selector already pinned a provider for this turn — preserves the explicit-pin-wins precedence asserted by PDX-105's tests.
- Convenience read-only indicator at the very top of the sign-in widget: `"In-prompt agent selector: ON"` / `"OFF — Settings → AI → AI features → Show model selectors in prompt"`. The toggle itself stays where it lives in Settings.

## Files touched

- `app/src/settings/ai.rs` — `DefaultCodingAgent` enum + `AISettings::default_coding_agent` field + getter.
- `app/src/settings/ai_tests.rs` — fresh-install test.
- `app/src/ai/agent_sdk/driver/local_orchestrator.rs` — process-wide latch, `set_default_coding_agent`, `apply_default_coding_agent_pin`, three unit tests.
- `app/src/ai/agent_sdk/driver.rs` — single dispatch-hook line that calls the new helper before consuming the per-turn pin.
- `app/src/settings_view/ai_page.rs` — widget, dropdown plumbing, action variant + handler, event-driven sync.
- `app/src/settings_view/cli_agent_sign_in_widget.rs` — informational header line at the very top of the widget. The gateway block, helm-cloud block, and per-agent rows are unchanged.

## Constraints honoured

- No changes to `crates/orchestrator/`, `crates/agents/`, `crates/auto_healing/`, `crates/symphony/`, or any `helm_cloud_*` / `ai_gateway_*` crate.
- No serde-key changes for existing settings; the new key (`agents.default_coding_agent`) is brand-new.
- Non-portable bits gated with `cfg(not(target_family = "wasm"))`.

## Test plan

- [x] `cargo check -p warp` clean (only pre-existing warnings).
- [x] `cargo test -p warp --lib -- local_orchestrator profile_model_selector` — 47/47 pass, including 3 new PDX-121 tests.
- [x] `cargo test -p warp --lib test_default_coding_agent_auto_for_fresh_install` — passes.
- [ ] Manual: open Settings → AI → AI features, confirm the "Default coding agent" dropdown is visible above the coding-agent sign-in row, the indicator at the top of the sign-in widget reflects the in-prompt selector toggle's current state, and changing the dropdown propagates to the dispatcher (no app restart needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Default coding agent" setting to AI preferences with options: Auto, Local, Claude Code, Codex, Ollama, and Foundation Models.
  * Added in-prompt agent selector status indicator to the settings view.
  * System now persists and applies your default coding agent preference automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->