### PR TITLE
🛡️ Sentinel: [HIGH] Fix unprotected audit sync endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-21 - Unprotected Audit Log Sync Endpoint
+**Vulnerability:** The `/api/audit/sync` endpoint was exposed without authentication, allowing any caller to inject arbitrary audit logs into the database.
+**Learning:** In the Hono-based control plane, middleware like `helmAuth` and `audit()` are applied to specific path prefixes. Endpoints defined outside these prefixes (or added later) may remain unprotected if the prefix list is not updated.
+**Prevention:** Maintain a strict "fail-closed" routing policy where all sensitive prefixes are explicitly protected. Verify middleware coverage for all new routes during security review.

--- a/cloudflare-control-plane/src/workers/app.ts
+++ b/cloudflare-control-plane/src/workers/app.ts
@@ -15,6 +15,7 @@
  *     GET  /api/environments
  *     POST /api/onboarding/check
  *     GET  /api/resources
+ *     POST /api/audit/sync
  *     POST /api/workflows/:slug/instances
  *     POST /api/workflows/deploy/instances/:id/approve
  *     GET  /api/workflows/:slug/instances/:id
@@ -489,6 +490,7 @@ export function createApp(): Hono<AppEnv> {
   app.use("/api/environments", helmAuth, audit());
   app.use("/api/onboarding/check", helmAuth, audit());
   app.use("/api/resources", helmAuth, audit());
+  app.use("/api/audit/*", helmAuth, audit());
   app.use("/api/workflows/*", helmAuth, audit());
   app.use("/api/sessions/*", helmAuth, audit());
   app.use("/api/workspaces/*", helmAuth, audit());
@@ -571,7 +573,7 @@ export function createApp(): Hono<AppEnv> {
   // dashboard, soak harness inspector). Authenticated like other protected
   // surfaces — `audit({})` middleware writes its own attribution row, and
   // the handler is responsible for parameterised insert.
-  app.post("/api/audit/sync", async (c) => {
+  app.post("/api/audit/sync", (c) => {
     return handleAuditSync(c.req.raw, c.env as ControlPlaneEnv);
   });
 


### PR DESCRIPTION
Identify and fix an unprotected audit log synchronization endpoint in the Cloudflare control plane. The endpoint `/api/audit/sync` was previously public, allowing arbitrary log injection. It is now protected by the same `helmAuth` and `audit()` middleware as other sensitive APIs.

---
*PR created automatically by Jules for task [13353354591773688866](https://jules.google.com/task/13353354591773688866) started by @aloewright*