### PR TITLE
🛡️ Sentinel: HIGH Fix missing authentication on audit sync endpoint

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Missing Authentication on Audit Sync Endpoint
+**Vulnerability:** The `/api/audit/sync` endpoint was exposed publicly without authentication, despite being intended for internal audit log synchronization from symphony daemons.
+**Learning:** In Hono applications with per-route middleware, newly added routes can be easily overlooked if they aren't explicitly included in a protected path prefix or have middleware applied directly. Comments describing an endpoint as "Authenticated" do not guarantee it is actually protected.
+**Prevention:** Always verify that sensitive endpoints are either matched by a wildcard middleware (e.g., `app.use("/api/*", ... )`) or have explicit authentication middleware applied. Add automated tests to verify 401 responses for all protected routes.

--- a/cloudflare-control-plane/src/workers/app.ts
+++ b/cloudflare-control-plane/src/workers/app.ts
@@ -571,7 +571,7 @@ export function createApp(): Hono<AppEnv> {
   // dashboard, soak harness inspector). Authenticated like other protected
   // surfaces — `audit({})` middleware writes its own attribution row, and
   // the handler is responsible for parameterised insert.
-  app.post("/api/audit/sync", async (c) => {
+  app.post("/api/audit/sync", helmAuth, audit(), async (c) => {
     return handleAuditSync(c.req.raw, c.env as ControlPlaneEnv);
   });
 

--- a/cloudflare-control-plane/test/control-plane-routes.test.ts
+++ b/cloudflare-control-plane/test/control-plane-routes.test.ts
@@ -183,6 +183,16 @@ describe("control-plane Hono app", () => {
       expect(res.status).toBe(401);
     });
 
+    it("rejects unauthenticated requests to /api/audit/sync", async () => {
+      const app = createApp();
+      const res = await app.fetch(
+        new Request("https://h/api/audit/sync", { method: "POST", body: "[]" }),
+        buildEnv(),
+        noopCtx
+      );
+      expect(res.status).toBe(401);
+    });
+
     it("accepts a helm JWT via Authorization header", async () => {
       const app = createApp();
       const issued = await issueHelmJwt({ userId: "user-1", signingKey: SIGNING_KEY });


### PR DESCRIPTION
This PR fixes a security vulnerability where the `/api/audit/sync` endpoint was exposed publicly without authentication. I've added the standard `helmAuth` and `audit()` middleware to this route in `cloudflare-control-plane/src/workers/app.ts`.

Changes:
- Added `helmAuth` and `audit()` middleware to `POST /api/audit/sync`.
- Added a security test case in `cloudflare-control-plane/test/control-plane-routes.test.ts` to verify 401 Unauthorized for unauthenticated requests.
- Updated `.Jules/sentinel.md` with the learning from this vulnerability.

Impact:
- High security impact: protects the audit log from unauthorized injection.
- Zero functionality impact: the Warp CLI `audit sync` command already uses the compatible bearer token authentication.

---
*PR created automatically by Jules for task [7407343246914082894](https://jules.google.com/task/7407343246914082894) started by @aloewright*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* **Security Fix**: The audit sync endpoint now requires proper authentication. Previously, it was publicly accessible without credentials, creating a security vulnerability. The endpoint has been secured and tests have been added to prevent regression.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aloewright/warp/pull/52)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->