### PR TITLE
🎨 Palette: [UX improvement] Enhance ActionButton accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2025-05-14 - Tiered Accessibility Labels for Generic UI Components
+
+**Learning:** When adding accessibility support to highly reusable UI components (like ActionButton), a tiered fallback system (Explicit Label > Visual Label > Tooltip) ensures that elements are always accessible by default while still allowing precise overrides for complex cases.
+
+**Action:** Always implement tiered fallbacks in core design system components to provide a "safe" baseline for accessibility across the entire application.

--- a/app/src/view_components/action_button.rs
+++ b/app/src/view_components/action_button.rs
@@ -17,6 +17,7 @@ use warpui::{
     fonts::{Properties, Weight},
     keymap::Keystroke,
     platform::Cursor,
+    accessibility::{AccessibilityContent, WarpA11yRole},
     ui_components::components::{Coords, UiComponent, UiComponentStyles},
     AppContext, BlurContext, Element, Entity, EventContext, FocusContext, SingletonEntity as _,
     TypedActionView, View, ViewContext,
@@ -90,6 +91,9 @@ pub struct ActionButton {
 
     /// If true, renders the keybinding before the label (but after the icon).
     keybinding_before_label: bool,
+
+    /// Optional accessibility label for the button.
+    accessibility_label: Option<Cow<'static, str>>,
 }
 
 pub type ClickHandler = Box<dyn Fn(&mut EventContext) + 'static>;
@@ -242,6 +246,7 @@ impl ActionButton {
             adjoined_side: None,
             compact_keybinding: false,
             keybinding_before_label: false,
+            accessibility_label: None,
         }
     }
 
@@ -362,6 +367,11 @@ impl ActionButton {
         self
     }
 
+    pub fn with_accessibility_label(mut self, label: impl Into<Cow<'static, str>>) -> Self {
+        self.accessibility_label = Some(label.into());
+        self
+    }
+
     pub fn with_max_label_width(mut self, max_label_width: f32) -> Self {
         self.max_label_width = Some(max_label_width);
         self
@@ -438,6 +448,15 @@ impl ActionButton {
         ctx: &mut ViewContext<Self>,
     ) {
         self.tooltip_sublabel = tooltip_sublabel.map(|t| t.into());
+        ctx.notify();
+    }
+
+    pub fn set_accessibility_label(
+        &mut self,
+        label: impl Into<Cow<'static, str>>,
+        ctx: &mut ViewContext<Self>,
+    ) {
+        self.accessibility_label = Some(label.into());
         ctx.notify();
     }
 
@@ -643,6 +662,18 @@ impl View for ActionButton {
             self.focused = false;
             ctx.notify();
         }
+    }
+
+    fn accessibility_contents(&self, _ctx: &AppContext) -> Option<AccessibilityContent> {
+        let label = if let Some(accessibility_label) = self.accessibility_label.as_ref() {
+            Some(accessibility_label.to_string())
+        } else if !self.label.is_empty() {
+            Some(self.label.to_string())
+        } else {
+            self.tooltip.clone()
+        };
+
+        label.map(|label| AccessibilityContent::new_without_help(label, WarpA11yRole::ButtonRole))
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {


### PR DESCRIPTION
Enhanced the `ActionButton` component in `app/src/view_components/action_button.rs` to support accessibility labels. Implemented tiered fallback logic (explicit label > visual label > tooltip) in `View::accessibility_contents` to ensure all buttons, especially icon-only ones, are descriptive for screen readers. Added `with_accessibility_label` and `set_accessibility_label` methods for granular control.

---
*PR created automatically by Jules for task [18334592510502714839](https://jules.google.com/task/18334592510502714839) started by @aloewright*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Action button now supports optional custom accessibility labels with automatic fallback to visual labels and tooltips for improved screen reader support.

* **Documentation**
  * Added tiered accessibility label guidance for implementing accessible generic UI components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aloewright/warp/pull/54)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->