### PR TITLE
⚡ Bolt: Memoize manifest parsing in control-plane

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-12 - Memoization of manifest parsing in control-plane
+**Learning:** In Cloudflare Workers, environment variables are static for the life of an isolate. Parsing and validating large JSON strings (like `HELM_MANIFEST_JSON`) on every request is an O(N) operation that can be safely memoized at the module level.
+**Action:** Always look for static configuration parsing or expensive validations that can be moved outside the request handler or memoized to improve per-request latency.

--- a/cloudflare-control-plane/src/shared/manifest.ts
+++ b/cloudflare-control-plane/src/shared/manifest.ts
@@ -113,10 +113,22 @@ export function isProtectedResource(
   return false;
 }
 
+let cachedManifest: HelmManifest | null = null;
+
+/**
+ * Extract and parse the Helm manifest from the environment.
+ *
+ * PDX-23 optimization: Parse and validate the manifest once per isolate.
+ * Since HELM_MANIFEST_JSON is a static environment variable, memoizing
+ * it here avoids the O(N) cost of Zod validation on every request.
+ */
 export function manifestForRuntime(env: { HELM_MANIFEST_JSON?: string }): HelmManifest {
+  if (cachedManifest) return cachedManifest;
+
   const json = env.HELM_MANIFEST_JSON;
   if (!json) {
     throw new Error("HELM_MANIFEST_JSON is required for runtime manifest-backed APIs.");
   }
-  return parseManifestJson(json);
+  cachedManifest = parseManifestJson(json);
+  return cachedManifest;
 }


### PR DESCRIPTION
💡 What: Memoized the `manifestForRuntime` function in `cloudflare-control-plane/src/shared/manifest.ts`.
🎯 Why: The function parses and validates the `HELM_MANIFEST_JSON` environment variable on every call. Since environment variables are static for the life of a Cloudflare Worker isolate, parsing it once and caching the result saves unnecessary CPU cycles (JSON parsing + Zod validation) on every request.
📊 Impact: Reduces per-request CPU time for all endpoints that use manifest-backed APIs (most authenticated routes).
🔬 Measurement: Verified by running existing unit tests and typecheck. Subsequent calls to `manifestForRuntime` within the same isolate will now return the cached object immediately.

---
*PR created automatically by Jules for task [12430601593150064891](https://jules.google.com/task/12430601593150064891) started by @aloewright*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive development guidance covering best practices for efficient environment variable handling, strategic caching patterns, and runtime performance optimization in serverless infrastructure platforms.

* **Chores**
  * Enhanced manifest processing performance by implementing intelligent caching mechanisms to systematically eliminate redundant parsing and validation operations, reducing computational overhead and improving request efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aloewright/warp/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->