### PR TITLE
🎨 Palette: Enhanced ActionButton accessibility with tiered fallback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-19 - Enhanced ActionButton Accessibility
+**Learning:** Core UI components like buttons, especially when icon-only, often lack descriptive labels for screen readers even if they have tooltips. Implementing a tiered fallback logic (explicit label > visual label > tooltip) at the component level ensures broad accessibility across the app.
+**Action:** Always implement accessibility fallback patterns in base UI components to provide a safe default for assistive technologies.

--- a/app/src/terminal/view.rs
+++ b/app/src/terminal/view.rs
@@ -4006,6 +4006,7 @@ impl TerminalView {
         let agent_view_back_button = ctx.add_typed_action_view(|ctx| {
             ActionButton::new("for terminal", AgentViewHeaderTheme)
                 .with_icon(icons::Icon::ArrowLeft)
+                .with_accessibility_label("Back to terminal")
                 .with_size(ButtonSize::Small)
                 .with_keybinding(
                     KeystrokeSource::Fixed(Keystroke {

--- a/app/src/view_components/action_button.rs
+++ b/app/src/view_components/action_button.rs
@@ -14,6 +14,7 @@ use warpui::{
         Hoverable, MouseStateHandle, OffsetPositioning, Padding, ParentAnchor, ParentElement as _,
         ParentOffsetBounds, Radius, Stack, Text, DEFAULT_UI_LINE_HEIGHT_RATIO,
     },
+    accessibility::{AccessibilityContent, WarpA11yRole},
     fonts::{Properties, Weight},
     keymap::Keystroke,
     platform::Cursor,
@@ -90,6 +91,9 @@ pub struct ActionButton {
 
     /// If true, renders the keybinding before the label (but after the icon).
     keybinding_before_label: bool,
+
+    /// An explicit accessibility label to be read by screen readers.
+    accessibility_label: Option<String>,
 }
 
 pub type ClickHandler = Box<dyn Fn(&mut EventContext) + 'static>;
@@ -139,6 +143,38 @@ pub trait ActionButtonTheme {
 
     fn font_properties(&self) -> Option<Properties> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use warpui::AppContext;
+
+    #[test]
+    fn test_action_button_accessibility_contents() {
+        let app = AppContext::mock();
+
+        // 1. Explicit accessibility label
+        let button = ActionButton::new("Visual Label", NakedTheme)
+            .with_accessibility_label("A11y Label")
+            .with_tooltip("Tooltip");
+        let contents = button.accessibility_contents(&app).unwrap();
+        assert_eq!(contents.value, "A11y Label");
+
+        // 2. Fallback to visual label
+        let button = ActionButton::new("Visual Label", NakedTheme).with_tooltip("Tooltip");
+        let contents = button.accessibility_contents(&app).unwrap();
+        assert_eq!(contents.value, "Visual Label");
+
+        // 3. Fallback to tooltip
+        let button = ActionButton::new("", NakedTheme).with_tooltip("Tooltip");
+        let contents = button.accessibility_contents(&app).unwrap();
+        assert_eq!(contents.value, "Tooltip");
+
+        // 4. None if all empty
+        let button = ActionButton::new("", NakedTheme);
+        assert!(button.accessibility_contents(&app).is_none());
     }
 }
 
@@ -242,6 +278,7 @@ impl ActionButton {
             adjoined_side: None,
             compact_keybinding: false,
             keybinding_before_label: false,
+            accessibility_label: None,
         }
     }
 
@@ -307,6 +344,12 @@ impl ActionButton {
     /// Renders the keybinding before the label (but after the icon).
     pub fn with_keybinding_before_label(mut self, before_label: bool) -> Self {
         self.keybinding_before_label = before_label;
+        self
+    }
+
+    /// Sets the accessibility label for this button.
+    pub fn with_accessibility_label(mut self, label: impl Into<String>) -> Self {
+        self.accessibility_label = Some(label.into());
         self
     }
 
@@ -456,6 +499,11 @@ impl ActionButton {
         ctx: &mut ViewContext<Self>,
     ) {
         self.disabled_theme = Some(Arc::new(disabled_theme));
+        ctx.notify();
+    }
+
+    pub fn set_accessibility_label(&mut self, label: Option<String>, ctx: &mut ViewContext<Self>) {
+        self.accessibility_label = label;
         ctx.notify();
     }
 
@@ -643,6 +691,25 @@ impl View for ActionButton {
             self.focused = false;
             ctx.notify();
         }
+    }
+
+    fn accessibility_contents(&self, _ctx: &AppContext) -> Option<AccessibilityContent> {
+        let label = self
+            .accessibility_label
+            .clone()
+            .or_else(|| {
+                if !self.label.is_empty() {
+                    Some(self.label.to_string())
+                } else {
+                    None
+                }
+            })
+            .or_else(|| self.tooltip.clone())?;
+
+        Some(AccessibilityContent::new_without_help(
+            label,
+            WarpA11yRole::ButtonRole,
+        ))
     }
 
     fn render(&self, app: &AppContext) -> Box<dyn Element> {


### PR DESCRIPTION
💡 What: Enhanced the core `ActionButton` component with a tiered accessibility label fallback and applied it to the Agent View back button.

🎯 Why: Assistive technologies often struggle with icon-only buttons. By implementing a fallback logic that leverages existing tooltips, we broad-scale improve accessibility across the entire application with minimal changes.

📸 Before/After: No visual changes. Screen readers now correctly identify the Agent View back button as "Back to terminal" instead of generic button information.

♿ Accessibility:
- Introduced `accessibility_label` for `ActionButton`.
- Automated screen reader label discovery: it now checks the explicit `accessibility_label`, then the visual `label`, and finally the `tooltip` text.
- Specifically improved the icon-only "Back" button in Agent View.

---
*PR created automatically by Jules for task [5617081414998628271](https://jules.google.com/task/5617081414998628271) started by @aloewright*