### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix unauthenticated audit ingestion and DoS risk

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-16 - Unauthenticated Audit Ingestion & DoS Risk
+**Vulnerability:** The `/api/audit/sync` endpoint in `cloudflare-control-plane` was completely public and lacked any payload size limits. This allowed unauthenticated attackers to inject arbitrary data into the `audit_log` table and potentially perform a DoS attack by sending massive batches.
+**Learning:** Sensitive routes defined outside the explicit `app.use` middleware matchers in Hono are public by default. The `audit` middleware for request attribution depends on `helmAuth` to populate the auth context; if applied alone or if the path is not matched by `helmAuth`, it defaults to anonymous logging but does not block access.
+**Prevention:** Always apply `helmAuth` and `audit()` middleware to new endpoints. Use explicit path prefixes for protected subtrees and verify middleware coverage in tests. Enforce batch size limits on all ingestion endpoints.

--- a/cloudflare-control-plane/src/workers/app.ts
+++ b/cloudflare-control-plane/src/workers/app.ts
@@ -493,6 +493,7 @@ export function createApp(): Hono<AppEnv> {
   app.use("/api/sessions/*", helmAuth, audit());
   app.use("/api/workspaces/*", helmAuth, audit());
   app.use("/api/runs/*", helmAuth, audit());
+  app.use("/api/audit/*", helmAuth, audit());
 
   app.get("/api/environments", (c) => {
     const manifest = manifestForRuntime(c.env);

--- a/cloudflare-control-plane/src/workers/audit_mirror.ts
+++ b/cloudflare-control-plane/src/workers/audit_mirror.ts
@@ -36,6 +36,9 @@ export interface AuditMirrorEnv {
   HELM_AUDIT_DB?: D1Database;
 }
 
+/** Maximum number of audit rows allowed in a single batch (DoS protection). */
+export const MAX_AUDIT_BATCH_SIZE = 500;
+
 /** Single audit-log row, matching the JSONL shape from PDX-28. */
 export interface AuditLogRow {
   timestamp: string;
@@ -171,6 +174,16 @@ export async function handleAuditSync(
     return json(
       { error: "expected_array", message: "Body must be a JSON array of audit rows." },
       { status: 400 }
+    );
+  }
+
+  if (body.length > MAX_AUDIT_BATCH_SIZE) {
+    return json(
+      {
+        error: "batch_too_large",
+        message: `Batch size ${body.length} exceeds maximum allowed (${MAX_AUDIT_BATCH_SIZE}).`
+      },
+      { status: 413 }
     );
   }
 

--- a/cloudflare-control-plane/test/security-audit-sync.test.ts
+++ b/cloudflare-control-plane/test/security-audit-sync.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { createApp, type ControlPlaneEnv } from "../src/workers/app.js";
+import { issueHelmJwt } from "../src/shared/auth.js";
+
+const SIGNING_KEY = "test-signing-key-security";
+
+const stubDb: D1Database = {
+  prepare: (() => ({
+    bind: () => ({
+      all: async () => ({ results: [] }),
+      first: async () => null,
+      run: async () => ({ success: true })
+    })
+  })) as unknown,
+  batch: async (stmts: any[]) => stmts.map(() => ({ meta: { changes: 1 } })),
+  exec: async () => ({ count: 0, duration: 0 }),
+  dump: async () => new ArrayBuffer(0)
+} as unknown as D1Database;
+
+function buildEnv(): ControlPlaneEnv {
+  return {
+    HELM_ENVIRONMENT: "dev",
+    HELM_VERSION: "0.0.1-test",
+    HELM_BUILD_ID: "test",
+    HELM_MANIFEST_JSON: JSON.stringify({
+      accountId: "acct-test",
+      zone: { id: "zone-test", domain: "test.example" },
+      environments: ["dev"],
+      workers: {},
+      resources: { d1: {}, r2: {}, durableObjects: {}, kv: {}, aiGateways: {} },
+      containers: { dev: { enabled: true, instanceClass: "dev" }, staging: { enabled: false, instanceClass: "dev" }, production: { enabled: false, instanceClass: "dev" } },
+      access: { required: false, teamDomain: "test.cloudflareaccess.com", audiences: { dev: "aud-dev" } },
+      protected: []
+    }),
+    HELM_JWT_SIGNING_KEY: SIGNING_KEY,
+    DB: stubDb,
+    HELM_AUDIT_DB: stubDb,
+    CONTROL_PLANE_REGISTRY: {} as DurableObjectNamespace
+  };
+}
+
+const noopCtx = {
+  waitUntil: (_: Promise<unknown>) => {},
+  passThroughOnException: () => {}
+} as unknown as ExecutionContext;
+
+describe("Security: /api/audit/sync", () => {
+  it("FIXED: rejects unauthenticated access", async () => {
+    const app = createApp();
+    const res = await app.fetch(
+      new Request("https://h/api/audit/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify([{ timestamp: new Date().toISOString(), action: "test" }])
+      }),
+      buildEnv(),
+      noopCtx
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("FIXED: rejects large batches (DoS protection)", async () => {
+    const app = createApp();
+    const issued = await issueHelmJwt({ userId: "user-1", signingKey: SIGNING_KEY });
+    const largeBatch = Array.from({ length: 600 }, () => ({
+      timestamp: new Date().toISOString(),
+      action: "spam"
+    }));
+
+    const res = await app.fetch(
+      new Request("https://h/api/audit/sync", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${issued.token}`
+        },
+        body: JSON.stringify(largeBatch)
+      }),
+      buildEnv(),
+      noopCtx
+    );
+    expect(res.status).toBe(413);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("batch_too_large");
+  });
+
+  it("FIXED: accepts authenticated batches within limits", async () => {
+    const app = createApp();
+    const issued = await issueHelmJwt({ userId: "user-1", signingKey: SIGNING_KEY });
+    const batch = Array.from({ length: 10 }, () => ({
+      timestamp: new Date().toISOString(),
+      action: "legit"
+    }));
+
+    const res = await app.fetch(
+      new Request("https://h/api/audit/sync", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${issued.token}`
+        },
+        body: JSON.stringify(batch)
+      }),
+      buildEnv(),
+      noopCtx
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { inserted: number };
+    expect(body.inserted).toBe(10);
+  });
+});


### PR DESCRIPTION
This PR addresses two security vulnerabilities in the `cloudflare-control-plane` component:

1.  **Authentication Bypass**: The `/api/audit/sync` endpoint was not protected by `helmAuth` middleware, allowing anyone to push data into the audit logs. I have now applied `helmAuth` and `audit()` middleware to the `/api/audit/*` route tree.
2.  **DoS Vulnerability**: The endpoint lacked batch size limits. I have introduced `MAX_AUDIT_BATCH_SIZE = 500` in `audit_mirror.ts` to prevent large payload attacks.

Verification:
- Created a new test file `cloudflare-control-plane/test/security-audit-sync.test.ts` which reproduces both issues and verifies the fixes.
- Ensured existing tests in `audit-mirror.test.ts` still pass.
- Added a journal entry to `.Jules/sentinel.md`.

---
*PR created automatically by Jules for task [10155057506794758644](https://jules.google.com/task/10155057506794758644) started by @aloewright*