### PR TITLE
🎨 Palette: Improve ActionButton accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Icon-only Action Button Accessibility Pattern
+**Learning:** Icon-only buttons often lack descriptive text for screen readers. Implementing a hierarchical fallback for accessibility labels (explicit label -> visual label -> tooltip) ensures that interactive elements always have some form of announcement while allowing developers to provide high-context overrides.
+**Action:** Always provide an explicit accessibility label for icon-only ActionButtons using the `.with_accessibility_label()` builder method, especially when the action is context-dependent (e.g., delete buttons).

--- a/app/src/settings_view/appearance_page.rs
+++ b/app/src/settings_view/appearance_page.rs
@@ -4758,6 +4758,8 @@ fn build_directory_delete_buttons(
                 ActionButton::new("", NakedTheme)
                     .with_icon(Icon::X)
                     .with_size(ButtonSize::XSmall)
+                    .with_tooltip("Remove directory color")
+                    .with_accessibility_label(format!("Remove directory color for {dir_path}"))
                     .on_click(move |ctx| {
                         ctx.dispatch_typed_action(
                             AppearancePageAction::RemoveDefaultDirectoryTabColor {

--- a/app/src/view_components/action_button.rs
+++ b/app/src/view_components/action_button.rs
@@ -21,6 +21,7 @@ use warpui::{
     AppContext, BlurContext, Element, Entity, EventContext, FocusContext, SingletonEntity as _,
     TypedActionView, View, ViewContext,
 };
+use warpui::accessibility::{AccessibilityContent, WarpA11yRole};
 
 use crate::{
     settings_view::keybindings::{KeybindingChangedEvent, KeybindingChangedNotifier},
@@ -90,6 +91,9 @@ pub struct ActionButton {
 
     /// If true, renders the keybinding before the label (but after the icon).
     keybinding_before_label: bool,
+
+    /// An optional label to use for accessibility (e.g. screen readers).
+    accessibility_label: Option<String>,
 }
 
 pub type ClickHandler = Box<dyn Fn(&mut EventContext) + 'static>;
@@ -242,6 +246,7 @@ impl ActionButton {
             adjoined_side: None,
             compact_keybinding: false,
             keybinding_before_label: false,
+            accessibility_label: None,
         }
     }
 
@@ -307,6 +312,12 @@ impl ActionButton {
     /// Renders the keybinding before the label (but after the icon).
     pub fn with_keybinding_before_label(mut self, before_label: bool) -> Self {
         self.keybinding_before_label = before_label;
+        self
+    }
+
+    /// Set the accessibility label for this button.
+    pub fn with_accessibility_label(mut self, label: impl Into<String>) -> Self {
+        self.accessibility_label = Some(label.into());
         self
     }
 
@@ -477,6 +488,15 @@ impl ActionButton {
         ctx.notify();
     }
 
+    pub fn set_accessibility_label(
+        &mut self,
+        label: Option<impl Into<String>>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.accessibility_label = label.map(|l| l.into());
+        ctx.notify();
+    }
+
     /// Set up a new keybinding associated with this button. The caller is responsible for resetting
     /// any previous keybinding state.
     fn setup_keybinding(&mut self, source: KeystrokeSource, ctx: &mut ViewContext<Self>) {
@@ -629,6 +649,22 @@ impl Entity for ActionButton {
 impl View for ActionButton {
     fn ui_name() -> &'static str {
         "ActionButton"
+    }
+
+    fn accessibility_contents(&self, _ctx: &AppContext) -> Option<AccessibilityContent> {
+        let label = self
+            .accessibility_label
+            .clone()
+            .or_else(|| {
+                if !self.label.is_empty() {
+                    Some(self.label.to_string())
+                } else {
+                    None
+                }
+            })
+            .or_else(|| self.tooltip.clone());
+
+        label.map(|label| AccessibilityContent::new_without_help(label, WarpA11yRole::ButtonRole))
     }
 
     fn on_focus(&mut self, focus_ctx: &FocusContext, ctx: &mut ViewContext<Self>) {


### PR DESCRIPTION
💡 What: Added accessibility support to the `ActionButton` component and improved the directory delete buttons in the settings page.

🎯 Why: Icon-only buttons (like the directory delete 'X' button) were not descriptive for screen readers. Now they have clear accessibility labels and tooltips.

♿ Accessibility: Implemented `View::accessibility_contents` for `ActionButton` with a tiered fallback (accessibility_label -> label -> tooltip) and added context-specific labels to directory delete buttons.

---
*PR created automatically by Jules for task [6231763103579470974](https://jules.google.com/task/6231763103579470974) started by @aloewright*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit accessibility label support to action buttons, enabling better screen reader announcements with intelligent fallback hierarchy
  * Enhanced the "remove directory color" button with improved tooltip and accessibility labeling

* **Documentation**
  * Added guidance on accessibility patterns for icon-only buttons and accessibility labeling best practices

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aloewright/warp/pull/47)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->