### PR TITLE
🎨 Palette: Accessibility tiered fallback for ActionButton

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - [Accessibility Tiered Fallback for ActionButton]
+**Learning:** Foundational UI components like `ActionButton` often lack explicit accessibility metadata. Implementing a tiered fallback (explicit label -> visual label -> tooltip) ensures that even icon-only buttons are screen-reader friendly without requiring every instance to be manually updated immediately.
+**Action:** Always implement `View::accessibility_contents` and `View::accessibility_data` for new UI components, and use tooltip text as a final fallback for labels when appropriate.

--- a/app/src/view_components/action_button.rs
+++ b/app/src/view_components/action_button.rs
@@ -18,7 +18,9 @@ use warpui::{
     keymap::Keystroke,
     platform::Cursor,
     ui_components::components::{Coords, UiComponent, UiComponentStyles},
-    AppContext, BlurContext, Element, Entity, EventContext, FocusContext, SingletonEntity as _,
+    accessibility::{AccessibilityContent, WarpA11yRole},
+    AccessibilityData, AppContext, BlurContext, Element, Entity, EventContext, FocusContext,
+    SingletonEntity as _,
     TypedActionView, View, ViewContext,
 };
 
@@ -90,6 +92,9 @@ pub struct ActionButton {
 
     /// If true, renders the keybinding before the label (but after the icon).
     keybinding_before_label: bool,
+
+    /// Optional explicit accessibility label.
+    accessibility_label: Option<Cow<'static, str>>,
 }
 
 pub type ClickHandler = Box<dyn Fn(&mut EventContext) + 'static>;
@@ -242,12 +247,19 @@ impl ActionButton {
             adjoined_side: None,
             compact_keybinding: false,
             keybinding_before_label: false,
+            accessibility_label: None,
         }
     }
 
     // `with_*` methods are for chained configuration when first creating an ActionButton.
     // They consume `self`, and can only be called before the ActionButton view has been added to
     // the UI framework (thus, no ctx.notify).
+
+    /// Set an explicit accessibility label for the button.
+    pub fn with_accessibility_label(mut self, label: impl Into<Cow<'static, str>>) -> Self {
+        self.accessibility_label = Some(label.into());
+        self
+    }
 
     /// Set the icon shown to the left of this button.
     pub fn with_icon(mut self, icon: Icon) -> Self {
@@ -438,6 +450,15 @@ impl ActionButton {
         ctx: &mut ViewContext<Self>,
     ) {
         self.tooltip_sublabel = tooltip_sublabel.map(|t| t.into());
+        ctx.notify();
+    }
+
+    pub fn set_accessibility_label(
+        &mut self,
+        label: Option<impl Into<Cow<'static, str>>>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.accessibility_label = label.map(|l| l.into());
         ctx.notify();
     }
 
@@ -643,6 +664,43 @@ impl View for ActionButton {
             self.focused = false;
             ctx.notify();
         }
+    }
+
+    fn accessibility_contents(&self, _ctx: &AppContext) -> Option<AccessibilityContent> {
+        let value = self
+            .accessibility_label
+            .as_ref()
+            .map(|l| l.to_string())
+            .or_else(|| {
+                if !self.label.is_empty() {
+                    Some(self.label.to_string())
+                } else {
+                    None
+                }
+            })
+            .or_else(|| self.tooltip.clone())?;
+
+        Some(AccessibilityContent::new_without_help(
+            value,
+            WarpA11yRole::ButtonRole,
+        ))
+    }
+
+    fn accessibility_data(&self, _ctx: &mut ViewContext<Self>) -> Option<AccessibilityData> {
+        let content = self
+            .accessibility_label
+            .as_ref()
+            .map(|l| l.to_string())
+            .or_else(|| {
+                if !self.label.is_empty() {
+                    Some(self.label.to_string())
+                } else {
+                    None
+                }
+            })
+            .or_else(|| self.tooltip.clone())?;
+
+        Some(AccessibilityData { content })
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {


### PR DESCRIPTION
💡 What: Added comprehensive accessibility support to the `ActionButton` component.

🎯 Why: Many buttons in the interface, especially icon-only ones, lack descriptive labels for screen readers. By implementing a tiered fallback system, we ensure that every button has a meaningful label derived from its context (explicit override, visual text, or tooltip).

📸 Before/After: No visual changes were made to the UI rendering, but the underlying accessibility tree now correctly identifies and describes action buttons.

♿ Accessibility:
- Implemented `View::accessibility_contents` and `View::accessibility_data`.
- Introduced a fallback hierarchy: `accessibility_label` -> `label` -> `tooltip`.
- Set the accessibility role to `WarpA11yRole::ButtonRole`.


---
*PR created automatically by Jules for task [6431913934674506820](https://jules.google.com/task/6431913934674506820) started by @aloewright*